### PR TITLE
test: expand integration test coverage across 6 scrapers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ const config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 73,
-      functions: 74,
-      lines: 87,
-      statements: 85,
+      branches: 77,
+      functions: 76,
+      lines: 89,
+      statements: 87,
     },
   },
 };

--- a/src/scrapers/base-beinleumi-group.test.ts
+++ b/src/scrapers/base-beinleumi-group.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import puppeteer from 'puppeteer';
 import { SHEKEL_CURRENCY } from '../constants';
-import { elementPresentOnPage, pageEvalAll } from '../helpers/elements-interactions';
+import { clickButton, elementPresentOnPage, pageEvalAll } from '../helpers/elements-interactions';
 import { applyAntiDetection } from '../helpers/browser';
 import { sleep } from '../helpers/waiting';
 import { getCurrentUrl } from '../helpers/navigation';
 import { createMockPage, createMockScraperOptions } from '../tests/mock-page';
 import BeinleumiGroupBaseScraper from './base-beinleumi-group';
 import { ScraperErrorTypes } from './errors';
-import { TransactionTypes } from '../transactions';
+import { TransactionStatuses, TransactionTypes } from '../transactions';
 
 jest.mock('puppeteer', () => ({ launch: jest.fn() }));
 jest.mock('../helpers/elements-interactions', () => ({
@@ -71,6 +71,14 @@ function createPageWithAccountFeatures(overrides: Record<string, any> = {}) {
 const COMPLETED_COLUMN_TYPES = [
   { colClass: 'date first', index: 0 },
   { colClass: 'reference wrap_normal', index: 1 },
+  { colClass: 'details', index: 2 },
+  { colClass: 'debit', index: 3 },
+  { colClass: 'credit', index: 4 },
+];
+
+const PENDING_COLUMN_TYPES = [
+  { colClass: 'first date', index: 0 },
+  { colClass: 'details wrap_normal', index: 1 },
   { colClass: 'details', index: 2 },
   { colClass: 'debit', index: 3 },
   { colClass: 'credit', index: 4 },
@@ -174,5 +182,107 @@ describe('fetchData', () => {
     const result = await scraper.scrape(CREDS);
 
     expect(result.accounts![0].txns[0].identifier).toBe(12345);
+  });
+
+  it('sets identifier to undefined when reference is empty', async () => {
+    mockTransactionTable([{ innerTds: ['15/06/2024', 'Test', '', '₪100.00', ''] }]);
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBeUndefined();
+  });
+
+  it('extracts pending transactions with pending column layout', async () => {
+    (pageEvalAll as jest.Mock)
+      .mockResolvedValueOnce(PENDING_COLUMN_TYPES) // pending column types
+      .mockResolvedValueOnce([{ innerTds: ['20/06/2024', 'Pending Purchase', '999', '₪75.00', ''] }]) // pending rows
+      .mockResolvedValueOnce(COMPLETED_COLUMN_TYPES) // completed column types
+      .mockResolvedValueOnce([]); // completed rows (empty)
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(1);
+    expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Pending);
+    expect(result.accounts![0].txns[0].description).toBe('Pending Purchase');
+    expect(result.accounts![0].txns[0].originalAmount).toBe(-75);
+  });
+
+  it('combines pending and completed transactions', async () => {
+    (pageEvalAll as jest.Mock)
+      .mockResolvedValueOnce(PENDING_COLUMN_TYPES)
+      .mockResolvedValueOnce([{ innerTds: ['20/06/2024', 'Pending', '', '₪50.00', ''] }])
+      .mockResolvedValueOnce(COMPLETED_COLUMN_TYPES)
+      .mockResolvedValueOnce([{ innerTds: ['15/06/2024', 'Completed', '100', '₪100.00', ''] }]);
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(2);
+    const pending = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Pending);
+    const completed = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Completed);
+    expect(pending).toBeDefined();
+    expect(completed).toBeDefined();
+  });
+
+  it('paginates completed transactions when next page exists', async () => {
+    // First call: pending (empty)
+    (pageEvalAll as jest.Mock)
+      .mockResolvedValueOnce([]) // pending column types
+      .mockResolvedValueOnce([]) // pending rows
+      // First page of completed
+      .mockResolvedValueOnce(COMPLETED_COLUMN_TYPES)
+      .mockResolvedValueOnce([{ innerTds: ['15/06/2024', 'Page1', '100', '₪100.00', ''] }]);
+
+    // After first page: next page link exists
+    (elementPresentOnPage as jest.Mock)
+      .mockResolvedValueOnce(false) // NO_DATA check
+      .mockResolvedValueOnce(true); // hasNextPage = true
+
+    // Second page of completed
+    (pageEvalAll as jest.Mock)
+      .mockResolvedValueOnce(COMPLETED_COLUMN_TYPES)
+      .mockResolvedValueOnce([{ innerTds: ['16/06/2024', 'Page2', '200', '₪200.00', ''] }]);
+
+    // After second page: no next page
+    (elementPresentOnPage as jest.Mock).mockResolvedValueOnce(false); // hasNextPage = false
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(2);
+    expect(result.accounts![0].txns[0].description).toBe('Page1');
+    expect(result.accounts![0].txns[1].description).toBe('Page2');
+    expect(clickButton).toHaveBeenCalledWith(expect.anything(), 'a#Npage.paging');
+  });
+
+  it('retries iframe detection with sleep', async () => {
+    mockTransactionTable([{ innerTds: ['15/06/2024', 'Test', '100', '₪100.00', ''] }]);
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    // getTransactionsFrame calls sleep(2000) up to 3 times when no iframe found
+    expect(result.success).toBe(true);
+    expect(sleep).toHaveBeenCalledWith(2000);
+  });
+
+  it('extracts balance from page', async () => {
+    mockTransactionTable([{ innerTds: ['15/06/2024', 'Test', '100', '₪100.00', ''] }]);
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBe(5000);
+  });
+
+  it('handles commas in currency amounts', async () => {
+    mockTransactionTable([{ innerTds: ['15/06/2024', 'Big Purchase', '100', '₪1,500.50', ''] }]);
+
+    const scraper = new TestBeinleumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].originalAmount).toBe(-1500.5);
   });
 });

--- a/src/scrapers/hapoalim.test.ts
+++ b/src/scrapers/hapoalim.test.ts
@@ -271,4 +271,96 @@ describe('fetchData', () => {
 
     expect(result.accounts![0].txns[0].type).toBe(TransactionTypes.Normal);
   });
+
+  it('constructs memo with only partial beneficiary details', async () => {
+    setupLoginAndAccounts();
+    mockBalance();
+    mockTransactions([
+      scrapedTxn({
+        beneficiaryDetailsData: {
+          partyHeadline: 'Wire',
+          partyName: undefined,
+          messageHeadline: undefined,
+          messageDetail: undefined,
+        },
+      }),
+    ]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].memo).toBe('Wire');
+  });
+
+  it('returns empty memo when beneficiary details are all empty', async () => {
+    setupLoginAndAccounts();
+    mockBalance();
+    mockTransactions([scrapedTxn({ beneficiaryDetailsData: {} })]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].memo).toBe('');
+  });
+
+  it('returns empty memo when no beneficiary details', async () => {
+    setupLoginAndAccounts();
+    mockBalance();
+    mockTransactions([scrapedTxn({ beneficiaryDetailsData: undefined })]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].memo).toBe('');
+  });
+
+  it('handles empty accounts list', async () => {
+    setupLoginAndAccounts([]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(0);
+  });
+
+  it('handles multiple open accounts', async () => {
+    setupLoginAndAccounts([
+      { bankNumber: '12', branchNumber: '100', accountNumber: '001', accountClosingReasonCode: 0 },
+      { bankNumber: '12', branchNumber: '200', accountNumber: '002', accountClosingReasonCode: 0 },
+    ]);
+    mockBalance(5000);
+    mockTransactions([scrapedTxn({ activityDescription: 'Acc1' })]);
+    mockBalance(3000);
+    mockTransactions([scrapedTxn({ activityDescription: 'Acc2' })]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts).toHaveLength(2);
+    expect(result.accounts![0].accountNumber).toBe('12-100-001');
+    expect(result.accounts![1].accountNumber).toBe('12-200-002');
+  });
+
+  it('handles null balance response', async () => {
+    setupLoginAndAccounts();
+    (fetchGetWithinPage as jest.Mock).mockResolvedValueOnce(null); // balance
+    mockTransactions([scrapedTxn()]);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBeUndefined();
+  });
+
+  it('handles empty transactions response', async () => {
+    setupLoginAndAccounts();
+    mockBalance();
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(null);
+
+    const scraper = new HapoalimScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(0);
+  });
 });

--- a/src/scrapers/leumi.test.ts
+++ b/src/scrapers/leumi.test.ts
@@ -38,24 +38,31 @@ const mockBrowser = {
 
 const CREDS = { username: 'testuser', password: 'testpass' };
 
-function createLeumiPage(accountIds: string[] = ['123/456']) {
-  const mockResponse = {
+function createLeumiResponse(overrides: Record<string, unknown> = {}) {
+  return {
     json: jest.fn().mockResolvedValue({
       jsonResp: JSON.stringify({
         TodayTransactionsItems: [],
-        HistoryTransactionsItems: [
-          {
-            DateUTC: '2025-06-15T00:00:00',
-            Amount: -100,
-            Description: 'Test Transaction',
-            ReferenceNumberLong: 12345,
-            AdditionalData: 'memo text',
-          },
-        ],
-        BalanceDisplay: '5000.00',
+        HistoryTransactionsItems: [],
+        ...overrides,
       }),
     }),
   };
+}
+
+function createLeumiPage(accountIds: string[] = ['123/456']) {
+  const mockResponse = createLeumiResponse({
+    BalanceDisplay: '5000.00',
+    HistoryTransactionsItems: [
+      {
+        DateUTC: '2025-06-15T00:00:00',
+        Amount: -100,
+        Description: 'Test Transaction',
+        ReferenceNumberLong: 12345,
+        AdditionalData: 'memo text',
+      },
+    ],
+  });
 
   return createMockPage({
     evaluate: jest.fn().mockResolvedValue(accountIds),
@@ -198,5 +205,55 @@ describe('fetchData', () => {
     const result = await scraper.scrape(CREDS);
 
     expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
+  });
+
+  it('handles multiple accounts with clicking', async () => {
+    const page = createLeumiPage(['111/222', '333/444']);
+    page.waitForResponse.mockResolvedValue(
+      createLeumiResponse({
+        HistoryTransactionsItems: [
+          { DateUTC: '2025-06-15T00:00:00', Amount: -100, Description: 'Txn', ReferenceNumberLong: 1 },
+        ],
+        BalanceDisplay: '3000.00',
+      }),
+    );
+    page.waitForSelector.mockResolvedValue(undefined);
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(2);
+    expect(result.accounts![0].accountNumber).toBe('111_222');
+    expect(result.accounts![1].accountNumber).toBe('333_444');
+  });
+
+  it('handles undefined balance gracefully', async () => {
+    const page = createLeumiPage();
+    page.waitForResponse.mockResolvedValue(createLeumiResponse());
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].balance).toBeUndefined();
+  });
+
+  it('uses empty string for missing description and memo', async () => {
+    const page = createLeumiPage();
+    page.waitForResponse.mockResolvedValue(
+      createLeumiResponse({
+        HistoryTransactionsItems: [{ DateUTC: '2025-06-15T00:00:00', Amount: -50 }],
+        BalanceDisplay: '1000.00',
+      }),
+    );
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    const scraper = new LeumiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].description).toBe('');
+    expect(result.accounts![0].txns[0].memo).toBe('');
   });
 });

--- a/src/scrapers/mizrahi.test.ts
+++ b/src/scrapers/mizrahi.test.ts
@@ -69,6 +69,10 @@ function mockApiResponse(rows: any[] = [], balance = '5000') {
   };
 }
 
+function mockDetailsResponse(fields: Array<{ Label: string; Value: string }>) {
+  return { body: { fields: [[{ Records: [{ Fields: fields }] }]] } };
+}
+
 function createMizrahiPage() {
   const mockRequest = {
     postData: () => JSON.stringify({ table: {} }),
@@ -228,6 +232,148 @@ describe('fetchData', () => {
     (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(mockApiResponse([scrapedTxn()]));
 
     const scraper = new MizrahiScraper(createMockScraperOptions({ includeRawTransaction: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();
+  });
+
+  it('returns error when API response is null', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(null);
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('handles multiple accounts', async () => {
+    const page = createMizrahiPage();
+    page.$$.mockResolvedValue([{ click: jest.fn() }, { click: jest.fn() }]);
+    mockBrowser.newPage.mockResolvedValue(page);
+
+    // Promise.any over 2 URLs consumes 2 mocks per account
+    (fetchPostWithinPage as jest.Mock)
+      .mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02TnuaTeurEZ: 'Acc1' })])) // account 1, url 1
+      .mockResolvedValueOnce(null) // account 1, url 2 (consumed by Promise.any)
+      .mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02TnuaTeurEZ: 'Acc2' })])) // account 2, url 1
+      .mockResolvedValueOnce(null); // account 2, url 2 (consumed by Promise.any)
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts).toHaveLength(2);
+    expect(result.accounts![0].txns[0].description).toBe('Acc1');
+    expect(result.accounts![1].txns[0].description).toBe('Acc2');
+  });
+
+  it('marks transactions with generic description as pending when feature flag enabled', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02TnuaTeurEZ: 'העברת יומן לבנק זר מסניף זר' })]),
+    );
+
+    const scraper = new MizrahiScraper(
+      createMockScraperOptions({ optInFeatures: ['mizrahi:pendingIfHasGenericDescription'] }),
+    );
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Pending);
+  });
+
+  it('does not mark generic description as pending without feature flag', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02TnuaTeurEZ: 'העברת יומן לבנק זר מסניף זר' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Completed);
+  });
+
+  it('fetches extra transaction details when additionalTransactionInformation enabled', async () => {
+    (fetchPostWithinPage as jest.Mock)
+      .mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02ShowDetailsEZ: '1' })])) // url 1
+      .mockResolvedValueOnce(null) // url 2 (consumed by Promise.any)
+      .mockResolvedValueOnce(
+        mockDetailsResponse([
+          { Label: 'שם', Value: 'John Doe' },
+          { Label: 'מהות', Value: 'Transfer' },
+        ]),
+      ); // extra details fetch
+
+    const scraper = new MizrahiScraper(createMockScraperOptions({ additionalTransactionInformation: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].memo).toContain('John Doe');
+    expect(result.accounts![0].txns[0].memo).toContain('Transfer');
+  });
+
+  it('skips extra details when MC02ShowDetailsEZ is not 1', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02ShowDetailsEZ: '0' })]));
+
+    const scraper = new MizrahiScraper(createMockScraperOptions({ additionalTransactionInformation: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].memo).toBeUndefined();
+  });
+
+  it('handles extra details fetch error gracefully', async () => {
+    (fetchPostWithinPage as jest.Mock)
+      .mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02ShowDetailsEZ: '1' })]))
+      .mockResolvedValueOnce(null) // consumed by Promise.any url 2
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    const scraper = new MizrahiScraper(createMockScraperOptions({ additionalTransactionInformation: true }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts![0].txns[0].memo).toBeUndefined();
+  });
+
+  it('returns undefined identifier when MC02AsmahtaMekoritEZ is empty', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02AsmahtaMekoritEZ: '' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBeUndefined();
+  });
+
+  it('uses integer identifier when TransactionNumber is 1', async () => {
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02AsmahtaMekoritEZ: '55555', TransactionNumber: '1' })]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].identifier).toBe(55555);
+  });
+
+  it('filters transactions before start date', async () => {
+    const oldDate = '2020-01-01T10:00:00';
+    (fetchPostWithinPage as jest.Mock).mockResolvedValueOnce(
+      mockApiResponse([scrapedTxn({ MC02PeulaTaaEZ: oldDate }), scrapedTxn()]),
+    );
+
+    const scraper = new MizrahiScraper(createMockScraperOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns).toHaveLength(1);
+  });
+
+  it('includes rawTransaction with additionalInformation when details enabled', async () => {
+    (fetchPostWithinPage as jest.Mock)
+      .mockResolvedValueOnce(mockApiResponse([scrapedTxn({ MC02ShowDetailsEZ: '1' })]))
+      .mockResolvedValueOnce(null) // consumed by Promise.any url 2
+      .mockResolvedValueOnce(mockDetailsResponse([{ Label: 'חשבון', Value: '12345' }]));
+
+    const scraper = new MizrahiScraper(
+      createMockScraperOptions({ additionalTransactionInformation: true, includeRawTransaction: true }),
+    );
     const result = await scraper.scrape(CREDS);
 
     expect(result.accounts![0].txns[0].rawTransaction).toBeDefined();

--- a/src/scrapers/one-zero.test.ts
+++ b/src/scrapers/one-zero.test.ts
@@ -317,4 +317,57 @@ describe('fetchData', () => {
 
     expect(result.accounts![0].txns[0].status).toBe(TransactionStatuses.Completed);
   });
+
+  it('handles multiple portfolios', async () => {
+    setupLongTermLogin();
+    mockCustomer([
+      { portfolioId: 'p1', portfolioNum: 'ACC-001', accounts: [{ accountId: 'a1' }] },
+      { portfolioId: 'p2', portfolioNum: 'ACC-002', accounts: [{ accountId: 'a2' }] },
+    ]);
+    mockMovements([movement({ description: 'Txn1' })]);
+    mockMovements([movement({ description: 'Txn2' })]);
+
+    const scraper = new OneZeroScraper(createMockScraperOptions({ startDate: new Date('2024-01-01') }));
+    const result = await scraper.scrape(LONG_TERM_CREDS);
+
+    expect(result.accounts).toHaveLength(2);
+    expect(result.accounts![0].accountNumber).toBe('ACC-001');
+    expect(result.accounts![1].accountNumber).toBe('ACC-002');
+  });
+
+  it('handles movement with zero balance', async () => {
+    setupLongTermLogin();
+    mockCustomer([{ portfolioId: 'p1', portfolioNum: 'ACC-001', accounts: [{ accountId: 'a1' }] }]);
+    mockMovements([movement({ runningBalance: '0' })]);
+
+    const scraper = new OneZeroScraper(createMockScraperOptions({ startDate: new Date('2024-01-01') }));
+    const result = await scraper.scrape(LONG_TERM_CREDS);
+
+    expect(result.accounts![0].balance).toBe(0);
+  });
+
+  it('returns error when missing otpCodeRetriever and no token', async () => {
+    const scraper = new OneZeroScraper(createMockScraperOptions());
+    // @ts-expect-error testing validation of incomplete credentials (no otpLongTermToken or otpCodeRetriever)
+    const result = await scraper.scrape({
+      email: 'test@example.com',
+      password: 'pass',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe(ScraperErrorTypes.TwoFactorRetrieverMissing);
+  });
+
+  it('returns error when phoneNumber is missing with otpCodeRetriever', async () => {
+    const scraper = new OneZeroScraper(createMockScraperOptions());
+    // @ts-expect-error testing validation of missing phoneNumber with otpCodeRetriever
+    const result = await scraper.scrape({
+      email: 'test@example.com',
+      password: 'pass',
+      otpCodeRetriever: jest.fn(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('phoneNumber is required');
+  });
 });

--- a/src/scrapers/visa-cal.test.ts
+++ b/src/scrapers/visa-cal.test.ts
@@ -93,6 +93,37 @@ function scrapedTxn(overrides: any = {}): any {
   };
 }
 
+function pendingTxn(overrides: Record<string, unknown> = {}) {
+  return {
+    merchantID: 'M1',
+    merchantName: 'Pending Shop',
+    trnPurchaseDate: '2025-06-10',
+    walletTranInd: 0,
+    transactionsOrigin: 0,
+    trnAmt: 75,
+    tpaApprovalAmount: null,
+    trnCurrencySymbol: 'ILS',
+    trnTypeCode: '5',
+    trnType: 'רגילה',
+    branchCodeDesc: '',
+    transCardPresentInd: false,
+    j5Indicator: '',
+    numberOfPayments: 0,
+    firstPaymentAmount: 0,
+    transTypeCommentDetails: [],
+    ...overrides,
+  };
+}
+
+function mockPendingResponse(txns: ReturnType<typeof pendingTxn>[] = [pendingTxn()]) {
+  return {
+    statusCode: 1,
+    result: {
+      cardsList: [{ cardUniqueID: 'card-1', authDetalisList: txns }],
+    },
+  };
+}
+
 function mockCardTransactionDetails(txns: any[] = [], overrides: any = {}) {
   return {
     statusCode: 1,
@@ -328,5 +359,124 @@ describe('fetchData', () => {
     const result = await scraper.scrape(CREDS);
 
     expect(result.accounts![0].txns[0].category).toBe('מסעדות');
+  });
+
+  it('merges pending transactions with completed ones', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce(mockPendingResponse([pendingTxn({ branchCodeDesc: 'קניות' })]))
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const pending = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Pending);
+    const completed = result.accounts![0].txns.find(t => t.status === TransactionStatuses.Completed);
+    expect(pending).toBeDefined();
+    expect(pending!.description).toBe('Pending Shop');
+    expect(pending!.originalAmount).toBe(-75);
+    expect(completed).toBeDefined();
+  });
+
+  it('handles standing order transaction type', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn({ trnTypeCode: '9' })]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.accounts![0].txns[0].type).toBe(TransactionTypes.Normal);
+  });
+
+  it('skips filtering when enableTransactionsFilterByDate is false', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions({ outputData: { enableTransactionsFilterByDate: false } }));
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(filterOldTransactions).not.toHaveBeenCalled();
+  });
+
+  it('handles failed pending transactions gracefully', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 0, title: 'Pending failed' })
+      .mockResolvedValueOnce(mockCardTransactionDetails([scrapedTxn()]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    expect(result.success).toBe(true);
+    expect(result.accounts![0].txns).toHaveLength(1);
+  });
+
+  it('handles foreign currency transactions', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(
+        mockCardTransactionDetails([
+          scrapedTxn({
+            trnCurrencySymbol: 'USD',
+            debCrdCurrencySymbol: 'ILS',
+            trnAmt: 50,
+            amtBeforeConvAndIndex: 180,
+          }),
+        ]),
+      );
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const t = result.accounts![0].txns[0];
+    expect(t.originalCurrency).toBe('USD');
+    expect(t.chargedCurrency).toBe('ILS');
+    expect(t.originalAmount).toBe(-50);
+    expect(t.chargedAmount).toBe(-180);
+  });
+
+  it('sets chargedCurrency only for completed transactions', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce(
+        mockPendingResponse([pendingTxn({ merchantName: 'Pending', trnAmt: 100, trnCurrencySymbol: 'USD' })]),
+      )
+      .mockResolvedValueOnce(mockCardTransactionDetails([]));
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const pendingResult = result.accounts![0].txns[0];
+    expect(pendingResult.chargedCurrency).toBeUndefined();
+  });
+
+  it('handles installment date shift', async () => {
+    setupVisaCalMocks();
+    (fetchPost as jest.Mock)
+      .mockResolvedValueOnce({ result: { bankIssuedCards: { cardLevelFrames: [] } } })
+      .mockResolvedValueOnce({ statusCode: 96 })
+      .mockResolvedValueOnce(
+        mockCardTransactionDetails([scrapedTxn({ trnTypeCode: '8', numOfPayments: 6, curPaymentNum: 3 })]),
+      );
+
+    const scraper = new VisaCalScraper(visaCalOptions());
+    const result = await scraper.scrape(CREDS);
+
+    const t = result.accounts![0].txns[0];
+    expect(t.installments).toEqual({ number: 3, total: 6 });
+    // Date should be shifted by (curPaymentNum - 1) months from purchase date
+    expect(t.date).toBeDefined();
   });
 });

--- a/tasks/integration-test-framework.md
+++ b/tasks/integration-test-framework.md
@@ -1,0 +1,226 @@
+# Task: Add Integration Test Framework for All Scrapers
+
+## Priority: High | Effort: Large (1+ days)
+
+## Current State
+
+The project has a three-tier test pyramid with a significant gap in the middle:
+
+| Layer | Coverage | Details |
+|-------|----------|---------|
+| Unit tests | 35 files, 86% line coverage | Test individual functions in isolation with mocked dependencies |
+| E2E mocked | 2 test files (Amex + anti-detection) | Full scraper flow with real Puppeteer but mocked HTTP |
+| E2E real | 3 banks (Amex, VisaCal, Discount) | Real bank APIs, requires credentials, skipped by default |
+
+**The gap:** Only Amex has a mocked integration test. The remaining 12+ scrapers have no full-flow tests without real credentials. This means:
+- Login flow + fetchData + transaction parsing aren't tested together
+- HTTP error scenarios (WAF blocks, session timeouts, invalid responses) aren't tested
+- Regressions in scraper flow require real bank credentials to detect
+
+## Target
+
+A reusable integration test framework that:
+1. Tests full scraper flows (login → fetchData → result) with mocked HTTP responses
+2. Covers all browser-based scrapers (not just Amex)
+3. Supports error scenario testing (failed login, WAF blocks, empty responses)
+4. Runs in CI without credentials
+5. Is easy to add new scrapers — just provide fixture files + route config
+
+---
+
+## Approach Comparison
+
+### Approach A: Real Browser + Request Interception (extend existing e2e-mocked pattern)
+
+Uses real Puppeteer browser with `page.setRequestInterception()` to serve fixture responses. This is the pattern already used in `amex.e2e-mocked.test.ts`.
+
+```
+Test → createScraper({ browser, preparePage }) → Real Puppeteer → Request Interception → Fixture files
+```
+
+| Dimension | Assessment |
+|-----------|-----------|
+| **Fidelity** | High — real DOM, real navigation, real `page.evaluate()`, real anti-detection hooks |
+| **Speed** | Slow — ~5-10s per test, ~60s timeout needed, browser startup ~2-3s (amortized via shared instance) |
+| **Fixture effort** | High — need full HTML login pages with correct selectors + JSON API responses |
+| **Maintenance** | Medium — fixtures break when banks change HTML selectors or API shapes |
+| **CI cost** | Medium — needs Puppeteer/Chromium binary in CI (already available) |
+| **What it catches** | Navigation bugs, selector mismatches, anti-detection regressions, real DOM parsing issues |
+| **Existing infra** | Complete — `browser-fixture.ts`, `request-interceptor.ts`, `amex/` fixtures all exist |
+| **Coverage impact** | Low — `page.evaluate()` callbacks run in browser context, not instrumented by Istanbul/Jest |
+
+### Approach B: Jest Module Mocking (extend existing unit test pattern to full flows)
+
+Uses `jest.mock('puppeteer')` + `createMockPage()` + `jest.mock('../helpers/fetch')` to test full scraper flows without any browser. This is the pattern used in `base-isracard-amex.test.ts`.
+
+```
+Test → createScraper() → jest.mock(puppeteer) → createMockPage() → jest.mock(fetch) → Inline mock data
+```
+
+| Dimension | Assessment |
+|-----------|-----------|
+| **Fidelity** | Medium — tests the JS logic path but not real browser behavior; `page.goto()` returns mock, selectors aren't verified |
+| **Speed** | Fast — ~100ms per test, no browser process |
+| **Fixture effort** | Low — inline JSON objects in test files, no HTML fixtures needed |
+| **Maintenance** | Low — mock data follows TypeScript interfaces, compiler catches shape mismatches |
+| **CI cost** | None — pure Node.js, no browser binary |
+| **What it catches** | Logic regressions, data transformation bugs, error handling paths, API response parsing |
+| **Existing infra** | Partial — `mock-page.ts` exists but needs extensions per scraper (login result detection, navigation simulation) |
+| **Coverage impact** | High — all code runs in Node.js, fully instrumented by Jest/Istanbul |
+
+### Side-by-side
+
+| | Approach A (Real Browser) | Approach B (Jest Mocks) |
+|---|---|---|
+| Time per test | ~5-10s | ~100ms |
+| Time for 40 tests | ~3-5 min | ~5s |
+| HTML fixtures needed | Yes (per bank) | No |
+| Tests real selectors | Yes | No |
+| Tests anti-detection | Yes | No |
+| Increases Jest coverage | No | Yes |
+| Runs in `npm test` | Currently excluded | Included by default |
+| Effort per scraper | ~2-3 hours (fixtures + routes) | ~1-2 hours (mock chains) |
+| Browser dependency | Yes (Puppeteer/Chromium) | No |
+
+### Recommendation: Approach B (Jest Module Mocking)
+
+**Rationale:**
+1. **Speed matters** — 40+ new tests at ~5-10s each would add 3-5 minutes to CI. Jest mocks run in seconds.
+2. **Coverage boost** — Approach B increases the 86% line coverage that the team tracks. Approach A doesn't (browser context is not instrumented).
+3. **Lower fixture effort** — No need to reverse-engineer HTML login pages with exact selectors. Mock data follows TypeScript interfaces.
+4. **Runs in `npm test`** — E2E mocked tests are excluded from `npm test` (see `jest.config.js` line 16: `testPathIgnorePatterns: [..., 'e2e-mocked/']`). Approach B tests run by default.
+5. **Existing Amex pattern proves it works** — `base-isracard-amex.test.ts` already tests login + fetch + parse with full mocks and catches real bugs.
+6. **Real browser testing already covered** — The existing 9 e2e-mocked tests + 3 e2e-real tests cover browser-specific concerns (anti-detection, real DOM). Adding more real-browser tests has diminishing returns.
+
+**What Approach A is better for (keep existing e2e-mocked for these):**
+- Anti-detection verification (already covered by 5 tests)
+- Validating that HTML selectors match real bank pages (better done with e2e-real tests)
+- New scraper smoke tests before going live
+
+---
+
+## Planned Work
+
+### 1. Create integration test utilities
+
+**`src/tests/integration-helpers.ts`** — Shared utilities for full-flow mock tests:
+- `setupScraperMocks(fetchResponses)` — Configure `jest.mock` for puppeteer, fetch helpers, browser, waiting, transactions
+- `createTestScraper(ScraperClass, options?)` — Instantiate scraper with mocked page and standard options
+- `mockLoginFlow(page, loginResult)` — Configure mock page to simulate login success/failure URL detection
+- `expectSuccessResult(result, expectedAccounts)` — Common success assertions
+- `expectErrorResult(result, errorType, messagePattern?)` — Common error assertions
+
+### 2. Write full-flow tests per scraper
+
+Each scraper gets a `<name>.test.ts` file (or section added to existing test file) with full-flow tests:
+
+**Test cases per scraper (minimum 3):**
+- Happy path: login succeeds → fetchData returns transactions → correct output shape
+- Invalid credentials: login fails → returns `InvalidPassword` error
+- Empty/no transactions: login succeeds → empty response → returns empty account array
+
+**Bank-specific edge cases:**
+| Scraper | Edge Cases |
+|---------|-----------|
+| **Isracard** | WAF block detection, dual currency (Israel + abroad), installment parsing |
+| **VisaCal** | Multi-card accounts, pending transactions, SSO auth flow |
+| **Leumi** | Account blocked, change password redirect, DOM-based error detection |
+| **Discount** | WAF block (known CI issue), gateway API errors |
+| **Hapoalim** | REST context extraction, multi-account handling |
+| **Mizrahi** | API intercept pattern, dropdown navigation |
+| **Beinleumi/Massad** | Table-based extraction, credit/debit parsing |
+| **Union Bank** | Table extraction, account number from DOM |
+| **Yahav** | Similar to Beinleumi pattern |
+| **OneZero** | OTP/2FA flow, token-based auth |
+| **Beyahad Bishvilha** | Currency symbol variants (₪/$/) in amounts |
+| **Max** | Similar to VisaCal SSO pattern |
+
+### 3. Create mock response factories
+
+Reusable factories for common response shapes:
+
+```typescript
+// Example: Isracard/Amex response factory
+function createIsracardResponse(overrides?: Partial<IsracardResponse>) {
+  return {
+    Header: { Status: '1' },
+    CardsTransactionsListBean: { ... },
+    ...overrides,
+  };
+}
+
+// Example: Table-based scraper response factory
+function createTableHtml(rows: { date: string; description: string; credit: string; debit: string }[]) {
+  return rows; // Used as mock return from $$eval
+}
+```
+
+### 4. Add error scenario mocks
+
+Shared error mock configs:
+- `mockWafBlock()` — Simulates WAF/bot detection response
+- `mockSessionTimeout()` — Simulates expired session
+- `mockServerError()` — Simulates 500 error
+- `mockInvalidCredentials(scraperType)` — Per-scraper invalid login response
+
+### 5. Update coverage thresholds
+
+After adding integration tests, coverage should increase. Update `jest.config.js` thresholds:
+- Target: branches 78%+, functions 80%+, lines 90%+, statements 88%+
+
+## Implementation Approach
+
+### File structure
+```
+src/tests/
+├── integration-helpers.ts           (NEW — shared mock setup/assertions)
+├── mock-page.ts                     (existing — extend if needed)
+└── ...
+
+src/scrapers/
+├── visa-cal.test.ts                 (NEW or extend existing)
+├── leumi.test.ts                    (NEW or extend existing)
+├── discount.test.ts                 (NEW or extend existing)
+├── hapoalim.test.ts                 (NEW or extend existing)
+├── mizrahi.test.ts                  (NEW or extend existing)
+├── base-beinleumi-group.test.ts     (extend existing)
+├── union-bank.test.ts               (NEW or extend existing)
+├── yahav.test.ts                    (NEW or extend existing)
+├── one-zero.test.ts                 (NEW or extend existing)
+├── beyahad-bishvilha.test.ts        (NEW or extend existing)
+└── max.test.ts                      (NEW or extend existing)
+```
+
+### Key technical decisions
+
+1. **Extend existing test files** — Add `describe('full scrape flow', ...)` blocks to existing `*.test.ts` files rather than creating separate integration test files. This keeps related tests together and avoids file proliferation.
+
+2. **Mock at module boundaries** — Mock `puppeteer`, `../helpers/fetch`, `../helpers/browser`, `../helpers/waiting`, and `../helpers/transactions` — same pattern as `base-isracard-amex.test.ts`.
+
+3. **Simulate login via URL matching** — The base scraper's `login()` method checks `page.url()` against `possibleResults` patterns. Mock `page.url()` to return a URL that matches `LoginResults.Success` or `LoginResults.InvalidPassword`.
+
+4. **Mock `page.evaluate()`/`$eval()` per call order** — Use `mockResolvedValueOnce()` chains to simulate the sequence of page interactions each scraper performs.
+
+5. **TypeScript-first fixtures** — Define mock data as typed objects (not JSON files), so the compiler catches shape mismatches immediately.
+
+6. **Start with highest-value scrapers** — Isracard (shares base with Amex), VisaCal, Leumi, Discount, then others.
+
+### Test strategy
+
+- Integration tests complement (not replace) existing unit tests
+- Focus on flow correctness: does login → fetch → parse → return work end-to-end?
+- Error tests focus on graceful degradation: does the scraper return proper error types?
+- Avoid testing individual function logic (that's what existing unit tests do)
+- Keep the existing e2e-mocked tests for browser-level concerns (anti-detection, real DOM)
+
+## Acceptance Criteria
+
+- [ ] Integration test helper module created with shared mock setup/teardown/assertions
+- [ ] Full-flow tests for at least 6 scrapers (Isracard, VisaCal, Leumi, Discount, Hapoalim, Mizrahi)
+- [ ] Happy-path test passing for each covered scraper
+- [ ] Error scenario tests (invalid login, empty data) for each covered scraper
+- [ ] Shared error mock utilities for WAF blocks and common failure modes
+- [ ] All tests run as part of `npm test` (included by default)
+- [ ] All existing tests still pass
+- [ ] Jest coverage thresholds raised (branches 78%+, functions 80%+)
+- [ ] ESLint, TypeScript, Prettier clean


### PR DESCRIPTION
## Summary
- Add **39 new test cases** covering previously untested code paths across 6 scrapers (beinleumi, mizrahi, visa-cal, hapoalim, leumi, one-zero)
- Extract shared test factories (`pendingTxn()`, `mockDetailsResponse()`, `createLeumiResponse()`, etc.) to reduce duplication
- Replace `as any` with `@ts-expect-error` in one-zero credential validation tests
- Raise jest coverage thresholds to lock in gains

## Coverage improvements

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Statements | 86.00% | **87.69%** | +1.69% |
| Branches | 73.89% | **78.30%** | **+4.41%** |
| Functions | 75.20% | **77.06%** | +1.86% |
| Lines | 87.47% | **89.12%** | +1.65% |

## New thresholds (jest.config.js)

| Metric | Old | New |
|--------|-----|-----|
| Branches | 73% | **77%** |
| Functions | 74% | **76%** |
| Lines | 87% | **89%** |
| Statements | 85% | **87%** |

## Test plan
- [x] All 384 tests pass (372 active + 12 skipped legacy credential tests)
- [x] TypeScript type-check clean
- [x] ESLint + Prettier clean
- [x] Build succeeds
- [x] Coverage above new thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)