### PR TITLE
fix(discount): return success with 0 txns when API has no records in range

### DIFF
--- a/src/scrapers/discount.test.ts
+++ b/src/scrapers/discount.test.ts
@@ -175,15 +175,15 @@ describe('fetchData', () => {
     expect(result.errorMessage).toBe('שגיאה בשרת');
   });
 
-  it('returns error when CurrentAccountLastTransactions is missing', async () => {
+  it('returns success with 0 transactions when CurrentAccountLastTransactions is absent', async () => {
     mockAccountsData();
     (fetchGetWithinPage as jest.Mock).mockResolvedValueOnce({});
 
     const scraper = new DiscountScraper(createMockScraperOptions());
     const result = await scraper.scrape(CREDS);
 
-    expect(result.success).toBe(false);
-    expect(result.errorMessage).toBe('unknown error');
+    expect(result.success).toBe(true);
+    expect(result.accounts![0].txns).toHaveLength(0);
   });
 
   it('includes pending (future) transactions', async () => {

--- a/src/scrapers/discount.ts
+++ b/src/scrapers/discount.ts
@@ -105,8 +105,11 @@ async function fetchOneAccount(
   const { page, apiSiteUrl, accountNumber, startDateStr, options } = opts;
   const txnsUrl = `${apiSiteUrl}/lastTransactions/${accountNumber}/Date?IsCategoryDescCode=True&IsTransactionDetails=True&IsEventNames=True&IsFutureTransactionFlag=True&FromDate=${startDateStr}`;
   const txnsResult = await fetchGetWithinPage<ScrapedTransactionData>(page, txnsUrl);
-  if (!txnsResult || txnsResult.Error || !txnsResult.CurrentAccountLastTransactions) {
+  if (!txnsResult || txnsResult.Error) {
     return { error: txnsResult?.Error?.MsgText ?? 'unknown error' };
+  }
+  if (!txnsResult.CurrentAccountLastTransactions) {
+    return { accountNumber, balance: 0, txns: [] };
   }
   return buildOneAccountResult(txnsResult, accountNumber, options);
 }


### PR DESCRIPTION
## Problem

When Discount API returns a response with no transactions in the requested date range, it omits \`CurrentAccountLastTransactions\` entirely (no \`Error\` field either). The scraper was treating this as:
\`\`\`
{ success: false, errorType: 'GENERIC', errorMessage: 'unknown error' }
\`\`\`

## Fix

Split the single guard into two conditions:
- \`txnsResult.Error\` → propagate as a real API error
- \`!txnsResult.CurrentAccountLastTransactions\` without an error → \`{ success: true, accounts: [{ txns: [] }] }\`

\`\`\`typescript
if (!txnsResult || txnsResult.Error) {
  return { error: txnsResult?.Error?.MsgText ?? 'unknown error' };
}
if (!txnsResult.CurrentAccountLastTransactions) {
  return { accountNumber, balance: 0, txns: [] };
}
\`\`\`

## Test plan
- [x] Unit test updated: "returns success with 0 transactions when CurrentAccountLastTransactions is absent" passes
- [x] All other Discount tests still pass (14 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)