### PR TITLE
fix: ratchet coverage thresholds to prevent regression

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ const config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 15,
-      functions: 17,
-      lines: 30,
-      statements: 30,
+      branches: 30,
+      functions: 25,
+      lines: 42,
+      statements: 42,
     },
   },
 };


### PR DESCRIPTION
## Summary

Raise Jest coverage thresholds to match actual coverage after adding 214 tests.

| Threshold | Before | After |
|-----------|--------|-------|
| branches | 15% | **30%** |
| functions | 17% | **25%** |
| lines | 30% | **42%** |
| statements | 30% | **42%** |

This ensures future PRs can't silently reduce test coverage below the current baseline.

## Test plan

- [x] All 214 tests pass with new thresholds
- [x] Coverage: 43% stmts, 34% branches, 27% funcs, 44% lines (all above thresholds)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)