### PR TITLE
feat: apply anti-detection to ALL 18 scrapers via base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **This is a maintained fork** of [eshaham/israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers)
-> with WAF bypass fixes for Amex and Isracard scrapers.
+> with anti-detection for **all 18 banks** — realistic User-Agent, client hints, stealth JS.
+> Bypasses WAF blocking on Amex, Isracard, and any other bank that detects headless Chrome.
 >
 > Install: `npm install @sergienko4/israeli-bank-scrapers`
 

--- a/src/scrapers/base-isracard-amex.ts
+++ b/src/scrapers/base-isracard-amex.ts
@@ -18,7 +18,7 @@ import {
 import { BaseScraperWithBrowser } from './base-scraper-with-browser';
 import { ScraperErrorTypes } from './errors';
 import { type ScraperOptions, type ScraperScrapingResult } from './interface';
-import { applyAntiDetection, interceptionPriorities, isBotDetectionScript } from '../helpers/browser';
+import { interceptionPriorities, isBotDetectionScript } from '../helpers/browser';
 
 const RATE_LIMIT = {
   SLEEP_BETWEEN: 1000,
@@ -402,8 +402,7 @@ class IsracardAmexBaseScraper extends BaseScraperWithBrowser<ScraperSpecificCred
   }
 
   async login(credentials: ScraperSpecificCredentials): Promise<ScraperScrapingResult> {
-    // Anti-detection: realistic UA, client hints, stealth JS — must run BEFORE navigation
-    await applyAntiDetection(this.page);
+    // Anti-detection already applied in base class initialize()
 
     await this.page.setRequestInterception(true);
     this.page.on('request', request => {

--- a/src/scrapers/base-scraper-with-browser.ts
+++ b/src/scrapers/base-scraper-with-browser.ts
@@ -1,6 +1,7 @@
 import puppeteer, { type Frame, type Page, type PuppeteerLifeCycleEvent } from 'puppeteer';
 import { ScraperProgressTypes } from '../definitions';
 import { getDebug } from '../helpers/debug';
+import { applyAntiDetection } from '../helpers/browser';
 import { clickButton, fillInput, waitUntilElementFound } from '../helpers/elements-interactions';
 import { getCurrentUrl, waitForNavigation } from '../helpers/navigation';
 import { BaseScraper } from './base-scraper';
@@ -124,6 +125,10 @@ class BaseScraperWithBrowser<TCredentials extends ScraperCredentials> extends Ba
       debug("execute 'preparePage' interceptor provided in options");
       await this.options.preparePage(this.page);
     }
+
+    // Anti-detection: realistic UA, client hints, stealth JS — runs for ALL scrapers
+    debug('applying anti-detection overrides');
+    await applyAntiDetection(this.page);
 
     const viewport = this.getViewPort();
     debug(`set viewport to width ${viewport.width}, height ${viewport.height}`);


### PR DESCRIPTION
Move applyAntiDetection() from base-isracard-amex.ts → base-scraper-with-browser.ts initialize().

**Before**: Only Amex/Isracard had anti-detection.
**After**: All 18 banks get realistic UA, client hints, stealth JS automatically.

- 31 test suites pass, 214 tests
- No per-scraper changes needed
- Future scrapers inherit it automatically