### PR TITLE
ci: fix OpenSSF Scorecard Token-Permissions and Pinned-Dependencies alerts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm ci
       - name: Generate TypeDoc
         run: npm run docs
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: docs
 
@@ -44,5 +44,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -31,7 +34,7 @@ jobs:
       - run: npm ci
       - run: npx ncp src/Tests/.tests-config.tpl.js src/Tests/.tests-config.js
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('package-lock.json') }}
@@ -53,7 +56,7 @@ jobs:
       - run: npm ci
       - run: npx ncp src/Tests/.tests-config.tpl.js src/Tests/.tests-config.js
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('package-lock.json') }}
@@ -76,7 +79,7 @@ jobs:
       - run: npm ci
       - run: npx ncp src/Tests/.tests-config.tpl.js src/Tests/.tests-config.js
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -98,7 +97,7 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,7 @@ on:
         options: ['false', 'true']
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   release-please:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:


### PR DESCRIPTION
## Summary

Fixes 8 of 14 open code scanning alerts (the ones addressable with code changes).

### Token-Permissions fixed (#4, #5, #6, #7)
- **`e2e.yml`**: Add missing top-level `permissions: contents: read` (workflow had no permissions block — inherited repo default `write-all`)
- **`stale.yml`**: Add job-level `permissions: issues: write, pull-requests: write` (action needs write access to close items)
- **`nodeCI.yml`**: Remove `security-events: write` from top-level permissions — only the CodeQL job needs it, and it already declares it at job level
- **`release-please.yml`**: Narrow top-level from `contents: write / pull-requests: write / id-token: write` → `contents: read` (release-please job uses `secrets.RELEASE_TOKEN` PAT, not GITHUB_TOKEN; publish job has its own job-level permissions)

### Pinned-Dependencies fixed (#8, #9, and cache in #4/#5)
- **`docs.yml`**: Pin `upload-pages-artifact@v4` → `7b1f4a7` and `deploy-pages@v4` → `d6db901`
- **`e2e.yml`**: Pin `actions/cache@v4` → `0057852` (×3 jobs)
- **`nodeCI.yml`**: Pin `actions/cache@v4` → `0057852`

### Not fixed (by design)
- `dependabot-auto-merge.yml` alert #3: `contents: write` is genuinely needed for merging PRs
- Alert #10 (`release-please.yml:75`): line IS already pinned to SHA — likely stale, will auto-close on re-scan
- Alerts #2, #11-14: Repo settings / org badges / project metrics — not addressable with code

## Test plan
- [x] Pre-commit hook: all 8 gates passed (type-check, unit tests, mocked E2E, real E2E for Amex/Isracard/Max/Discount, build, lint, exports, dep audit)
- [ ] After merge: verify Scorecard alerts auto-close on next scheduled scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)