### PR TITLE
fix: replace node-fetch with native fetch() API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "lodash": "^4.17.23",
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
-        "node-fetch": "^2.2.0",
         "puppeteer": "24.37.5",
         "utility-types": "^3.11.0",
         "uuid": "^11.1.0"
@@ -28,7 +27,6 @@
         "@types/debug": "^4.1.12",
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.24",
-        "@types/node-fetch": "^2.6.13",
         "@types/source-map-support": "^0.5.10",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
@@ -2876,17 +2874,6 @@
         "undici-types": "~7.13.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/source-map-support": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
@@ -3426,13 +3413,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4107,19 +4087,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -4435,16 +4402,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -5527,23 +5484,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -7914,29 +7854,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -8047,26 +7964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-int64": {
@@ -9966,12 +9863,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -10465,22 +10356,6 @@
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.24",
-    "@types/node-fetch": "^2.6.13",
     "@types/source-map-support": "^0.5.10",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
@@ -85,7 +84,6 @@
     "lodash": "^4.17.23",
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
-    "node-fetch": "^2.2.0",
     "puppeteer": "24.37.5",
     "utility-types": "^3.11.0",
     "uuid": "^11.1.0"

--- a/src/helpers/fetch.test.ts
+++ b/src/helpers/fetch.test.ts
@@ -1,55 +1,59 @@
 import { fetchGet, fetchPost, fetchGraphql, fetchGetWithinPage, fetchPostWithinPage } from './fetch';
 import { createMockPage } from '../tests/mock-page';
 
-jest.mock('node-fetch', () => {
-  return jest.fn();
+const mockFetch = jest.fn();
+const originalFetch = global.fetch;
+
+beforeAll(() => {
+  global.fetch = mockFetch;
 });
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const nodeFetch = require('node-fetch') as jest.Mock;
+afterAll(() => {
+  global.fetch = originalFetch;
+});
 
 describe('fetchGet', () => {
   beforeEach(() => {
-    nodeFetch.mockReset();
+    mockFetch.mockReset();
   });
 
   it('sends GET request with JSON headers', async () => {
-    nodeFetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ data: 'test' }) });
+    mockFetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ data: 'test' }) });
     const result = await fetchGet('https://api.bank.co.il/data', {});
     expect(result).toEqual({ data: 'test' });
-    expect(nodeFetch).toHaveBeenCalledWith('https://api.bank.co.il/data', expect.objectContaining({ method: 'GET' }));
+    expect(mockFetch).toHaveBeenCalledWith('https://api.bank.co.il/data', expect.objectContaining({ method: 'GET' }));
   });
 
   it('merges extra headers', async () => {
-    nodeFetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({}) });
+    mockFetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({}) });
     await fetchGet('https://api.bank.co.il/data', { Authorization: 'Bearer token' });
-    const callArgs = nodeFetch.mock.calls[0][1];
+    const callArgs = mockFetch.mock.calls[0][1];
     expect(callArgs.headers.Authorization).toBe('Bearer token');
     expect(callArgs.headers.Accept).toBe('application/json');
   });
 
   it('throws when status is not 200', async () => {
-    nodeFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({}) });
+    mockFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({}) });
     await expect(fetchGet('https://api.bank.co.il/data', {})).rejects.toThrow('status code 500');
   });
 });
 
 describe('fetchPost', () => {
   beforeEach(() => {
-    nodeFetch.mockReset();
+    mockFetch.mockReset();
   });
 
   it('sends POST request with JSON body', async () => {
-    nodeFetch.mockResolvedValue({ json: () => Promise.resolve({ success: true }) });
+    mockFetch.mockResolvedValue({ json: () => Promise.resolve({ success: true }) });
     const result = await fetchPost('https://api.bank.co.il/login', { user: 'test' });
     expect(result).toEqual({ success: true });
-    const callArgs = nodeFetch.mock.calls[0][1];
+    const callArgs = mockFetch.mock.calls[0][1];
     expect(callArgs.method).toBe('POST');
     expect(callArgs.body).toBe(JSON.stringify({ user: 'test' }));
   });
 
   it('returns JSON even on non-200 status', async () => {
-    nodeFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({ error: true }) });
+    mockFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({ error: true }) });
     const result = await fetchPost('https://api.bank.co.il/fail', {});
     expect(result).toEqual({ error: true });
   });
@@ -57,26 +61,26 @@ describe('fetchPost', () => {
 
 describe('fetchGraphql', () => {
   beforeEach(() => {
-    nodeFetch.mockReset();
+    mockFetch.mockReset();
   });
 
   it('sends GraphQL query and returns data', async () => {
-    nodeFetch.mockResolvedValue({ json: () => Promise.resolve({ data: { accounts: [] } }) });
+    mockFetch.mockResolvedValue({ json: () => Promise.resolve({ data: { accounts: [] } }) });
     const result = await fetchGraphql('https://api.bank.co.il/graphql', '{ accounts { id } }');
     expect(result).toEqual({ accounts: [] });
   });
 
   it('throws when GraphQL response has errors', async () => {
-    nodeFetch.mockResolvedValue({
+    mockFetch.mockResolvedValue({
       json: () => Promise.resolve({ errors: [{ message: 'Unauthorized' }] }),
     });
     await expect(fetchGraphql('https://api.bank.co.il/graphql', 'query')).rejects.toThrow('Unauthorized');
   });
 
   it('sends variables in the request body', async () => {
-    nodeFetch.mockResolvedValue({ json: () => Promise.resolve({ data: {} }) });
+    mockFetch.mockResolvedValue({ json: () => Promise.resolve({ data: {} }) });
     await fetchGraphql('https://api.bank.co.il/graphql', '{ accounts }', { id: '123' });
-    const body = JSON.parse(nodeFetch.mock.calls[0][1].body);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.variables).toEqual({ id: '123' });
     expect(body.query).toBe('{ accounts }');
   });

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -1,4 +1,3 @@
-import nodeFetch from 'node-fetch';
 import { type Page } from 'puppeteer';
 
 const JSON_CONTENT_TYPE = 'application/json';
@@ -19,13 +18,13 @@ export async function fetchGet<TResult>(url: string, extraHeaders: Record<string
     method: 'GET',
     headers,
   };
-  const fetchResult = await nodeFetch(url, request);
+  const fetchResult = await fetch(url, request);
 
   if (fetchResult.status !== 200) {
     throw new Error(`sending a request to the institute server returned with status code ${fetchResult.status}`);
   }
 
-  return fetchResult.json();
+  return (await fetchResult.json()) as TResult;
 }
 
 export async function fetchPost<TResult = any>(
@@ -38,8 +37,8 @@ export async function fetchPost<TResult = any>(
     headers: { ...getJsonHeaders(), ...extraHeaders },
     body: JSON.stringify(data),
   };
-  const result = await nodeFetch(url, request);
-  return result.json();
+  const result = await fetch(url, request);
+  return (await result.json()) as TResult;
 }
 
 export async function fetchGraphql<TResult>(


### PR DESCRIPTION
## Summary
- Remove `node-fetch` and `@types/node-fetch` dependencies
- Use Node.js built-in `fetch()` API (project requires Node >= 22.14.0)
- Cast `.json()` results with `as TResult` (native fetch returns `unknown` vs node-fetch's `any`)

## Why
- `node-fetch` v3 is ESM-only — incompatible with this CommonJS project
- Native `fetch()` is stable since Node 18, eliminating the need for a polyfill
- Removes 1 production dependency, reducing install size

## Changes
- [src/helpers/fetch.ts](src/helpers/fetch.ts) — remove import, replace 2 `nodeFetch()` calls with `fetch()`
- [src/helpers/fetch.test.ts](src/helpers/fetch.test.ts) — mock `global.fetch` with proper save/restore
- `package.json` — remove `node-fetch` and `@types/node-fetch`

## Test plan
- [x] TypeScript type-check clean
- [x] ESLint + Prettier clean
- [x] All 384 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)