### PR TITLE
ci: auto-approve and auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        run: gh pr review "$PR_URL" --approve
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        run: gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds workflow that auto-approves and auto-merges Dependabot PRs
- The PR still **must pass all 7 required CI checks** before merge happens
- If any check fails (lint, type-check, tests, build, audit), the PR stays open for manual review

## How it works

1. Dependabot opens a PR
2. This workflow auto-approves it (satisfies the 1-review requirement)
3. Enables auto-merge (squash)
4. GitHub waits for all required status checks to pass
5. If all pass → auto-merged. If any fail → stays open.


🤖 Generated with [Claude Code](https://claude.com/claude-code)