### PR TITLE
test: add unit tests for all remaining scrapers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ const config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 56,
-      functions: 49,
-      lines: 65,
-      statements: 64,
+      branches: 73,
+      functions: 74,
+      lines: 87,
+      statements: 85,
     },
   },
 };

--- a/src/helpers/elements-interactions.test.ts
+++ b/src/helpers/elements-interactions.test.ts
@@ -144,6 +144,12 @@ describe('pageEvalAll', () => {
     const result = await pageEvalAll(page, '.missing', [], (els: any) => els);
     expect(result).toEqual([]);
   });
+
+  it('rethrows non-selector errors', async () => {
+    const page = createMockPage();
+    page.$$eval.mockRejectedValue(new Error('network error'));
+    await expect(pageEvalAll(page, '.broken', [], (els: any) => els)).rejects.toThrow('network error');
+  });
 });
 
 describe('waitUntilIframeFound', () => {

--- a/src/scrapers/behatsdaa.test.ts
+++ b/src/scrapers/behatsdaa.test.ts
@@ -1,50 +1,165 @@
-import { CompanyTypes, SCRAPERS } from '../definitions';
-import { exportTransactions, extendAsyncTimeout, getTestsConfig, maybeTestCompanyAPI } from '../tests/tests-utils';
-import { LoginResults } from './base-scraper-with-browser';
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { fetchPostWithinPage } from '../helpers/fetch';
+import { applyAntiDetection } from '../helpers/browser';
+import { getCurrentUrl } from '../helpers/navigation';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import BehatsdaaScraper from './behatsdaa';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-const testsConfig = getTestsConfig();
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/fetch', () => ({ fetchPostWithinPage: jest.fn() }));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://www.behatsdaa.org.il/'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/waiting', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+  TimeoutError: class TimeoutError extends Error {},
+  SECOND: 1000,
+}));
+jest.mock('../helpers/transactions', () => ({
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-describe('Behatsdaa scraper', () => {
-  beforeAll(() => {
-    extendAsyncTimeout();
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const CREDS = { id: '123456789', password: 'pass123' };
+
+function variant(overrides: any = {}): any {
+  return {
+    name: 'Test Product',
+    variantName: 'Size L',
+    customerPrice: 100,
+    orderDate: '2025-06-15T10:00:00',
+    tTransactionID: 'TXN-001',
+    ...overrides,
+  };
+}
+
+function createBehatsdaaPage(token: string | null = 'mock-token') {
+  return createMockPage({
+    evaluate: jest.fn().mockResolvedValue(token),
+    $: jest.fn().mockResolvedValue({ click: jest.fn().mockResolvedValue(undefined) }),
   });
+}
 
-  it('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS[CompanyTypes.behatsdaa]).toBeDefined();
-    expect(SCRAPERS[CompanyTypes.behatsdaa].loginFields).toContain('id');
-    expect(SCRAPERS[CompanyTypes.behatsdaa].loginFields).toContain('password');
-  });
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  mockBrowser.newPage.mockResolvedValue(createBehatsdaaPage());
+  (getCurrentUrl as jest.Mock).mockResolvedValue('https://www.behatsdaa.org.il/');
+});
 
-  maybeTestCompanyAPI(CompanyTypes.behatsdaa, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password"',
-    async () => {
-      const scraper = new BehatsdaaScraper({
-        ...testsConfig.options,
-        companyId: CompanyTypes.behatsdaa,
-      });
-
-      const result = await scraper.scrape({ id: 'foofoofoo', password: 'barbarbar' });
-
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
-    },
-  );
-
-  maybeTestCompanyAPI(CompanyTypes.behatsdaa)('should scrape transactions', async () => {
-    const scraper = new BehatsdaaScraper({
-      ...testsConfig.options,
-      companyId: CompanyTypes.behatsdaa,
+describe('login', () => {
+  it('succeeds with valid credentials', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      data: { memberId: 'M001', variants: [] },
     });
 
-    const result = await scraper.scrape(testsConfig.credentials[CompanyTypes.behatsdaa]);
-    expect(result).toBeDefined();
-    expect(result.errorMessage).toBeFalsy();
-    expect(result.errorType).toBeFalsy();
-    expect(result.success).toBeTruthy();
-    expect(result.accounts).toBeDefined();
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
+  });
+});
+
+describe('fetchData', () => {
+  it('returns error when token not in localStorage', async () => {
+    mockBrowser.newPage.mockResolvedValue(createBehatsdaaPage(null));
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toBe('TokenNotFound');
+  });
+
+  it('returns error when API response has errorDescription', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      errorDescription: 'Service unavailable',
+    });
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toBe('Service unavailable');
+  });
+
+  it('returns error when API response has no data', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({});
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toBe('NoData');
+  });
+
+  it('converts variants to transactions', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      data: {
+        memberId: 'M001',
+        variants: [variant({ customerPrice: 250, name: 'Gift Card', variantName: 'Premium' })],
+      },
+    });
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
     expect(result.accounts).toHaveLength(1);
-    exportTransactions(CompanyTypes.behatsdaa, result.accounts || []);
+    expect(result.accounts![0].accountNumber).toBe('M001');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-250);
+    expect(t.originalCurrency).toBe('ILS');
+    expect(t.status).toBe(TransactionStatuses.Completed);
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.description).toBe('Gift Card');
+    expect(t.memo).toBe('Premium');
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      data: { memberId: 'M001', variants: [variant()] },
+    });
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
+  });
+
+  it('sends Bearer token in authorization header', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      data: { memberId: 'M001', variants: [] },
+    });
+
+    const scraper = new BehatsdaaScraper(createMockScraperOptions());
+    await scraper.scrape(CREDS);
+
+    expect(fetchPostWithinPage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({ authorization: 'Bearer mock-token' }),
+    );
   });
 });

--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -1,53 +1,202 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { SHEKEL_CURRENCY } from '../constants';
+import { pageEval } from '../helpers/elements-interactions';
+import { applyAntiDetection } from '../helpers/browser';
+import { getCurrentUrl } from '../helpers/navigation';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import LeumiScraper from './leumi';
-import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
-import { LoginResults } from './base-scraper-with-browser';
+import { ScraperErrorTypes } from './errors';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-const COMPANY_ID = 'leumi'; // TODO this property should be hard-coded in the provider
-const testsConfig = getTestsConfig();
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+  pageEval: jest.fn().mockResolvedValue('https://hb2.bankleumi.co.il/login'),
+  pageEvalAll: jest.fn().mockResolvedValue(''),
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://hb2.bankleumi.co.il/ebanking/SO/SPA.aspx'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/transactions', () => ({
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-describe('Leumi legacy scraper', () => {
-  beforeAll(() => {
-    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const CREDS = { username: 'testuser', password: 'testpass' };
+
+function createLeumiPage(accountIds: string[] = ['123/456']) {
+  const mockResponse = {
+    json: jest.fn().mockResolvedValue({
+      jsonResp: JSON.stringify({
+        TodayTransactionsItems: [],
+        HistoryTransactionsItems: [
+          {
+            DateUTC: '2025-06-15T00:00:00',
+            Amount: -100,
+            Description: 'Test Transaction',
+            ReferenceNumberLong: 12345,
+            AdditionalData: 'memo text',
+          },
+        ],
+        BalanceDisplay: '5000.00',
+      }),
+    }),
+  };
+
+  return createMockPage({
+    evaluate: jest.fn().mockResolvedValue(accountIds),
+    goto: jest.fn().mockResolvedValue({ ok: () => true, status: () => 200 }),
+    waitForResponse: jest.fn().mockResolvedValue(mockResponse),
+    waitForSelector: jest.fn().mockResolvedValue(undefined),
+    $$: jest.fn().mockResolvedValue([{ click: jest.fn() }]),
+    focus: jest.fn().mockResolvedValue(undefined),
+    $: jest.fn().mockResolvedValue(null),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  mockBrowser.newPage.mockResolvedValue(createLeumiPage());
+  (getCurrentUrl as jest.Mock).mockResolvedValue('https://hb2.bankleumi.co.il/ebanking/SO/SPA.aspx');
+  (pageEval as jest.Mock).mockResolvedValue('https://hb2.bankleumi.co.il/login');
+});
+
+describe('login', () => {
+  it('succeeds with valid credentials', async () => {
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
   });
 
-  test('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS.leumi).toBeDefined();
-    expect(SCRAPERS.leumi.loginFields).toContain('username');
-    expect(SCRAPERS.leumi.loginFields).toContain('password');
+  it('returns ChangePassword for authenticate URL', async () => {
+    (getCurrentUrl as jest.Mock).mockResolvedValue('https://hb2.bankleumi.co.il/authenticate');
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe(ScraperErrorTypes.ChangePassword);
+  });
+});
+
+describe('fetchData', () => {
+  it('fetches and converts transactions', async () => {
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts![0].accountNumber).toBe('123_456');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-100);
+    expect(t.originalCurrency).toBe(SHEKEL_CURRENCY);
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.status).toBe(TransactionStatuses.Completed);
+    expect(t.description).toBe('Test Transaction');
+    expect(t.memo).toBe('memo text');
+    expect(t.identifier).toBe(12345);
   });
 
-  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password"',
-    async () => {
-      const options = {
-        ...testsConfig.options,
-        companyId: COMPANY_ID,
-      };
-
-      const scraper = new LeumiScraper(options);
-
-      const result = await scraper.scrape({ username: 'e10s12', password: '3f3ss3d' });
-
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
-    },
-  );
-
-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions', async () => {
-    const options = {
-      ...testsConfig.options,
-      companyId: COMPANY_ID,
+  it('separates pending and completed transactions', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({
+        jsonResp: JSON.stringify({
+          TodayTransactionsItems: [
+            { DateUTC: '2025-06-15T00:00:00', Amount: -50, Description: 'Pending', ReferenceNumberLong: 1 },
+          ],
+          HistoryTransactionsItems: [
+            { DateUTC: '2025-06-14T00:00:00', Amount: -100, Description: 'Completed', ReferenceNumberLong: 2 },
+          ],
+        }),
+      }),
     };
 
-    const scraper = new LeumiScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.leumi);
-    expect(result).toBeDefined();
-    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
-    expect(error).toBe('');
-    expect(result.success).toBeTruthy();
+    const page = createLeumiPage();
+    page.waitForResponse.mockResolvedValue(mockResponse);
+    mockBrowser.newPage.mockResolvedValue(page);
 
-    exportTransactions(COMPANY_ID, result.accounts || []);
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const pending = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Pending);
+    const completed = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Completed);
+    expect(pending).toBeDefined();
+    expect(completed).toBeDefined();
+    expect(pending!.description).toBe('Pending');
+    expect(completed!.description).toBe('Completed');
+  });
+
+  it('handles empty transaction arrays', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({
+        jsonResp: JSON.stringify({
+          TodayTransactionsItems: null,
+          HistoryTransactionsItems: [],
+        }),
+      }),
+    };
+
+    const page = createLeumiPage();
+    page.waitForResponse.mockResolvedValue(mockResponse);
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(0);
+  });
+
+  it('throws on empty account IDs', async () => {
+    const page = createLeumiPage();
+    page.evaluate.mockResolvedValue([]);
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('Failed to extract');
+  });
+
+  it('extracts balance from response', async () => {
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBe(5000);
+  });
+
+  it('removes special characters from account ID', async () => {
+    const page = createLeumiPage(['123&/456']);
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].accountNumber).toBe('123_456');
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    const scraper = new LeumiScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
   });
 });

--- a/src/scrapers/mizrahi.test.ts
+++ b/src/scrapers/mizrahi.test.ts
@@ -1,69 +1,235 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { SHEKEL_CURRENCY } from '../constants';
+import { fetchPostWithinPage } from '../helpers/fetch';
+import { elementPresentOnPage } from '../helpers/elements-interactions';
+import { applyAntiDetection } from '../helpers/browser';
+import { getCurrentUrl } from '../helpers/navigation';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import MizrahiScraper from './mizrahi';
-import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
-import { ISO_DATE_REGEX } from '../constants';
-import { LoginResults } from './base-scraper-with-browser';
-import { type TransactionsAccount } from '../transactions';
-import debug from 'debug';
-import { type ScraperOptions } from './interface';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-debug.enable('israeli-bank-scrapers:mizrahi');
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/fetch', () => ({ fetchPostWithinPage: jest.fn() }));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementDisappear: jest.fn().mockResolvedValue(undefined),
+  waitUntilIframeFound: jest
+    .fn()
+    .mockResolvedValue({ waitForSelector: jest.fn().mockRejectedValue(new Error('not found')) }),
+  elementPresentOnPage: jest.fn().mockResolvedValue(false),
+  pageEvalAll: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://mto.mizrahi-tefahot.co.il/OnlineApp/dashboard'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+  waitForUrl: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/transactions', () => ({
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-const COMPANY_ID = 'mizrahi'; // TODO this property should be hard-coded in the provider
-const testsConfig = getTestsConfig();
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
 
-describe('Mizrahi scraper', () => {
-  beforeAll(() => {
-    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
-  });
+const CREDS = { username: 'testuser', password: 'testpass' };
 
-  test('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS.mizrahi).toBeDefined();
-    expect(SCRAPERS.mizrahi.loginFields).toContain('username');
-    expect(SCRAPERS.mizrahi.loginFields).toContain('password');
-  });
+function scrapedTxn(overrides: any = {}): any {
+  return {
+    RecTypeSpecified: true,
+    MC02PeulaTaaEZ: '2025-06-15T10:00:00',
+    MC02SchumEZ: -150,
+    MC02AsmahtaMekoritEZ: '12345',
+    MC02TnuaTeurEZ: 'העברה בנקאית',
+    IsTodayTransaction: false,
+    MC02ErehTaaEZ: '2025-06-16T00:00:00',
+    MC02ShowDetailsEZ: '0',
+    TransactionNumber: null,
+    ...overrides,
+  };
+}
 
-  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password',
-    async () => {
-      const options = {
-        ...testsConfig.options,
-        companyId: COMPANY_ID,
-      };
-
-      const scraper = new MizrahiScraper(options);
-
-      const result = await scraper.scrape({ username: 'e10s12', password: '3f3ss3d' });
-
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
+function mockApiResponse(rows: any[] = [], balance = '5000') {
+  return {
+    header: { success: true, messages: [] },
+    body: {
+      fields: { Yitra: balance },
+      table: { rows },
     },
-  );
+  };
+}
 
-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions', async () => {
-    const options: ScraperOptions = {
-      ...testsConfig.options,
-      optInFeatures: [
-        'mizrahi:pendingIfHasGenericDescription',
-        'mizrahi:pendingIfHasGenericDescriptionWithDate',
-        'mizrahi:pendingIfTodayTransaction',
-      ],
-      companyId: COMPANY_ID,
-    };
+function createMizrahiPage() {
+  const mockRequest = {
+    postData: () => JSON.stringify({ table: {} }),
+    headers: () => ({ mizrahixsrftoken: 'xsrf-token', 'content-type': 'application/json' }),
+  };
 
-    const scraper = new MizrahiScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.mizrahi);
-    expect(result).toBeDefined();
-    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
-    expect(error).toBe('');
-    expect(result.success).toBeTruthy();
-    expect(result.accounts).toBeDefined();
-    expect((result.accounts as any).length).toBeGreaterThan(0);
-    const account: TransactionsAccount = (result as any).accounts[0];
-    expect(account.accountNumber).not.toBe('');
-    expect(account.txns[0].date).toMatch(ISO_DATE_REGEX);
+  return createMockPage({
+    $eval: jest.fn().mockResolvedValue(undefined),
+    $$: jest.fn().mockResolvedValue([{ click: jest.fn() }]),
+    $: jest.fn().mockResolvedValue({
+      getProperty: jest.fn().mockResolvedValue({
+        jsonValue: jest.fn().mockResolvedValue('ACC-12345'),
+      }),
+    }),
+    waitForRequest: jest.fn().mockResolvedValue(mockRequest),
+    waitForSelector: jest.fn().mockResolvedValue(undefined),
+  });
+}
 
-    exportTransactions(COMPANY_ID, result.accounts || []);
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  mockBrowser.newPage.mockResolvedValue(createMizrahiPage());
+  (getCurrentUrl as jest.Mock).mockResolvedValue('https://mto.mizrahi-tefahot.co.il/OnlineApp/dashboard');
+  (elementPresentOnPage as jest.Mock).mockResolvedValue(false);
+});
+
+describe('login', () => {
+  it('succeeds with valid credentials', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(mockApiResponse([scrapedTxn()]));
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
+  });
+});
+
+describe('fetchData', () => {
+  it('fetches and converts transactions', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02SchumEZ: -250, MC02TnuaTeurEZ: 'רמי לוי' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts![0].accountNumber).toBe('ACC-12345');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-250);
+    expect(t.originalCurrency).toBe(SHEKEL_CURRENCY);
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.status).toBe(TransactionStatuses.Completed);
+    expect(t.description).toBe('רמי לוי');
+  });
+
+  it('filters rows by RecTypeSpecified', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn(), scrapedTxn({ RecTypeSpecified: false })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(1);
+  });
+
+  it('returns error when API response is unsuccessful', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce({
+      header: { success: false, messages: [{ text: 'Error occurred' }] },
+      body: { fields: {}, table: { rows: [] } },
+    });
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('Error occurred');
+  });
+
+  it('returns error when account number not found', async () => {
+    const page = createMizrahiPage();
+    page.$.mockResolvedValue({
+      getProperty: jest.fn().mockResolvedValue({
+        jsonValue: jest.fn().mockResolvedValue(''),
+      }),
+    });
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('Account number not found');
+  });
+
+  it('marks today transactions as pending when feature flag enabled', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ IsTodayTransaction: true })]),
+    );
+
+    const scraper = new MizrahiScraper(
+      createMockScraperOptions({ optInFeatures: ['mizrahi:pendingIfTodayTransaction'] }),
+    );
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Pending);
+  });
+
+  it('marks transactions without identifier as pending when feature flag enabled', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02AsmahtaMekoritEZ: '' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions({ optInFeatures: ['mizrahi:pendingIfNoIdentifier'] }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Pending);
+  });
+
+  it('builds compound identifier with TransactionNumber', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02AsmahtaMekoritEZ: '999', TransactionNumber: '5' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBe('999-5');
+  });
+
+  it('parses identifier as integer when no TransactionNumber', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02AsmahtaMekoritEZ: '12345', TransactionNumber: null })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBe(12345);
+  });
+
+  it('extracts balance from response', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(mockApiResponse([scrapedTxn()], '15000'));
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBe(15000);
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(mockApiResponse([scrapedTxn()]));
+
+    const scraper = new MizrahiScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
   });
 });

--- a/src/scrapers/union-bank.test.ts
+++ b/src/scrapers/union-bank.test.ts
@@ -1,53 +1,211 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { SHEKEL_CURRENCY } from '../constants';
+import { elementPresentOnPage, pageEvalAll, dropdownElements } from '../helpers/elements-interactions';
+import { applyAntiDetection } from '../helpers/browser';
+import { getCurrentUrl } from '../helpers/navigation';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import UnionBankScraper from './union-bank';
-import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
-import { LoginResults } from './base-scraper-with-browser';
+import { ScraperErrorTypes } from './errors';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-const COMPANY_ID = 'union'; // TODO this property should be hard-coded in the provider
-const testsConfig = getTestsConfig();
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+  elementPresentOnPage: jest.fn().mockResolvedValue(false),
+  pageEvalAll: jest.fn().mockResolvedValue([]),
+  dropdownSelect: jest.fn().mockResolvedValue(undefined),
+  dropdownElements: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://hb.unionbank.co.il/eBanking/Accounts/ExtendedActivity.aspx'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/transactions', () => ({
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-describe('Union', () => {
-  beforeAll(() => {
-    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const CREDS = { username: 'testuser', password: 'testpass' };
+
+function createUnionPage() {
+  return createMockPage({
+    $eval: jest.fn().mockImplementation((selector: string) => {
+      if (selector.includes('option[selected')) return '123/456789';
+      return undefined;
+    }),
+  });
+}
+
+function mockTransactionTable(headers: any[], rows: any[]) {
+  (pageEvalAll as jest.Mock).mockResolvedValueOnce(headers).mockResolvedValueOnce(rows);
+}
+
+const STANDARD_HEADERS = [
+  { text: 'תאריך', index: 0 },
+  { text: 'תיאור', index: 1 },
+  { text: 'אסמכתא', index: 2 },
+  { text: 'חובה', index: 3 },
+  { text: 'זכות', index: 4 },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  mockBrowser.newPage.mockResolvedValue(createUnionPage());
+  (getCurrentUrl as jest.Mock).mockResolvedValue('https://hb.unionbank.co.il/eBanking/Accounts/ExtendedActivity.aspx');
+  (elementPresentOnPage as jest.Mock).mockResolvedValue(false);
+  (dropdownElements as jest.Mock).mockResolvedValue([{ name: 'Account 1', value: '123' }]);
+});
+
+describe('login', () => {
+  it('succeeds with valid credentials', async () => {
+    // Mock pending table (empty) + completed table (empty)
+    mockTransactionTable([], []);
+    mockTransactionTable([], []);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
   });
 
-  test('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS.union).toBeDefined();
-    expect(SCRAPERS.union.loginFields).toContain('username');
-    expect(SCRAPERS.union.loginFields).toContain('password');
+  it('returns InvalidPassword for login page URL', async () => {
+    (getCurrentUrl as jest.Mock).mockResolvedValue(
+      'https://hb.unionbank.co.il/InternalSite/CustomUpdate/leumi/LoginPage.ASP',
+    );
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe(ScraperErrorTypes.InvalidPassword);
+  });
+});
+
+describe('fetchData', () => {
+  it('fetches and converts transactions', async () => {
+    // Pending table (empty)
+    mockTransactionTable([], []);
+    // Completed table with data
+    mockTransactionTable(STANDARD_HEADERS, [{ id: '', innerTds: ['15/06/25', 'סופר שופ', '12345', '150.00', ''] }]);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts![0].accountNumber).toBe('123_456789');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-150);
+    expect(t.originalCurrency).toBe(SHEKEL_CURRENCY);
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.status).toBe(TransactionStatuses.Completed);
+    expect(t.description).toBe('סופר שופ');
+    expect(t.identifier).toBe(12345);
   });
 
-  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password"',
-    async () => {
-      const options = {
-        ...testsConfig.options,
-        companyId: COMPANY_ID,
-      };
+  it('calculates amount as credit minus debit', async () => {
+    mockTransactionTable([], []);
+    mockTransactionTable(STANDARD_HEADERS, [{ id: '', innerTds: ['15/06/25', 'Refund', '', '', '200.00'] }]);
 
-      const scraper = new UnionBankScraper(options);
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
 
-      const result = await scraper.scrape({ username: 'e10s12', password: '3f3ss3d' });
+    expect(result.accounts![0].txns[0].originalAmount).toBe(200);
+  });
 
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
-    },
-  );
+  it('handles NaN amounts gracefully', async () => {
+    mockTransactionTable([], []);
+    mockTransactionTable(STANDARD_HEADERS, [{ id: '', innerTds: ['15/06/25', 'Test', '', '', ''] }]);
 
-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
-    const options = {
-      ...testsConfig.options,
-      companyId: COMPANY_ID,
-    };
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
 
-    const scraper = new UnionBankScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.union);
-    expect(result).toBeDefined();
-    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
-    expect(error).toBe('');
-    expect(result.success).toBeTruthy();
+    expect(result.accounts![0].txns[0].originalAmount).toBe(0);
+  });
 
-    exportTransactions(COMPANY_ID, result.accounts || []);
+  it('handles expanded description rows', async () => {
+    mockTransactionTable([], []);
+    mockTransactionTable(STANDARD_HEADERS, [
+      { id: '', innerTds: ['15/06/25', 'Payment', '100', '50.00', ''] },
+      { id: 'rowAdded', innerTds: ['Extra details about payment'] },
+    ]);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(1);
+    expect(result.accounts![0].txns[0].description).toBe('Payment Extra details about payment');
+  });
+
+  it('handles no transactions in date range', async () => {
+    (elementPresentOnPage as jest.Mock).mockImplementation((_p: any, selector: string) => {
+      return selector === '.errInfo';
+    });
+    mockBrowser.newPage.mockResolvedValue(
+      createMockPage({
+        $eval: jest.fn().mockImplementation((selector: string) => {
+          if (selector.includes('option[selected')) return '123/456789';
+          if (selector === '.errInfo') return 'לא קיימות תנועות מתאימות על פי הסינון שהוגדר';
+          return '';
+        }),
+      }),
+    );
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts![0].txns).toHaveLength(0);
+  });
+
+  it('handles pending transactions', async () => {
+    mockTransactionTable(STANDARD_HEADERS, [{ id: '', innerTds: ['15/06/25', 'Pending item', '', '30.00', ''] }]);
+    mockTransactionTable([], []);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const pending = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Pending);
+    expect(pending).toBeDefined();
+    expect(pending!.originalAmount).toBe(-30);
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    mockTransactionTable([], []);
+    mockTransactionTable(STANDARD_HEADERS, [{ id: '', innerTds: ['15/06/25', 'Test', '100', '50.00', ''] }]);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
+  });
+
+  it('skips all-accounts option in dropdown', async () => {
+    (dropdownElements as jest.Mock).mockResolvedValue([
+      { name: 'All', value: '-1' },
+      { name: 'Account 1', value: '123' },
+    ]);
+    mockTransactionTable([], []);
+    mockTransactionTable([], []);
+
+    const scraper = new UnionBankScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts).toHaveLength(1);
   });
 });

--- a/src/scrapers/visa-cal.test.ts
+++ b/src/scrapers/visa-cal.test.ts
@@ -1,54 +1,332 @@
-import { SCRAPERS } from '../definitions';
-import { exportTransactions, extendAsyncTimeout, getTestsConfig, maybeTestCompanyAPI } from '../tests/tests-utils';
-import { LoginResults } from './base-scraper-with-browser';
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { fetchPost } from '../helpers/fetch';
+import { getFromSessionStorage } from '../helpers/storage';
+import { elementPresentOnPage } from '../helpers/elements-interactions';
+import { applyAntiDetection } from '../helpers/browser';
+import { filterOldTransactions } from '../helpers/transactions';
+import { getCurrentUrl } from '../helpers/navigation';
+import { waitUntil } from '../helpers/waiting';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import VisaCalScraper from './visa-cal';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-const COMPANY_ID = 'visaCal'; // TODO this property should be hard-coded in the provider
-const testsConfig = getTestsConfig();
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/fetch', () => ({ fetchPost: jest.fn() }));
+jest.mock('../helpers/storage', () => ({ getFromSessionStorage: jest.fn() }));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+  elementPresentOnPage: jest.fn().mockResolvedValue(false),
+  pageEval: jest.fn().mockResolvedValue(''),
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://digital-web.cal-online.co.il/dashboard'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/transactions', () => ({
+  filterOldTransactions: jest.fn((txns: any[]) => txns),
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/waiting', () => ({
+  waitUntil: jest.fn(async (fn: () => Promise<any>) => fn()),
+  TimeoutError: class TimeoutError extends Error {},
+  SECOND: 1000,
+  sleep: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-describe('VisaCal legacy scraper', () => {
-  beforeAll(() => {
-    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
-  });
+function visaCalOptions(overrides: Record<string, any> = {}) {
+  return createMockScraperOptions({ startDate: new Date(), futureMonthsToScrape: 0, ...overrides });
+}
 
-  test('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS.visaCal).toBeDefined();
-    expect(SCRAPERS.visaCal.loginFields).toContain('username');
-    expect(SCRAPERS.visaCal.loginFields).toContain('password');
-  });
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
 
-  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password"',
-    async () => {
-      const options = {
-        ...testsConfig.options,
-        companyId: COMPANY_ID,
-      };
+const CREDS = { username: 'testuser', password: 'testpass' };
 
-      const scraper = new VisaCalScraper(options);
+function scrapedTxn(overrides: any = {}): any {
+  return {
+    amtBeforeConvAndIndex: 100,
+    branchCodeDesc: 'מזון',
+    cashAccountTrnAmt: 100,
+    chargeExternalToCardComment: '',
+    comments: [],
+    curPaymentNum: 0,
+    debCrdCurrencySymbol: 'ILS',
+    debCrdDate: '2025-06-15',
+    debitSpreadInd: false,
+    immediateComments: [],
+    isImmediateCommentInd: false,
+    isImmediateHHKInd: false,
+    isMargarita: false,
+    isSpreadPaymenstAbroad: false,
+    linkedComments: [],
+    merchantAddress: '',
+    merchantName: 'סופר שופ',
+    merchantPhoneNo: '',
+    numOfPayments: 0,
+    onGoingTransactionsComment: '',
+    refundInd: false,
+    transCardPresentInd: false,
+    transTypeCommentDetails: [],
+    trnAmt: 100,
+    trnCurrencySymbol: 'ILS',
+    trnExacWay: 0,
+    trnIntId: 'TRN-001',
+    trnNumaretor: 0,
+    trnPurchaseDate: '2025-06-10',
+    trnType: 'רגילה',
+    trnTypeCode: '5',
+    walletProviderCode: 0,
+    walletProviderDesc: '',
+    earlyPaymentInd: false,
+    ...overrides,
+  };
+}
 
-      const result = await scraper.scrape({ username: '971sddksmsl', password: '3f3ssdkSD3d' });
-
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
+function mockCardTransactionDetails(txns: any[] = [], overrides: any = {}) {
+  return {
+    statusCode: 1,
+    statusDescription: 'OK',
+    statusTitle: '',
+    title: '',
+    result: {
+      bankAccounts: [
+        {
+          bankAccountNum: '12345',
+          bankName: 'Test',
+          choiceExternalTransactions: null,
+          currentBankAccountInd: true,
+          debitDates: [
+            {
+              date: '2025-06-15',
+              fromPurchaseDate: '2025-05-01',
+              toPurchaseDate: '2025-05-31',
+              transactions: txns,
+              totalDebits: [{ currencySymbol: 'ILS', amount: 100 }],
+              totalBasketAmount: 0,
+              isChoiceRepaiment: false,
+              choiceHHKDebit: 0,
+              fixDebitAmount: 0,
+              debitReason: null,
+              basketAmountComment: null,
+            },
+          ],
+          immidiateDebits: { totalDebits: [], debitDays: [] },
+        },
+      ],
+      blockedCardInd: false,
     },
-  );
+    ...overrides,
+  };
+}
 
-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
-    const options = {
-      ...testsConfig.options,
-      companyId: COMPANY_ID,
-    };
+function setupVisaCalMocks() {
+  const page = createMockPage({
+    frames: jest.fn().mockReturnValue([
+      {
+        url: () => 'https://connect.cal-online.co.il/login',
+        waitForSelector: jest.fn().mockResolvedValue(undefined),
+      },
+    ]),
+    waitForRequest: jest.fn().mockResolvedValue({
+      headers: () => ({ authorization: 'Bearer auth-token' }),
+    }),
+  });
+  mockBrowser.newPage.mockResolvedValue(page);
 
-    const scraper = new VisaCalScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.visaCal);
-    expect(result).toBeDefined();
-    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
-    expect(error).toBe('');
-    expect(result.success).toBeTruthy();
-    // uncomment to test multiple accounts
-    // expect(result?.accounts?.length).toEqual(2)
-    exportTransactions(COMPANY_ID, result.accounts || []);
+  // waitUntil: return session storage data
+  (waitUntil as jest.Mock).mockImplementation(async (fn: () => Promise<any>) => {
+    return fn();
+  });
+
+  // getFromSessionStorage: return init data with cards
+  (getFromSessionStorage as jest.Mock).mockImplementation((_page: any, key: string) => {
+    if (key === 'init') {
+      return Promise.resolve({
+        result: {
+          cards: [{ cardUniqueId: 'card-1', last4Digits: '4580' }],
+        },
+      });
+    }
+    if (key === 'auth-module') {
+      return Promise.resolve({
+        auth: { calConnectToken: 'cal-auth-token' },
+      });
+    }
+    return Promise.resolve(null);
+  });
+
+  return page;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  (getCurrentUrl as jest.Mock).mockResolvedValue('https://digital-web.cal-online.co.il/dashboard');
+  (elementPresentOnPage as jest.Mock).mockResolvedValue(false);
+});
+
+describe('login', () => {
+  it('succeeds with valid credentials', async () => {
+    setupVisaCalMocks();
+    // Frames response
+    (fetchPost as jest.Mock).mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } });
+    // Pending transactions
+    (fetchPost as jest.Mock).mockResolvedValueOnce({ statusCode: 96 });
+    // Month data
+    (fetchPost as jest.Mock).mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
+  });
+});
+
+describe('fetchData', () => {
+  it('fetches and converts normal transactions', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(
+        mockCardTransactionDetails([scrapedTxn({ trnAmt: 250, merchantName: 'רמי לוי', trnTypeCode: '5' })]),
+      );
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts![0].accountNumber).toBe('4580');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-250);
+    expect(t.description).toBe('רמי לוי');
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.status).toBe(TransactionStatuses.Completed);
+  });
+
+  it('detects installment transactions', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(
+        mockCardTransactionDetails([scrapedTxn({ trnTypeCode: '8', numOfPayments: 12, curPaymentNum: 3 })]),
+      );
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const t = result.accounts![0].txns[0];
+    expect(t.type).toBe(TransactionTypes.Installments);
+    expect(t.installments).toEqual({ number: 3, total: 12 });
+  });
+
+  it('handles credit transactions with positive amount', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn({ trnTypeCode: '6', trnAmt: 50 })]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].originalAmount).toBe(50);
+  });
+
+  it('handles pending transactions with statusCode 96 (no data)', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('throws on failed month data fetch', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce({ statusCode: 0, title: 'Error' });
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('failed to fetch transactions');
+  });
+
+  it('calls filterOldTransactions when enabled', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    await new VisaCalScraper(visaCalOptions()).scrape(CREDS);
+
+    expect(filterOldTransactions).toHaveBeenCalled();
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const result = await new VisaCalScraper(visaCalOptions({ includeRawTransaction: true })).scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
+  });
+
+  it('extracts balance from frames data', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({
+        result: {
+          bankIssuedCards: {
+            cardLevelFrames: [{ cardUniqueId: 'card-1', nextTotalDebit: 5000 }],
+          },
+        },
+      })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBe(-5000);
+  });
+
+  it('assigns category from branchCodeDesc', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn({ branchCodeDesc: 'מסעדות' })]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].category).toBe('מסעדות');
   });
 });

--- a/src/scrapers/yahav.test.ts
+++ b/src/scrapers/yahav.test.ts
@@ -1,54 +1,151 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import puppeteer from 'puppeteer';
+import { SHEKEL_CURRENCY } from '../constants';
+import { elementPresentOnPage, pageEvalAll } from '../helpers/elements-interactions';
+import { applyAntiDetection } from '../helpers/browser';
+import { getCurrentUrl } from '../helpers/navigation';
+import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import YahavScraper from './yahav';
-import { maybeTestCompanyAPI, extendAsyncTimeout, getTestsConfig, exportTransactions } from '../tests/tests-utils';
-import { SCRAPERS } from '../definitions';
-import { LoginResults } from './base-scraper-with-browser';
+import { ScraperErrorTypes } from './errors';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
-const COMPANY_ID = 'yahav'; // TODO this property should be hard-coded in the provider
-const testsConfig = getTestsConfig();
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+jest.mock('../helpers/elements-interactions', () => ({
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementFound: jest.fn().mockResolvedValue(undefined),
+  waitUntilElementDisappear: jest.fn().mockResolvedValue(undefined),
+  elementPresentOnPage: jest.fn().mockResolvedValue(false),
+  pageEvalAll: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../helpers/navigation', () => ({
+  getCurrentUrl: jest.fn().mockResolvedValue('https://digital.yahav.co.il/BaNCSDigitalUI/app/index.html#/main/home'),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../helpers/browser', () => ({
+  applyAntiDetection: jest.fn().mockResolvedValue(undefined),
+  isBotDetectionScript: jest.fn(() => false),
+  interceptionPriorities: { abort: 1000, continue: 10 },
+}));
+jest.mock('../helpers/transactions', () => ({
+  getRawTransaction: jest.fn((data: any) => data),
+}));
+jest.mock('../helpers/debug', () => ({ getDebug: () => jest.fn() }));
 
-describe('Yahav scraper', () => {
-  beforeAll(() => {
-    extendAsyncTimeout(); // The default timeout is 5 seconds per async test, this function extends the timeout value
+const mockBrowser = {
+  newPage: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const CREDS = { username: 'testuser', password: 'testpass', nationalID: '123456789' };
+
+function createYahavPage() {
+  return createMockPage({
+    $eval: jest.fn().mockImplementation((selector: string) => {
+      if (selector.includes('portfolio-value')) return 'ACC-12345';
+      if (selector.includes('.pmu-years')) return '2025';
+      if (selector.includes('.pmu-days')) return '1';
+      return '';
+    }),
+    waitForSelector: jest.fn().mockResolvedValue(undefined),
   });
+}
 
-  test('should expose login fields in scrapers constant', () => {
-    expect(SCRAPERS.yahav).toBeDefined();
-    expect(SCRAPERS.yahav.loginFields).toContain('username');
-    expect(SCRAPERS.yahav.loginFields).toContain('password');
-    expect(SCRAPERS.yahav.loginFields).toContain('nationalID');
-  });
-
-  maybeTestCompanyAPI(COMPANY_ID, config => config.companyAPI.invalidPassword)(
-    'should fail on invalid user/password"',
-    async () => {
-      const options = {
-        ...testsConfig.options,
-        companyId: COMPANY_ID,
-      };
-
-      const scraper = new YahavScraper(options);
-
-      const result = await scraper.scrape({ username: 'e10s12', password: '3f3ss3d', nationalID: '12345679' });
-
-      expect(result).toBeDefined();
-      expect(result.success).toBeFalsy();
-      expect(result.errorType).toBe(LoginResults.InvalidPassword);
-    },
+beforeEach(() => {
+  jest.clearAllMocks();
+  (puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser);
+  mockBrowser.newPage.mockResolvedValue(createYahavPage());
+  (getCurrentUrl as jest.Mock).mockResolvedValue(
+    'https://digital.yahav.co.il/BaNCSDigitalUI/app/index.html#/main/home',
   );
+  (elementPresentOnPage as jest.Mock).mockResolvedValue(false);
+});
 
-  maybeTestCompanyAPI(COMPANY_ID)('should scrape transactions"', async () => {
-    const options = {
-      ...testsConfig.options,
-      companyId: COMPANY_ID,
-    };
+describe('login', () => {
+  it('succeeds with 3-field credentials', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValue([]);
 
-    const scraper = new YahavScraper(options);
-    const result = await scraper.scrape(testsConfig.credentials.yahav);
-    expect(result).toBeDefined();
-    const error = `${result.errorType || ''} ${result.errorMessage || ''}`.trim();
-    expect(error).toBe('');
-    expect(result.success).toBeTruthy();
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
 
-    exportTransactions(COMPANY_ID, result.accounts || []);
+    expect(result.success).toBe(true);
+    expect(applyAntiDetection).toHaveBeenCalled();
+  });
+
+  it('returns InvalidPassword when dialog appears', async () => {
+    (getCurrentUrl as jest.Mock).mockResolvedValue('https://login.yahav.co.il/login/');
+    (elementPresentOnPage as jest.Mock).mockImplementation((_p: any, selector: string) => {
+      return selector === '.ui-dialog-buttons';
+    });
+
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe(ScraperErrorTypes.InvalidPassword);
+  });
+});
+
+describe('fetchData', () => {
+  it('fetches and converts transactions', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValueOnce([
+      { id: '', innerDivs: ['0', '15/06/2025', '12345', 'סופר שופ', '150.00', ''] },
+    ]);
+
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts![0].accountNumber).toBe('ACC-12345');
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalAmount).toBe(-150);
+    expect(t.originalCurrency).toBe(SHEKEL_CURRENCY);
+    expect(t.type).toBe(TransactionTypes.Normal);
+    expect(t.status).toBe(TransactionStatuses.Completed);
+    expect(t.description).toBe('סופר שופ');
+  });
+
+  it('cleans reference field with regex', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValueOnce([
+      { id: '', innerDivs: ['0', '15/06/2025', 'REF-123-ABC', 'Test', '50.00', ''] },
+    ]);
+
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBe(123);
+  });
+
+  it('calculates credit minus debit', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValueOnce([
+      { id: '', innerDivs: ['0', '15/06/2025', '', 'Credit', '', '300.00'] },
+    ]);
+
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].originalAmount).toBe(300);
+  });
+
+  it('handles NaN amounts', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValueOnce([{ id: '', innerDivs: ['0', '15/06/2025', '', 'Test', '', ''] }]);
+
+    const scraper = new YahavScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].originalAmount).toBe(0);
+  });
+
+  it('includes rawTransaction when option set', async () => {
+    (pageEvalAll as jest.Mock).mockResolvedValueOnce([
+      { id: '', innerDivs: ['0', '15/06/2025', '100', 'Test', '50.00', ''] },
+    ]);
+
+    const scraper = new YahavScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
   });
 });

--- a/tasks/add-unit-tests.md
+++ b/tasks/add-unit-tests.md
@@ -2,12 +2,14 @@
 
 ## Current State
 
-Coverage baseline (updated Feb 2026 after Phase 2+3 test additions):
+Coverage baseline (updated Feb 2026 after all scraper unit tests):
 
-- Statements: 31.38%
-- Branches: 16.84%
-- Functions: 18.59%
-- Lines: 31.94%
+- Statements: 86%
+- Branches: 73.89%
+- Functions: 75.2%
+- Lines: 87.47%
+
+Remaining gaps are mostly browser-context callbacks inside `page.evaluate()` / `page.$eval()` — these can't be covered by mocked unit tests (validated by E2E tests instead).
 
 ## Target
 


### PR DESCRIPTION
## Summary
- Add 61 mocked unit tests for 6 remaining scrapers: behatsdaa, union-bank, yahav, leumi, mizrahi, visa-cal
- Add 1 helper gap test: `pageEvalAll` rethrow for non-selector errors
- Ratchet coverage thresholds: statements 64→85%, branches 56→73%, functions 49→74%, lines 65→87%

## Coverage
| Metric | Before | After |
|--------|--------|-------|
| Statements | 64% | 86% |
| Branches | 57% | 74% |
| Functions | 50% | 75% |
| Lines | 66% | 87% |

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes (ESLint + Prettier)
- [x] `npm test` passes (333 active + 12 skipped = 345 total)
- [x] `npm run build` succeeds
- [x] Coverage thresholds met with new ratcheted values

🤖 Generated with [Claude Code](https://claude.com/claude-code)