### PR TITLE
fix(ci): validate release-please PRs before merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,14 +16,60 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      pr_created: ${{ steps.release.outputs.prs_created }}
+      pr_branch: ${{ steps.pr-info.outputs.branch }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - name: Extract PR branch
+        id: pr-info
+        if: steps.release.outputs.prs_created == 'true'
+        run: echo "branch=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')" >> "$GITHUB_OUTPUT"
 
-  validate:
+  validate-release-pr:
+    name: Validate Release PR
+    needs: release-please
+    if: needs.release-please.outputs.pr_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.pr_branch }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - uses: browser-actions/setup-chrome@v2
+      - run: npm ci
+      - name: Lint (warnings as errors)
+        run: npx eslint src --ext .ts --max-warnings 0
+      - name: Format check
+        run: npx prettier --check "src/**/*.{ts,tsx,js,jsx,json,md}"
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Unit tests with coverage
+        run: |
+          npx ncp src/tests/.tests-config.tpl.js src/tests/.tests-config.js
+          npx jest --ci --coverage
+      - name: E2E tests
+        run: npx jest --ci --testPathPattern='tests/e2e' --verbose
+        env:
+          PUPPETEER_HEADLESS: 'true'
+      - name: Build verification
+        run: |
+          npx rimraf lib
+          npx tsc --emitDeclarationOnly
+          npx babel src --out-dir lib --extensions ".ts" --source-maps inline --verbose
+          npx rimraf lib/tests
+          test -f lib/index.js || (echo "ERROR: lib/index.js missing" && exit 1)
+          test -f lib/index.d.ts || (echo "ERROR: lib/index.d.ts missing" && exit 1)
+      - name: Security audit
+        run: npm audit --audit-level=high --omit=dev
+
+  validate-release:
     name: Full Validation
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
@@ -51,7 +97,7 @@ jobs:
 
   publish:
     name: Publish to NPM
-    needs: [release-please, validate]
+    needs: [release-please, validate-release]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     environment: npm-publish


### PR DESCRIPTION
## Summary

Fixes the issue where release-please PRs have zero CI checks running, making them unmergeable without admin bypass.

**Root cause:** PRs created by `github-actions[bot]` (via `GITHUB_TOKEN`) don't trigger `pull_request` events — this is a GitHub security feature.

**Fix:** Run full validation (lint, type-check, tests, E2E, build, audit) inside the release-please workflow itself when a PR is created/updated.

## New workflow structure

```
Push to main
  ├─ release-please creates/updates Release PR
  │   └─ validate-release-pr job: checks out PR branch, runs ALL checks
  │
  └─ (when Release PR merged → release_created == true)
      ├─ validate-release job: full validation on main
      └─ publish job: npm publish with OIDC
```

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, next release-please PR should show validation results in the "Release & Publish" workflow run


🤖 Generated with [Claude Code](https://claude.com/claude-code)