### PR TITLE
ci: add force_publish dispatch input to Release & Publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force npm publish without a new release (recover from release-please tag glitches)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
 
 permissions:
   contents: write
@@ -15,7 +22,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      release_created: ${{ steps.release.outputs.release_created || inputs.force_publish }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release


### PR DESCRIPTION
Adds a `force_publish` boolean to `workflow_dispatch` so npm publish can be triggered manually when release-please fails to set `release_created` (e.g. after a tag was created outside the normal flow). Needed to publish v7.8.0 which was skipped due to a release-please/GitHub 500 timing glitch.