### PR TITLE
fix: pre-commit hook runs full lint (same as CI)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -28,8 +28,9 @@ echo "🎭  [3/8] Mocked E2E tests..." | tee -a "$LOG_FILE"
 run_gate npm run test:e2e:mock || exit 1
 
 echo "" | tee -a "$LOG_FILE"
-echo "🧹  [4/8] Lint + format (changed files only)..." | tee -a "$LOG_FILE"
-run_gate npx lint-staged || exit 1
+echo "🧹  [4/8] Lint + format (all source files, same as CI)..." | tee -a "$LOG_FILE"
+run_gate npx eslint 'src/**/*.ts' --max-warnings 0 || exit 1
+run_gate npm run format:check || exit 1
 
 echo "" | tee -a "$LOG_FILE"
 echo "📦  [5/8] Build verification (tsup + publint)..." | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary
- Replace `lint-staged` (changed files only) with `eslint 'src/**/*.ts'` (all source files) in pre-commit gate 4
- Ensures pre-commit catches the same ESLint violations that CI catches
- Prevents false passes where lint-staged misses violations in unchanged files

## Test plan
- [x] Pre-commit 8-gate pipeline passes locally with the new full lint
- [x] ESLint security rules now caught locally (was previously missed, caught only in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)