### PR TITLE
fix(ci): use PAT for release-please to trigger CI on PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

One-line fix: add `token: ${{ secrets.RELEASE_TOKEN }}` to release-please action.

**Problem:** release-please PRs created with `GITHUB_TOKEN` don't trigger CI workflows (GitHub security limitation). PRs had 0 checks and couldn't be merged.

**Fix:** Use `RELEASE_TOKEN` (PAT) so release-please PRs trigger all CI checks normally — same approach as the reference repo.

## Test plan

- [x] CI checks pass on this PR
- [ ] After merge, next push to main creates a release-please PR WITH CI checks running


🤖 Generated with [Claude Code](https://claude.com/claude-code)