### PR TITLE
feat: label-text-first SelectorResolver with 5 strategies

### DIFF
--- a/src/Common/SelectorResolver.ts
+++ b/src/Common/SelectorResolver.ts
@@ -19,6 +19,9 @@ const WELL_KNOWN_DASHBOARD_SELECTORS = SCRAPER_CONFIGURATION.wellKnownDashboardS
   SelectorCandidate[]
 >;
 
+/** XPath union of elements that can visually label an input field. */
+const LABEL_TAGS = 'self::label or self::div or self::span';
+
 /** Convert a SelectorCandidate to a Playwright-compatible selector string */
 export function candidateToCss(c: SelectorCandidate): string {
   switch (c.kind) {
@@ -29,7 +32,7 @@ export function candidateToCss(c: SelectorCandidate): string {
     case 'placeholder':
       return `input[placeholder*="${c.value}"]`;
     case 'ariaLabel':
-      return `input[aria-label*="${c.value}"]`;
+      return `input[aria-label="${c.value}"]`;
     case 'name':
       return `[name="${c.value}"]`;
     case 'xpath':
@@ -75,14 +78,16 @@ export function extractCredentialKey(selector: string): string {
 }
 
 async function queryWithTimeout(ctx: Page | Frame, css: string): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout>;
   const el = await Promise.race([
     ctx.$(css),
-    new Promise<null>(resolve =>
-      setTimeout(() => {
+    new Promise<null>(resolve => {
+      timer = setTimeout(() => {
         resolve(null);
-      }, CANDIDATE_TIMEOUT_MS),
-    ),
+      }, CANDIDATE_TIMEOUT_MS);
+    }),
   ]);
+  clearTimeout(timer!);
   return el !== null;
 }
 
@@ -108,38 +113,136 @@ async function findInputByForAttr(
   return inputSelector;
 }
 
+/** Check that a resolved element is a fillable input (not hidden/submit/button). */
+async function isFillableInput(ctx: Page | Frame, selector: string): Promise<boolean> {
+  const tagName = await ctx.$eval(selector, (el: Element) => el.tagName.toLowerCase());
+  if (tagName === 'textarea') return true;
+  if (tagName !== 'input') return false;
+  const type = await ctx.$eval(selector, (el: Element) => el.getAttribute('type') ?? 'text');
+  return type !== 'hidden' && type !== 'submit' && type !== 'button';
+}
+
+/** Strategy 2: find <input> nested inside the labeling element. */
+async function resolveByNestedInput(ctx: Page | Frame, baseXpath: string): Promise<string | null> {
+  const xpath = `${baseXpath}//input[1]`;
+  if (!(await queryWithTimeout(ctx, xpath))) return null;
+  if (!(await isFillableInput(ctx, xpath))) return null;
+  LOG.debug('resolved labelText → nested input via %s', baseXpath);
+  return xpath;
+}
+
+/** Strategy 3: labeling element has id → find input[aria-labelledby="<id>"]. */
+async function resolveByAriaRef(
+  ctx: Page | Frame,
+  label: { getAttribute: (n: string) => Promise<string | null> },
+  labelValue: string,
+): Promise<string | null> {
+  const labelId = await label.getAttribute('id');
+  if (!labelId) return null;
+  const selector = `input[aria-labelledby="${labelId}"]`;
+  if (!(await queryWithTimeout(ctx, selector))) return null;
+  LOG.debug('resolved labelText "%s" → aria-labelledby="%s"', labelValue, labelId);
+  return selector;
+}
+
+/** Strategy 4: labeling element followed by a sibling <input>. */
+async function resolveBySibling(ctx: Page | Frame, baseXpath: string): Promise<string | null> {
+  const xpath = `${baseXpath}/following-sibling::input[1]`;
+  if (!(await queryWithTimeout(ctx, xpath))) return null;
+  if (!(await isFillableInput(ctx, xpath))) return null;
+  LOG.debug('resolved labelText → sibling input via %s', baseXpath);
+  return xpath;
+}
+
+/** Strategy 5: nearest <input> in the same parent container. */
+async function resolveByProximity(ctx: Page | Frame, baseXpath: string): Promise<string | null> {
+  const xpath = `${baseXpath}/..//input[1]`;
+  if (!(await queryWithTimeout(ctx, xpath))) return null;
+  if (!(await isFillableInput(ctx, xpath))) return null;
+  LOG.debug('resolved labelText → proximity input via %s', baseXpath);
+  return xpath;
+}
+
+/** Inputs for label-based input resolution strategies. */
+interface LabelStrategyOpts {
+  ctx: Page | Frame;
+  label: { getAttribute: (n: string) => Promise<string | null> };
+  baseXpath: string;
+  labelValue: string;
+}
+
+/** Try label-based resolution (for-attr, then nesting/ariaRef/sibling/proximity). */
+async function resolveLabelStrategies(opts: LabelStrategyOpts): Promise<string | null> {
+  const { ctx, label, baseXpath, labelValue } = opts;
+  const forAttr = await label.getAttribute('for');
+  if (forAttr) return findInputByForAttr(ctx, forAttr, labelValue);
+  return (
+    (await resolveByNestedInput(ctx, baseXpath)) ??
+    (await resolveByAriaRef(ctx, label, labelValue)) ??
+    (await resolveBySibling(ctx, baseXpath)) ??
+    (await resolveByProximity(ctx, baseXpath))
+  );
+}
+
+/**
+ * Strict XPath for div/span: matches only elements whose OWN text
+ * (not nested children) contains the value. Prevents matching large containers.
+ */
+function divSpanStrictXpath(value: string): string {
+  return `xpath=//*[${LABEL_TAGS}][text()[contains(., "${value}")]]`;
+}
+
+/** Resolve a labelText candidate: <label> first, then div/span with strict text. */
 async function resolveLabelText(
   ctx: Page | Frame,
   labelXpath: string,
   labelValue: string,
 ): Promise<string | null> {
   const label = await ctx.$(labelXpath);
-  if (!label) return null;
-  const forAttr = await label.getAttribute('for');
-  if (!forAttr) {
-    LOG.debug('labelText "%s" found but no for= attribute', labelValue);
-    return null;
-  }
-  return findInputByForAttr(ctx, forAttr, labelValue);
+  if (label) return resolveLabelStrategies({ ctx, label, baseXpath: labelXpath, labelValue });
+  const strictXpath = divSpanStrictXpath(labelValue);
+  const divSpan = await ctx.$(strictXpath);
+  if (!divSpan) return null;
+  LOG.debug('labelText "%s" found via div/span fallback', labelValue);
+  return resolveLabelStrategies({ ctx, label: divSpan, baseXpath: strictXpath, labelValue });
+}
+
+async function probeLabelText(
+  ctx: Page | Frame,
+  candidate: SelectorCandidate,
+): Promise<ProbeResult | null> {
+  const css = candidateToCss(candidate);
+  const resolved = await resolveLabelText(ctx, css, candidate.value);
+  return resolved ? { css: resolved, kind: 'labelText' } : null;
 }
 
 async function probeCandidate(
   ctx: Page | Frame,
   candidate: SelectorCandidate,
-): Promise<string | null> {
-  const css = candidateToCss(candidate);
+): Promise<ProbeResult | null> {
   try {
-    if (candidate.kind === 'labelText') {
-      return await resolveLabelText(ctx, css, candidate.value);
-    }
+    if (candidate.kind === 'labelText') return await probeLabelText(ctx, candidate);
+    const css = candidateToCss(candidate);
     const isFound = await queryWithTimeout(ctx, css);
     if (isFound) {
       LOG.debug('resolved %s "%s" → %s', candidate.kind, candidate.value, css);
-      return css;
+      return { css, kind: candidate.kind };
     }
     LOG.debug('candidate %s "%s" → NOT FOUND', candidate.kind, candidate.value);
   } catch {
     debugCandidateSkipped(candidate);
+  }
+  return null;
+}
+
+/** Internal: try each candidate, return first match with kind metadata. */
+async function tryInContextInternal(
+  ctx: Page | Frame,
+  candidates: SelectorCandidate[],
+): Promise<ProbeResult | null> {
+  for (const candidate of candidates) {
+    const found = await probeCandidate(ctx, candidate);
+    if (found) return found;
   }
   return null;
 }
@@ -152,11 +255,8 @@ export async function tryInContext(
   ctx: Page | Frame,
   candidates: SelectorCandidate[],
 ): Promise<string | null> {
-  for (const candidate of candidates) {
-    const found = await probeCandidate(ctx, candidate);
-    if (found) return found;
-  }
-  return null;
+  const result = await tryInContextInternal(ctx, candidates);
+  return result?.css ?? null;
 }
 
 /**
@@ -171,6 +271,8 @@ export interface FieldContext {
   context: Page | Frame;
   resolvedVia: 'bankConfig' | 'wellKnown' | 'notResolved';
   round: 'iframe' | 'mainPage' | 'notResolved';
+  /** Which SelectorCandidate kind actually matched (additive, optional). */
+  resolvedKind?: SelectorCandidate['kind'];
   /** Diagnostic message — populated when isResolved is false */
   message?: string;
 }
@@ -180,6 +282,13 @@ export interface FieldContext {
 interface FieldMatch {
   selector: string;
   context: Page | Frame;
+  kind?: SelectorCandidate['kind'];
+}
+
+/** Internal probe result — selector + which kind matched. */
+interface ProbeResult {
+  css: string;
+  kind: SelectorCandidate['kind'];
 }
 
 async function searchInChildFrames(
@@ -190,10 +299,10 @@ async function searchInChildFrames(
   const childFrames = cachedFrames ?? page.frames().filter(f => f !== page.mainFrame());
   if (childFrames.length > 0) LOG.debug('Round 1: searching %d iframe(s)', childFrames.length);
   for (const frame of childFrames) {
-    const found = await tryInContext(frame, allCandidates);
+    const found = await tryInContextInternal(frame, allCandidates);
     if (found) {
-      LOG.debug('Round 1: resolved in iframe %s → %s', frame.url(), found);
-      return { selector: found, context: frame };
+      LOG.debug('Round 1: resolved in iframe %s → %s', frame.url(), found.css);
+      return { selector: found.css, context: frame, kind: found.kind };
     }
   }
   return { selector: '', context: page }; // not found — caller checks selector !== ''
@@ -235,10 +344,10 @@ async function resolveInMainContext(
   credentialKey: string,
 ): Promise<FieldMatch> {
   LOG.debug('Round 2: searching main page');
-  const main = await tryInContext(pageOrFrame, allCandidates);
+  const main = await tryInContextInternal(pageOrFrame, allCandidates);
   if (!main) return { selector: '', context: pageOrFrame }; // not found
-  LOG.debug('Round 2: resolved "%s" → %s', credentialKey, main);
-  return { selector: main, context: pageOrFrame };
+  LOG.debug('Round 2: resolved "%s" → %s', credentialKey, main.css);
+  return { selector: main.css, context: pageOrFrame, kind: main.kind };
 }
 
 /** All inputs needed to resolve a single login field. */
@@ -278,15 +387,30 @@ async function buildNotFoundContext(opts: ResolveAllOpts): Promise<FieldContext>
   };
 }
 
+function toFieldContext(
+  match: FieldMatch,
+  via: FieldContext['resolvedVia'],
+  round: FieldContext['round'],
+): FieldContext {
+  return {
+    isResolved: true,
+    selector: match.selector,
+    context: match.context,
+    resolvedVia: via,
+    round,
+    resolvedKind: match.kind,
+  };
+}
+
 async function probeIframes(page: Page, opts: ResolveAllOpts): Promise<FieldContext | null> {
   const { bankCandidates: b, wellKnownCandidates: wk, cachedFrames } = opts;
   if (b.length > 0) {
     const r = await searchInChildFrames(page, b, cachedFrames);
-    if (r.selector) return { isResolved: true, ...r, resolvedVia: 'bankConfig', round: 'iframe' };
+    if (r.selector) return toFieldContext(r, 'bankConfig', 'iframe');
   }
   if (wk.length > 0) {
     const r = await searchInChildFrames(page, wk, cachedFrames);
-    if (r.selector) return { isResolved: true, ...r, resolvedVia: 'wellKnown', round: 'iframe' };
+    if (r.selector) return toFieldContext(r, 'wellKnown', 'iframe');
   }
   return null;
 }
@@ -295,11 +419,11 @@ async function probeMainPage(opts: ResolveAllOpts): Promise<FieldContext | null>
   const { pageOrFrame: ctx, bankCandidates: b, wellKnownCandidates: wk, field } = opts;
   if (b.length > 0) {
     const r = await resolveInMainContext(ctx, b, field.credentialKey);
-    if (r.selector) return { isResolved: true, ...r, resolvedVia: 'bankConfig', round: 'mainPage' };
+    if (r.selector) return toFieldContext(r, 'bankConfig', 'mainPage');
   }
   if (wk.length > 0) {
     const r = await resolveInMainContext(ctx, wk, field.credentialKey);
-    if (r.selector) return { isResolved: true, ...r, resolvedVia: 'wellKnown', round: 'mainPage' };
+    if (r.selector) return toFieldContext(r, 'wellKnown', 'mainPage');
   }
   return null;
 }

--- a/src/Tests/E2eMocked/SelectorFallback.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/SelectorFallback.e2e-mocked.test.ts
@@ -241,3 +241,448 @@ describe('Selector fallback Round 1: iframe-first detection', () => {
     expect(result.errorMessage).toBeUndefined();
   }, 30000);
 });
+
+// ─── labelText resolution: <label for="id"> ────────────────────────────────
+//
+// Scenario: page uses <label for="id"> pattern (no placeholders, no CSS ids).
+// The scraper must find the <label> by visible text, read for= attr, fill #id.
+
+const LABEL_FOR_LOGIN_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <label for="usr">שם משתמש</label>
+  <input id="usr" type="text" />
+  <label for="pwd">סיסמה</label>
+  <input id="pwd" type="password" />
+  <button type="button" aria-label="כניסה"
+    onclick="window.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+</body></html>`;
+
+describe('labelText resolution: <label for="id">', () => {
+  it('resolves fields via <label for="id"> when no placeholder or CSS id matches', async () => {
+    const labelConfig: LoginConfig = {
+      loginUrl: 'https://test-bank.local/login',
+      fields: [
+        { credentialKey: 'username', selectors: [] },
+        { credentialKey: 'password', selectors: [] },
+      ],
+      submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+      possibleResults: {
+        success: ['https://test-bank.local/home'],
+      },
+    };
+
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: LABEL_FOR_LOGIN_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      labelConfig,
+    );
+
+    const result = await scraper.scrape({
+      username: 'testuser',
+      password: 'testpass',
+    } as { username: string; password: string });
+
+    expect(result.success).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  }, 30000);
+});
+
+// ─── labelText false-positive guard: <div> with nested "סיסמה" text ─────────
+//
+// Scenario: page has <div> containing "סיסמה" in a <p> paragraph (OTP prompt),
+// but the actual password <input> uses a placeholder. The resolver must NOT
+// match the <div> as a label (would find the OTP input instead of password).
+
+const FALSE_POSITIVE_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form id="login-form">
+  <input type="text" placeholder="שם משתמש" />
+  <input type="password" placeholder="סיסמה" />
+  <button type="button" aria-label="כניסה"
+    onclick="window.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+<div id="otp-section" style="display:none">
+  <p>יש להזין סיסמה חד פעמית</p>
+  <input id="otp-code" placeholder="קוד חד פעמי" />
+</div>
+</body></html>`;
+
+describe('labelText false-positive guard', () => {
+  it('does NOT resolve <div> containing "סיסמה" in nested <p> — uses placeholder instead', async () => {
+    const fpConfig: LoginConfig = {
+      loginUrl: 'https://test-bank.local/login',
+      fields: [
+        { credentialKey: 'username', selectors: [] },
+        { credentialKey: 'password', selectors: [] },
+      ],
+      submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+      possibleResults: {
+        success: ['https://test-bank.local/home'],
+      },
+    };
+
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: FALSE_POSITIVE_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      fpConfig,
+    );
+
+    const result = await scraper.scrape({
+      username: 'testuser',
+      password: 'testpass',
+    } as { username: string; password: string });
+
+    // Login succeeds — password field resolved via placeholder (not the OTP div)
+    expect(result.success).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  }, 30000);
+});
+
+// ─── labelText in iframe: <label for="id"> inside an iframe ────────────────
+//
+// Scenario: bank moves login form into an <iframe>. The iframe uses <label>
+// elements with for= attrs. No placeholders, no CSS ids on the main page.
+// The resolver must search the iframe (Round 1) and resolve via labelText.
+
+const MAIN_PAGE_NO_FORM = `<!DOCTYPE html><html><body>
+<h1>Bank Portal</h1>
+<iframe src="https://test-bank.local/login-frame"
+  style="width:100%;height:400px"></iframe>
+</body></html>`;
+
+const FRAME_LABEL_LOGIN_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <label for="user">שם משתמש</label>
+  <input id="user" type="text" />
+  <label for="pass">סיסמה</label>
+  <input id="pass" type="password" />
+  <button type="button" aria-label="כניסה"
+    onclick="window.top.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+</body></html>`;
+
+describe('labelText in iframe', () => {
+  it('resolves <label for="id"> inside an iframe (Round 1)', async () => {
+    const iframeLabelConfig: LoginConfig = {
+      loginUrl: 'https://test-bank.local/',
+      fields: [
+        { credentialKey: 'username', selectors: [] },
+        { credentialKey: 'password', selectors: [] },
+      ],
+      submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+      possibleResults: {
+        success: ['https://test-bank.local/home'],
+      },
+    };
+
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 15000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login-frame',
+              contentType: 'text/html; charset=utf-8',
+              body: FRAME_LABEL_LOGIN_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+            {
+              match: 'test-bank.local',
+              contentType: 'text/html; charset=utf-8',
+              body: MAIN_PAGE_NO_FORM,
+            },
+          ]);
+        },
+      },
+      iframeLabelConfig,
+    );
+
+    const result = await scraper.scrape({
+      username: 'testuser',
+      password: 'testpass',
+    } as { username: string; password: string });
+
+    // Round 1 found <label for="user"> in iframe → filled #user
+    expect(result.success).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  }, 30000);
+});
+
+// ─── Sibling strategy: <label>text</label><input> (no for= attr) ───────────
+//
+// Scenario: bank uses <label> without for= attr, input is a sibling.
+// Strategy 4 (following-sibling) should find the adjacent <input>.
+
+const LABEL_SIBLING_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <div class="field">
+    <label>שם משתמש</label>
+    <input type="text" />
+  </div>
+  <div class="field">
+    <label>סיסמה</label>
+    <input type="password" />
+  </div>
+  <button type="button" aria-label="כניסה"
+    onclick="window.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+</body></html>`;
+
+describe('labelText sibling strategy', () => {
+  it('resolves <label>text</label><input> (no for= attr) via sibling strategy', async () => {
+    const siblingConfig: LoginConfig = {
+      loginUrl: 'https://test-bank.local/login',
+      fields: [
+        { credentialKey: 'username', selectors: [] },
+        { credentialKey: 'password', selectors: [] },
+      ],
+      submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+      possibleResults: {
+        success: ['https://test-bank.local/home'],
+      },
+    };
+
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: LABEL_SIBLING_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      siblingConfig,
+    );
+
+    const result = await scraper.scrape({
+      username: 'testuser',
+      password: 'testpass',
+    } as { username: string; password: string });
+
+    expect(result.success).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  }, 30000);
+});
+
+// ─── <span> as labeling element with nested <input> ────────────────────────
+
+const SPAN_NESTED_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <span class="lbl">שם משתמש<input type="text" /></span>
+  <span class="lbl">סיסמה<input type="password" /></span>
+  <button type="button" aria-label="כניסה"
+    onclick="window.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+</body></html>`;
+
+describe('labelText via <span> with nested input', () => {
+  it('resolves <span>סיסמה<input></span> via nested strategy', async () => {
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: SPAN_NESTED_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      {
+        loginUrl: 'https://test-bank.local/login',
+        fields: [
+          { credentialKey: 'username', selectors: [] },
+          { credentialKey: 'password', selectors: [] },
+        ],
+        submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+        possibleResults: { success: ['https://test-bank.local/home'] },
+      },
+    );
+    const result = await scraper.scrape({ username: 'u', password: 'p' } as {
+      username: string;
+      password: string;
+    });
+    expect(result.success).toBe(true);
+  }, 30000);
+});
+
+// ─── <div> as labeling element with sibling <input> ────────────────────────
+
+const DIV_SIBLING_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <div class="row"><div class="lbl">שם משתמש</div><input type="text" /></div>
+  <div class="row"><div class="lbl">סיסמה</div><input type="password" /></div>
+  <button type="button" aria-label="כניסה"
+    onclick="window.location.href='https://test-bank.local/home'">כניסה</button>
+</form>
+</body></html>`;
+
+describe('labelText via <div> with sibling input', () => {
+  it('resolves <div>סיסמה</div><input> via sibling strategy', async () => {
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: DIV_SIBLING_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      {
+        loginUrl: 'https://test-bank.local/login',
+        fields: [
+          { credentialKey: 'username', selectors: [] },
+          { credentialKey: 'password', selectors: [] },
+        ],
+        submit: [{ kind: 'ariaLabel', value: 'כניסה' }],
+        possibleResults: { success: ['https://test-bank.local/home'] },
+      },
+    );
+    const result = await scraper.scrape({ username: 'u', password: 'p' } as {
+      username: string;
+      password: string;
+    });
+    expect(result.success).toBe(true);
+  }, 30000);
+});
+
+// ─── Placeholder resolution (existing behavior preserved) ──────────────────
+
+const PLACEHOLDER_ONLY_HTML = `<!DOCTYPE html><html><body dir="rtl">
+<form>
+  <input type="text" placeholder="שם משתמש" />
+  <input type="password" placeholder="סיסמה" />
+  <button type="submit">כניסה</button>
+</form>
+<script>
+  document.querySelector('form').onsubmit = function(e) {
+    e.preventDefault();
+    window.location.href = 'https://test-bank.local/home';
+  };
+</script>
+</body></html>`;
+
+describe('placeholder resolution (regression)', () => {
+  it('resolves fields via placeholder when no label/div/span/CSS exists', async () => {
+    const scraper = new ConcreteGenericScraper(
+      {
+        companyId: CompanyTypes.Discount,
+        startDate: new Date('2026-01-01'),
+        browser,
+        skipCloseBrowser: true,
+        defaultTimeout: 10000,
+        preparePage: async page => {
+          await setupRequestInterception(page, [
+            {
+              match: 'test-bank.local/login',
+              contentType: 'text/html; charset=utf-8',
+              body: PLACEHOLDER_ONLY_HTML,
+            },
+            {
+              match: 'test-bank.local/home',
+              contentType: 'text/html; charset=utf-8',
+              body: HOME_HTML,
+            },
+          ]);
+        },
+      },
+      {
+        loginUrl: 'https://test-bank.local/login',
+        fields: [
+          { credentialKey: 'username', selectors: [] },
+          { credentialKey: 'password', selectors: [] },
+        ],
+        submit: [{ kind: 'css', value: 'button[type="submit"]' }],
+        possibleResults: { success: ['https://test-bank.local/home'] },
+      },
+    );
+    const result = await scraper.scrape({ username: 'u', password: 'p' } as {
+      username: string;
+      password: string;
+    });
+    expect(result.success).toBe(true);
+  }, 30000);
+});

--- a/src/Tests/Unit/SelectorResolver.test.ts
+++ b/src/Tests/Unit/SelectorResolver.test.ts
@@ -53,7 +53,7 @@ describe('candidateToCss', () => {
     [{ kind: 'labelText', value: 'סיסמה' }, 'xpath=//label[contains(., "סיסמה")]'],
     [{ kind: 'css', value: '#userCode' }, '#userCode'],
     [{ kind: 'placeholder', value: 'שם משתמש' }, 'input[placeholder*="שם משתמש"]'],
-    [{ kind: 'ariaLabel', value: 'סיסמה' }, 'input[aria-label*="סיסמה"]'],
+    [{ kind: 'ariaLabel', value: 'סיסמה' }, 'input[aria-label="סיסמה"]'],
     [{ kind: 'name', value: 'password' }, '[name="password"]'],
     [
       { kind: 'xpath', value: '//button[contains(., "כניסה")]' },
@@ -143,7 +143,7 @@ describe('resolveFieldContext', () => {
       .mockResolvedValue({}); // first WELL_KNOWN match → found
     const page = makePage({ $: findOnSecondCall });
     const result = await resolveFieldContext(page, field, 'https://bank.test/');
-    // WELL_KNOWN_SELECTORS.username[0] = input[placeholder*="שם משתמש"]
+    // wellKnown.username[0-2] are labelText (fail on mock — no getAttribute), [3] is placeholder
     expect(result.isResolved).toBe(true);
     expect(result.selector).toBe('input[placeholder*="שם משתמש"]');
     expect(result.resolvedVia).toBe('wellKnown');
@@ -156,6 +156,7 @@ describe('resolveFieldContext', () => {
     const emptyField: FieldConfig = { credentialKey: 'username', selectors: [] };
     const result = await resolveFieldContext(page, emptyField, 'https://bank.test/');
     expect(result.isResolved).toBe(true);
+    // wellKnown.username[0-2] are labelText (fail on mock), [3] is placeholder
     expect(result.selector).toBe('input[placeholder*="שם משתמש"]');
     expect(result.resolvedVia).toBe('wellKnown');
   });
@@ -285,5 +286,452 @@ describe('resolveDashboardField', () => {
     expect(result.isResolved).toBe(false);
     expect(result.resolvedVia).toBe('notResolved');
     expect(result.round).toBe('notResolved');
+  });
+});
+
+// ── resolveLabelText strategies ─────────────────────────────────────────────
+
+describe('resolveLabelText strategies', () => {
+  const labelField: FieldConfig = { credentialKey: 'password', selectors: [] };
+
+  function makeLabelPage(querySelector: jest.Mock): Page {
+    const mainFrame = { url: jest.fn().mockReturnValue('https://bank.test/login') };
+    return {
+      $: querySelector,
+      $eval: jest.fn(),
+      frames: jest.fn().mockReturnValue([mainFrame]),
+      mainFrame: jest.fn().mockReturnValue(mainFrame),
+      title: jest.fn().mockResolvedValue('Login'),
+      url: jest.fn().mockReturnValue('https://bank.test/login'),
+    } as unknown as Page;
+  }
+
+  it('Strategy 1: <label for="pw"> → resolves #pw', async () => {
+    const labelEl = { getAttribute: jest.fn().mockResolvedValue('pw') };
+    const inputEl = {};
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      if (sel.includes('label') && sel.includes('סיסמה')) return Promise.resolve(labelEl);
+      if (sel === '#pw') return Promise.resolve(inputEl);
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('#pw');
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('Strategy 2: <div>סיסמה<input></div> → resolves nested input', async () => {
+    const divEl = {
+      getAttribute: jest.fn().mockImplementation((attr: string) => {
+        if (attr === 'for') return Promise.resolve(null); // div has no for=
+        if (attr === 'id') return Promise.resolve(null); // div has no id
+        return Promise.resolve(null);
+      }),
+    };
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      // labelText xpath finds a div
+      if (sel.includes('self::label') && sel.includes('סיסמה') && !sel.includes('//input'))
+        return Promise.resolve(divEl);
+      // nested input xpath → found
+      if (sel.includes('סיסמה') && sel.includes('//input')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    (page.$eval as jest.Mock).mockResolvedValue('input'); // isFillableInput → tagName
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('Strategy 3: <span id="lbl">סיסמה</span> + aria-labelledby → resolves input', async () => {
+    const labelEl = {
+      getAttribute: jest.fn().mockImplementation((attr: string) => {
+        if (attr === 'for') return Promise.resolve(null);
+        if (attr === 'id') return Promise.resolve('lbl');
+        return Promise.resolve(null);
+      }),
+    };
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      if (sel.includes('self::label') && sel.includes('סיסמה') && !sel.includes('//input'))
+        return Promise.resolve(labelEl);
+      if (sel === 'input[aria-labelledby="lbl"]') return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[aria-labelledby="lbl"]');
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('Strategy 4: <label>סיסמה</label><input> → resolves sibling input', async () => {
+    const labelEl = {
+      getAttribute: jest.fn().mockImplementation((attr: string) => {
+        if (attr === 'for') return Promise.resolve(null);
+        if (attr === 'id') return Promise.resolve(null);
+        return Promise.resolve(null);
+      }),
+    };
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      if (
+        sel.includes('self::label') &&
+        sel.includes('סיסמה') &&
+        !sel.includes('//input') &&
+        !sel.includes('following-sibling') &&
+        !sel.includes('../')
+      )
+        return Promise.resolve(labelEl);
+      // nested → not found
+      if (sel.includes('//input[1]') && !sel.includes('following-sibling') && !sel.includes('../'))
+        return Promise.resolve(null);
+      // sibling → found
+      if (sel.includes('following-sibling::input')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    (page.$eval as jest.Mock).mockResolvedValue('input');
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('returns null when no labeling element found', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue(null) });
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    // All labelText + placeholder + css + ariaLabel candidates fail → not resolved
+    expect(result.isResolved).toBe(false);
+  });
+
+  it('skips hidden inputs in nested strategy', async () => {
+    const divEl = {
+      getAttribute: jest.fn().mockImplementation((attr: string) => {
+        if (attr === 'for') return Promise.resolve(null);
+        if (attr === 'id') return Promise.resolve(null);
+        return Promise.resolve(null);
+      }),
+    };
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      // labelText xpath → div with no for/id
+      if (sel.includes('self::label') && sel.includes('סיסמה') && !sel.includes('//input'))
+        return Promise.resolve(divEl);
+      // nested/sibling/proximity input → all found but hidden
+      if (sel.includes('סיסמה') && sel.includes('//input')) return Promise.resolve({});
+      if (sel.includes('following-sibling::input')) return Promise.resolve({});
+      // placeholder fallback → found (non-labelText resolution)
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    // isFillableInput: all labelText-found inputs are hidden
+    (page.$eval as jest.Mock).mockResolvedValue('hidden');
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    // all labelText inputs are hidden → falls through to placeholder
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+});
+
+// ── ariaLabel exact match ───────────────────────────────────────────────────
+
+describe('ariaLabel exact match', () => {
+  it('matches input[aria-label="סיסמה"] exactly', async () => {
+    const element = {};
+    const ctx = makeFrame({ $: jest.fn().mockResolvedValue(element) });
+    const candidates: SelectorCandidate[] = [{ kind: 'ariaLabel', value: 'סיסמה' }];
+    const result = await tryInContext(ctx, candidates);
+    expect(result).toBe('input[aria-label="סיסמה"]');
+  });
+
+  it('does NOT match substring — candidateToCss uses exact match', () => {
+    const css = candidateToCss({ kind: 'ariaLabel', value: 'סיסמה' });
+    // Exact match (=), not substring (*=)
+    expect(css).toBe('input[aria-label="סיסמה"]');
+    expect(css).not.toContain('*=');
+  });
+});
+
+// ── resolvedKind tracking — every SelectorCandidate kind ────────────────────
+
+describe('resolvedKind tracking', () => {
+  it('resolvedKind = "css" for CSS selector match', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'username',
+      selectors: [{ kind: 'css', value: '#userCode' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('css');
+  });
+
+  it('resolvedKind = "placeholder" for placeholder match', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'username',
+      selectors: [{ kind: 'placeholder', value: 'שם משתמש' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[placeholder*="שם משתמש"]');
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+
+  it('resolvedKind = "ariaLabel" for exact aria-label match', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'username',
+      selectors: [{ kind: 'ariaLabel', value: 'שם משתמש' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[aria-label="שם משתמש"]');
+    expect(result.resolvedKind).toBe('ariaLabel');
+  });
+
+  it('resolvedKind = "name" for name attribute match', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'username',
+      selectors: [{ kind: 'name', value: 'username' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('[name="username"]');
+    expect(result.resolvedKind).toBe('name');
+  });
+
+  it('resolvedKind = "xpath" for XPath match', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'username',
+      selectors: [{ kind: 'xpath', value: '//input[@id="user"]' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('xpath=//input[@id="user"]');
+    expect(result.resolvedKind).toBe('xpath');
+  });
+
+  it('resolvedKind is undefined when not resolved', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue(null) });
+    const field: FieldConfig = { credentialKey: 'unknown', selectors: [] };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(false);
+    expect(result.resolvedKind).toBeUndefined();
+  });
+});
+
+// ── Placeholder-specific edge cases ─────────────────────────────────────────
+
+describe('placeholder resolution', () => {
+  it('resolves via placeholder when it is the only candidate', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'password',
+      selectors: [{ kind: 'placeholder', value: 'סיסמה' }],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[placeholder*="סיסמה"]');
+    expect(result.resolvedKind).toBe('placeholder');
+    expect(result.resolvedVia).toBe('bankConfig');
+  });
+
+  it('placeholder fallback from wellKnown when bank selectors empty', async () => {
+    // wellKnown.password[0-2] are labelText (fail), [3] is placeholder
+    const findPlaceholder = jest.fn().mockImplementation((sel: string) => {
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makePage({ $: findPlaceholder });
+    const field: FieldConfig = { credentialKey: 'password', selectors: [] };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[placeholder*="סיסמה"]');
+    expect(result.resolvedVia).toBe('wellKnown');
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+
+  it('placeholder NOT found → falls through to css candidates', async () => {
+    const findCss = jest.fn().mockImplementation((sel: string) => {
+      if (sel === 'input[type="password"]') return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makePage({ $: findCss });
+    const field: FieldConfig = { credentialKey: 'password', selectors: [] };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    // wellKnown password: placeholder entries fail, then css input[type=password] hits
+    expect(result.selector).toBe('input[type="password"]');
+    expect(result.resolvedKind).toBe('css');
+  });
+
+  it('first placeholder candidate wins over second', async () => {
+    const page = makePage({ $: jest.fn().mockResolvedValue({}) });
+    const field: FieldConfig = {
+      credentialKey: 'test',
+      selectors: [
+        { kind: 'placeholder', value: 'first' },
+        { kind: 'placeholder', value: 'second' },
+      ],
+    };
+    const result = await resolveFieldContext(page, field, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.selector).toBe('input[placeholder*="first"]');
+  });
+});
+
+// ── div/span strict fallback ────────────────────────────────────────────────
+
+describe('div/span strict text fallback', () => {
+  const labelField: FieldConfig = { credentialKey: 'password', selectors: [] };
+
+  function makeLabelPage(querySelector: jest.Mock): Page {
+    const mainFrame = { url: jest.fn().mockReturnValue('https://bank.test/login') };
+    return {
+      $: querySelector,
+      $eval: jest.fn(),
+      frames: jest.fn().mockReturnValue([mainFrame]),
+      mainFrame: jest.fn().mockReturnValue(mainFrame),
+      title: jest.fn().mockResolvedValue('Login'),
+      url: jest.fn().mockReturnValue('https://bank.test/login'),
+    } as unknown as Page;
+  }
+
+  it('finds input via <span>סיסמה</span> when no <label> exists', async () => {
+    const spanEl = {
+      getAttribute: jest.fn().mockImplementation((attr: string) => {
+        if (attr === 'for') return Promise.resolve(null);
+        if (attr === 'id') return Promise.resolve(null);
+        return Promise.resolve(null);
+      }),
+    };
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      // <label> xpath → not found
+      if (sel.includes('//label[contains')) return Promise.resolve(null);
+      // strict div/span xpath with text() → found
+      if (sel.includes('text()[contains')) return Promise.resolve(spanEl);
+      // nested input → found
+      if (sel.includes('//input')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    (page.$eval as jest.Mock).mockResolvedValue('input');
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('does NOT match <div> containing "סיסמה" only in nested child text', async () => {
+    // This simulates <div><p>סיסמה חד פעמית</p></div> — the div's OWN text
+    // does not contain "סיסמה", only a nested <p> does.
+    // The strict xpath text()[contains(.,"סיסמה")] should NOT match this div.
+    const querySelector = jest.fn().mockImplementation((sel: string) => {
+      // <label> → not found
+      if (sel.includes('//label[contains')) return Promise.resolve(null);
+      // strict div/span xpath → NOT found (text() doesn't match nested-only text)
+      if (sel.includes('text()[contains')) return Promise.resolve(null);
+      // placeholder fallback → found
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const page = makeLabelPage(querySelector);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    // Resolved via placeholder, NOT labelText — div/span false positive prevented
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+});
+
+// ── isFillableInput validation ──────────────────────────────────────────────
+
+describe('isFillableInput (via nested input strategy)', () => {
+  const labelField: FieldConfig = { credentialKey: 'password', selectors: [] };
+
+  function makeLabelPage(querySelector: jest.Mock, evalMock: jest.Mock): Page {
+    const mainFrame = { url: jest.fn().mockReturnValue('https://bank.test/login') };
+    return {
+      $: querySelector,
+      $eval: evalMock,
+      frames: jest.fn().mockReturnValue([mainFrame]),
+      mainFrame: jest.fn().mockReturnValue(mainFrame),
+      title: jest.fn().mockResolvedValue('Login'),
+      url: jest.fn().mockReturnValue('https://bank.test/login'),
+    } as unknown as Page;
+  }
+
+  function makeQuerySelectorWithLabel(): jest.Mock {
+    const labelEl = {
+      getAttribute: jest.fn().mockResolvedValue(null), // no for=
+    };
+    return jest.fn().mockImplementation((sel: string) => {
+      if (sel.includes('//label[contains')) return Promise.resolve(labelEl);
+      if (sel.includes('//input')) return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+  }
+
+  it('accepts <input type="text"> (fillable)', async () => {
+    const evalMock = jest
+      .fn()
+      .mockResolvedValueOnce('input') // tagName
+      .mockResolvedValueOnce('text'); // type
+    const page = makeLabelPage(makeQuerySelectorWithLabel(), evalMock);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('accepts <textarea> (fillable)', async () => {
+    const evalMock = jest.fn().mockResolvedValueOnce('textarea');
+    const page = makeLabelPage(makeQuerySelectorWithLabel(), evalMock);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('labelText');
+  });
+
+  it('rejects <input type="submit"> (not fillable)', async () => {
+    const evalMock = jest.fn().mockResolvedValueOnce('input').mockResolvedValueOnce('submit');
+    const querySelector = makeQuerySelectorWithLabel();
+    // Also return {} for placeholder fallback
+    const original = querySelector.getMockImplementation()!;
+    querySelector.mockImplementation((sel: string) => {
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return original(sel);
+    });
+    const page = makeLabelPage(querySelector, evalMock);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    // Nested input was type=submit → rejected → fell through to placeholder
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+
+  it('rejects <input type="hidden"> (not fillable)', async () => {
+    const evalMock = jest.fn().mockResolvedValueOnce('input').mockResolvedValueOnce('hidden');
+    const querySelector = makeQuerySelectorWithLabel();
+    const original = querySelector.getMockImplementation()!;
+    querySelector.mockImplementation((sel: string) => {
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return original(sel);
+    });
+    const page = makeLabelPage(querySelector, evalMock);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('placeholder');
+  });
+
+  it('rejects <div> element (not input/textarea)', async () => {
+    const evalMock = jest.fn().mockResolvedValueOnce('div');
+    const querySelector = makeQuerySelectorWithLabel();
+    const original = querySelector.getMockImplementation()!;
+    querySelector.mockImplementation((sel: string) => {
+      if (sel.includes('placeholder')) return Promise.resolve({});
+      return original(sel);
+    });
+    const page = makeLabelPage(querySelector, evalMock);
+    const result = await resolveFieldContext(page, labelField, 'https://bank.test/');
+    expect(result.isResolved).toBe(true);
+    expect(result.resolvedKind).toBe('placeholder');
   });
 });


### PR DESCRIPTION
## Summary
- Enhanced `resolveLabelText` with 5 resolution strategies: `for=` attr → nested input → `aria-labelledby` → sibling → proximity
- Scans `<label>` first, then `<div>`/`<span>` with strict own-text matching (prevents false positives on large containers)
- Tightened `ariaLabel` from substring (`*=`) to exact (`=`) match — prevents "שכחתי סיסמה" matching "סיסמה"
- Added `isFillableInput` validation (rejects hidden/submit/button inputs)
- Added `resolvedKind` to `FieldContext` (additive, non-breaking)
- Fixed `queryWithTimeout` timer leak that prevented Jest clean exit
- All changes internal to `SelectorResolver.ts` — **black box** for bank scrapers and npm consumers

## Test plan
- [x] 54 unit tests covering all 6 SelectorCandidate kinds, 5 label strategies, placeholder edge cases, isFillableInput validation, div/span false positive prevention
- [x] 10 E2E mock tests: `<label for=id>`, iframe, sibling, `<span>` nested, `<div>` sibling, placeholder regression, false positive guard
- [x] 5 real bank E2E (Amex, Isracard, Max, Discount, VisaCal) — all pass with real credentials
- [x] All 8 pre-commit gates pass (tsc, unit, e2e-mock, lint+format, build, audit, real-e2e, dep-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)