### PR TITLE
fix(ci): replace Babel with tsup in publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,9 +75,7 @@ jobs:
       - run: npm ci
       - name: Build
         run: |
-          npx rimraf lib
-          npx tsc --emitDeclarationOnly
-          npx babel src --out-dir lib --extensions ".ts" --source-maps inline --verbose
-          npx rimraf lib/tests
+          npx tsup
+          npx rimraf lib/Helpers lib/Scrapers lib/Tests
       - name: Publish with provenance (Trusted Publishing OIDC)
         run: npm publish --access public --provenance


### PR DESCRIPTION
The release-please publish workflow still used `npx babel src --out-dir lib` 
which downloaded Babel 5 (since @babel/cli was removed in Phase 3 tsup migration).
Babel 5 can't parse TypeScript enums → `SyntaxError: Unexpected token` on 
`export enum CompanyTypes`.

Fix: replace with `npx tsup` + `npx rimraf lib/Helpers lib/Scrapers lib/Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)