### PR TITLE
feat: remove all CSS selectors from login fields — visible text first

### DIFF
--- a/src/Scrapers/Max/MaxLoginConfig.ts
+++ b/src/Scrapers/Max/MaxLoginConfig.ts
@@ -14,13 +14,21 @@ import { SCRAPER_CONFIGURATION } from '../Registry/ScraperConfig.js';
 
 const CFG = SCRAPER_CONFIGURATION.banks[CompanyTypes.Max];
 
-// FieldConfig for the ID field — selectors empty so SelectorResolver falls back to wellKnownSelectors.id
-const MAX_ID_FIELD_CONFIG: FieldConfig = { credentialKey: 'id', selectors: [] };
+// FieldConfig constants — selectors empty so SelectorResolver falls back to wellKnownSelectors
+const MAX_USERNAME_FIELD: FieldConfig = { credentialKey: 'username', selectors: [] };
+const MAX_PASSWORD_FIELD: FieldConfig = { credentialKey: 'password', selectors: [] };
+const MAX_ID_FIELD: FieldConfig = { credentialKey: 'id', selectors: [] };
+
+async function resolveAndFill(page: Page, field: FieldConfig, value: string): Promise<void> {
+  const ctx = await resolveFieldContext(page, field, page.url());
+  if (!ctx.isResolved) return;
+  await fillInput(ctx.context, ctx.selector, value);
+}
 
 /**
  * Handles the optional second-login step in Max's Flow B:
  *   home → username+password → 2nd form (username+password+ID) → dashboard
- * Uses wellKnownSelectors.id from ScraperConfig to detect the field.
+ * Uses wellKnownSelectors to detect all fields via SelectorResolver.
  * If the ID form is not present (Flow A), this function is a no-op.
  */
 export async function maxHandleSecondLoginStep(
@@ -28,10 +36,10 @@ export async function maxHandleSecondLoginStep(
   credentials: { username: string; password: string; id?: string },
 ): Promise<void> {
   if (!credentials.id) return;
-  const idCtx = await resolveFieldContext(page, MAX_ID_FIELD_CONFIG, page.url());
+  const idCtx = await resolveFieldContext(page, MAX_ID_FIELD, page.url());
   if (!idCtx.isResolved) return;
-  await fillInput(page, '#user-name', credentials.username);
-  await fillInput(page, '#password', credentials.password);
+  await resolveAndFill(page, MAX_USERNAME_FIELD, credentials.username);
+  await resolveAndFill(page, MAX_PASSWORD_FIELD, credentials.password);
   await fillInput(idCtx.context, idCtx.selector, credentials.id);
   await clickButton(page, 'app-user-login-form .general-button.send-me-code');
   await sleep(1000);

--- a/src/Scrapers/Mizrahi/MizrahiLoginConfig.ts
+++ b/src/Scrapers/Mizrahi/MizrahiLoginConfig.ts
@@ -31,8 +31,8 @@ async function mizrahiPostAction(page: Page): Promise<void> {
 export const MIZRAHI_CONFIG: LoginConfig = {
   loginUrl: SCRAPER_CONFIGURATION.banks[CompanyTypes.Mizrahi].urls.base,
   fields: [
-    { credentialKey: 'username', selectors: [{ kind: 'css', value: '#userNumberDesktopHeb' }] },
-    { credentialKey: 'password', selectors: [{ kind: 'css', value: '#passwordDesktopHeb' }] },
+    { credentialKey: 'username', selectors: [] },
+    { credentialKey: 'password', selectors: [] },
   ],
   submit: [{ kind: 'css', value: 'button.btn.btn-primary' }],
   checkReadiness: async (page: Page) => {

--- a/src/Scrapers/Registry/BankRegistry.ts
+++ b/src/Scrapers/Registry/BankRegistry.ts
@@ -8,6 +8,7 @@ import { HAPOALIM_CONFIG } from '../Hapoalim/HapoalimLoginConfig.js';
 import { LEUMI_CONFIG } from '../Leumi/LeumiLoginConfig.js';
 import { MAX_CONFIG } from '../Max/MaxLoginConfig.js';
 import { MIZRAHI_CONFIG } from '../Mizrahi/MizrahiLoginConfig.js';
+import { VISACAL_LOGIN_CONFIG } from '../VisaCal/VisaCalLoginConfig.js';
 import { YAHAV_CONFIG } from '../Yahav/YahavLoginConfig.js';
 import { SCRAPER_CONFIGURATION } from './ScraperConfig.js';
 
@@ -34,5 +35,6 @@ export const BANK_REGISTRY: Partial<Record<CompanyTypes, LoginConfig>> = {
   [CompanyTypes.Max]: MAX_CONFIG,
   [CompanyTypes.Behatsdaa]: BEHATSDAA_CONFIG,
   [CompanyTypes.BeyahadBishvilha]: BEYAHAD_CONFIG,
+  [CompanyTypes.VisaCal]: VISACAL_LOGIN_CONFIG,
   [CompanyTypes.Yahav]: YAHAV_CONFIG,
 };

--- a/src/Scrapers/Registry/ScraperConfig.ts
+++ b/src/Scrapers/Registry/ScraperConfig.ts
@@ -380,9 +380,13 @@ export const SCRAPER_CONFIGURATION = {
     },
   } satisfies Record<CompanyTypes, BankScraperConfig>,
 
-  /** Global login-field fallback dictionary used by SelectorResolver on every bank */
+  /**
+   * Global login-field fallback dictionary used by SelectorResolver on every bank.
+   * Order = middleware priority: visible text first → CSS last resort.
+   */
   wellKnownSelectors: {
     username: [
+      // --- visible text (what the user sees) ---
       { kind: 'labelText', value: 'שם משתמש' },
       { kind: 'labelText', value: 'קוד משתמש' },
       { kind: 'labelText', value: 'מספר לקוח' },
@@ -390,93 +394,117 @@ export const SCRAPER_CONFIGURATION = {
       { kind: 'placeholder', value: 'קוד משתמש' },
       { kind: 'placeholder', value: 'מספר לקוח' },
       { kind: 'placeholder', value: 'תז' },
-      { kind: 'css', value: '#username' }, // Beinleumi group, Yahav
-      { kind: 'css', value: '#user-name' }, // Max
-      { kind: 'css', value: '[formcontrolname="userName"]' }, // VisaCal (Angular Material)
       { kind: 'ariaLabel', value: 'שם משתמש' },
       { kind: 'ariaLabel', value: 'קוד משתמש' },
+      // --- semantic HTML ---
       { kind: 'name', value: 'username' },
       { kind: 'name', value: 'userCode' },
+      // --- CSS last resort ---
+      { kind: 'css', value: '#username' }, // Beinleumi group, Yahav
+      { kind: 'css', value: '#user-name' }, // Max
+      { kind: 'css', value: '#userNumberDesktopHeb' }, // Mizrahi
+      { kind: 'css', value: '[formcontrolname="userName"]' }, // VisaCal
     ],
     userCode: [
+      // --- visible text ---
       { kind: 'labelText', value: 'קוד משתמש' },
       { kind: 'labelText', value: 'שם משתמש' },
       { kind: 'placeholder', value: 'קוד משתמש' },
       { kind: 'placeholder', value: 'שם משתמש' },
       { kind: 'placeholder', value: 'מספר לקוח' },
-      { kind: 'css', value: '#userCode' }, // Hapoalim
       { kind: 'ariaLabel', value: 'קוד משתמש' },
+      // --- semantic HTML ---
       { kind: 'name', value: 'userCode' },
       { kind: 'name', value: 'username' },
+      // --- CSS last resort ---
+      { kind: 'css', value: '#userCode' }, // Hapoalim
     ],
     password: [
+      // --- visible text ---
       { kind: 'labelText', value: 'סיסמה' },
       { kind: 'labelText', value: 'סיסמא' },
       { kind: 'labelText', value: 'קוד סודי' },
       { kind: 'placeholder', value: 'סיסמה' },
       { kind: 'placeholder', value: 'סיסמא' },
       { kind: 'placeholder', value: 'קוד סודי' },
+      { kind: 'ariaLabel', value: 'סיסמה' },
+      // --- semantic HTML ---
+      { kind: 'name', value: 'password' },
+      // --- CSS last resort ---
       { kind: 'css', value: 'input[type="password"]' },
       { kind: 'css', value: '#password' }, // Hapoalim, Max, Beinleumi, Yahav
       { kind: 'css', value: '#loginPassword' }, // Behatsdaa, BeyahadBishvilha
       { kind: 'css', value: '#tzPassword' }, // Discount
-      { kind: 'css', value: '[formcontrolname="password"]' }, // VisaCal (Angular Material)
-      { kind: 'ariaLabel', value: 'סיסמה' },
-      { kind: 'name', value: 'password' },
+      { kind: 'css', value: '#passwordDesktopHeb' }, // Mizrahi
+      { kind: 'css', value: '[formcontrolname="password"]' }, // VisaCal
     ],
     id: [
+      // --- visible text ---
       { kind: 'labelText', value: 'תעודת זהות' },
       { kind: 'labelText', value: 'מספר זהות' },
       { kind: 'placeholder', value: 'תעודת זהות' },
       { kind: 'placeholder', value: 'מספר זהות' },
       { kind: 'placeholder', value: 'ת.ז' },
+      { kind: 'ariaLabel', value: 'תעודת זהות' },
+      // --- semantic HTML ---
+      { kind: 'name', value: 'id' },
+      // --- CSS last resort ---
       { kind: 'css', value: '#loginId' }, // Behatsdaa, BeyahadBishvilha
       { kind: 'css', value: '#tzId' }, // Discount
-      { kind: 'ariaLabel', value: 'תעודת זהות' },
-      { kind: 'name', value: 'id' },
     ],
     nationalID: [
+      // --- visible text ---
       { kind: 'labelText', value: 'תעודת זהות' },
       { kind: 'labelText', value: 'מספר זהות' },
       { kind: 'placeholder', value: 'תעודת זהות' },
       { kind: 'placeholder', value: 'מספר זהות' },
-      { kind: 'css', value: '#pinno' }, // Yahav
       { kind: 'ariaLabel', value: 'תעודת זהות' },
+      // --- semantic HTML ---
       { kind: 'name', value: 'nationalID' },
       { kind: 'name', value: 'id' },
+      // --- CSS last resort ---
+      { kind: 'css', value: '#pinno' }, // Yahav
     ],
     card6Digits: [
+      // --- visible text ---
       { kind: 'labelText', value: 'ספרות' },
       { kind: 'placeholder', value: '6 ספרות' },
       { kind: 'placeholder', value: 'ספרות הכרטיס' },
       { kind: 'ariaLabel', value: 'ספרות הכרטיס' },
     ],
     num: [
+      // --- visible text ---
       { kind: 'labelText', value: 'קוד מזהה' },
       { kind: 'labelText', value: 'מספר חשבון' },
       { kind: 'placeholder', value: 'מספר חשבון' },
-      { kind: 'css', value: '#aidnum' }, // Discount
       { kind: 'ariaLabel', value: 'מספר חשבון' },
+      // --- semantic HTML ---
       { kind: 'name', value: 'num' },
+      // --- CSS last resort ---
+      { kind: 'css', value: '#aidnum' }, // Discount
     ],
     otpCode: [
+      // --- visible text ---
       { kind: 'labelText', value: 'קוד חד פעמי' },
       { kind: 'labelText', value: 'קוד אימות' },
       { kind: 'placeholder', value: 'קוד חד פעמי' },
       { kind: 'placeholder', value: 'קוד SMS' },
       { kind: 'placeholder', value: 'קוד אימות' },
       { kind: 'placeholder', value: 'הזן קוד' },
+      // --- semantic HTML ---
       { kind: 'name', value: 'otpCode' },
     ],
-    /** Universal submit-button fallback — tried after every bank's explicit submit candidate */
+    /** Universal submit-button fallback — visible text first, CSS last */
     __submit__: [
-      { kind: 'css', value: 'button[type="submit"]' },
+      // --- visible text ---
       { kind: 'ariaLabel', value: 'כניסה' },
       { kind: 'ariaLabel', value: 'התחברות' },
       { kind: 'ariaLabel', value: 'התחבר' },
       { kind: 'xpath', value: '//button[contains(., "כניסה")]' },
       { kind: 'xpath', value: '//button[contains(., "התחברות")]' },
       { kind: 'xpath', value: '//button[contains(., "התחבר")]' },
+      // --- CSS last resort ---
+      { kind: 'css', value: 'button[type="submit"]' },
     ],
   } satisfies Record<string, SelectorCandidate[]>,
 

--- a/src/Scrapers/VisaCal/VisaCalHelpers.ts
+++ b/src/Scrapers/VisaCal/VisaCalHelpers.ts
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import { type Frame, type Page } from 'playwright';
 
-import { getDebug } from '../../Common/Debug.js';
 import {
   elementPresentOnPage,
   pageEval,
@@ -9,7 +8,6 @@ import {
 } from '../../Common/ElementsInteractions.js';
 import { getRawTransaction } from '../../Common/Transactions.js';
 import { type Transaction, TransactionStatuses, TransactionTypes } from '../../Transactions.js';
-import { LOGIN_RESULTS } from '../Base/BaseScraperWithBrowser.js';
 import { type ScraperOptions } from '../Base/Interface.js';
 import {
   type CardLevelFrame,
@@ -22,7 +20,6 @@ import {
   TrnTypeCode,
 } from './VisaCalTypes.js';
 
-const LOG = getDebug('visa-cal');
 const INVALID_PASSWORD_MESSAGE = 'שם המשתמש או הסיסמה שהוזנו שגויים';
 export const CONNECT_IFRAME_OPTS = {
   timeout: 45000,
@@ -63,35 +60,6 @@ export async function hasChangePasswordForm(page: Page): Promise<boolean> {
   } catch {
     return false; // iframe gone = page navigated away = no change-password form
   }
-}
-
-export function getPossibleLoginResults(): Record<
-  string,
-  (string | RegExp | ((options?: { page?: Page }) => Promise<boolean>))[]
-> {
-  LOG.debug('return possible login results');
-  return {
-    [LOGIN_RESULTS.Success]: [/dashboard/i, /cal-online\.co\.il\/#/],
-    [LOGIN_RESULTS.InvalidPassword]: [
-      async (opts?: { page?: Page }): Promise<boolean> =>
-        opts?.page ? hasInvalidPasswordError(opts.page) : false,
-    ],
-    [LOGIN_RESULTS.ChangePassword]: [
-      async (opts?: { page?: Page }): Promise<boolean> =>
-        opts?.page ? hasChangePasswordForm(opts.page) : false,
-    ],
-  };
-}
-
-export function createLoginFields(credentials: {
-  username: string;
-  password: string;
-}): { selector: string; value: string }[] {
-  LOG.debug('create login fields for username and password');
-  return [
-    { selector: '[formcontrolname="userName"]', value: credentials.username },
-    { selector: '[formcontrolname="password"]', value: credentials.password },
-  ];
 }
 
 export function getInstallments(

--- a/src/Scrapers/VisaCal/VisaCalLoginConfig.ts
+++ b/src/Scrapers/VisaCal/VisaCalLoginConfig.ts
@@ -1,0 +1,63 @@
+import type { Frame, Page } from 'playwright';
+
+import {
+  clickButton,
+  waitUntilElementFound,
+  waitUntilIframeFound,
+} from '../../Common/ElementsInteractions.js';
+import { waitForNavigation } from '../../Common/Navigation.js';
+import { CompanyTypes } from '../../Definitions.js';
+import type { LoginConfig } from '../Base/LoginConfig.js';
+import { SCRAPER_CONFIGURATION } from '../Registry/ScraperConfig.js';
+import {
+  CONNECT_IFRAME_OPTS,
+  hasChangePasswordForm,
+  hasInvalidPasswordError,
+  isConnectFrame,
+} from './VisaCalHelpers.js';
+
+const CFG = SCRAPER_CONFIGURATION.banks[CompanyTypes.VisaCal];
+
+async function visaCalCheckReadiness(page: Page): Promise<void> {
+  await waitUntilElementFound(page, '#ccLoginDesktopBtn');
+}
+
+async function visaCalOpenLoginPopup(page: Page): Promise<Frame> {
+  await waitUntilElementFound(page, '#ccLoginDesktopBtn', { visible: true });
+  await clickButton(page, '#ccLoginDesktopBtn');
+  const frame = await waitUntilIframeFound(page, isConnectFrame, CONNECT_IFRAME_OPTS);
+  await waitUntilElementFound(frame, '#regular-login', { timeout: 30000 });
+  await clickButton(frame, '#regular-login');
+  await waitUntilElementFound(frame, '[formcontrolname="userName"]', { timeout: 45000 });
+  return frame;
+}
+
+async function visaCalPostAction(page: Page): Promise<void> {
+  const isAlreadyLoggedIn = page.url().includes('cal-online.co.il/#');
+  if (!isAlreadyLoggedIn) {
+    await waitForNavigation(page);
+  }
+}
+
+export const VISACAL_LOGIN_CONFIG: LoginConfig = {
+  loginUrl: CFG.urls.base,
+  fields: [
+    { credentialKey: 'username', selectors: [] },
+    { credentialKey: 'password', selectors: [] },
+  ],
+  submit: [{ kind: 'css', value: 'button[type="submit"]' }],
+  checkReadiness: visaCalCheckReadiness,
+  preAction: visaCalOpenLoginPopup,
+  postAction: visaCalPostAction,
+  possibleResults: {
+    success: [/dashboard/i, /cal-online\.co\.il\/#/],
+    invalidPassword: [
+      async (opts?: { page?: Page }): Promise<boolean> =>
+        opts?.page ? hasInvalidPasswordError(opts.page) : false,
+    ],
+    changePassword: [
+      async (opts?: { page?: Page }): Promise<boolean> =>
+        opts?.page ? hasChangePasswordForm(opts.page) : false,
+    ],
+  },
+};

--- a/src/Scrapers/VisaCal/VisaCalScraper.ts
+++ b/src/Scrapers/VisaCal/VisaCalScraper.ts
@@ -1,30 +1,19 @@
 import moment from 'moment';
-import type { Frame } from 'playwright';
 
 import { getDebug } from '../../Common/Debug.js';
-import {
-  clickButton,
-  waitUntilElementFound,
-  waitUntilIframeFound,
-} from '../../Common/ElementsInteractions.js';
 import { fetchPost } from '../../Common/Fetch.js';
-import { getCurrentUrl, waitForUrl } from '../../Common/Navigation.js';
+import { getCurrentUrl } from '../../Common/Navigation.js';
 import { getFromSessionStorage } from '../../Common/Storage.js';
 import { filterOldTransactions } from '../../Common/Transactions.js';
 import { waitUntil } from '../../Common/Waiting.js';
 import { CompanyTypes } from '../../Definitions.js';
 import type { TransactionsAccount } from '../../Transactions.js';
-import { BaseScraperWithBrowser, type LoginOptions } from '../Base/BaseScraperWithBrowser.js';
-import type { ScraperScrapingResult } from '../Base/Interface.js';
+import type { LoginOptions } from '../Base/BaseScraperWithBrowser.js';
+import { GenericBankScraper } from '../Base/GenericBankScraper.js';
+import type { ScraperOptions, ScraperScrapingResult } from '../Base/Interface.js';
 import { SCRAPER_CONFIGURATION } from '../Registry/ScraperConfig.js';
-import {
-  CONNECT_IFRAME_OPTS,
-  convertParsedDataToTransactions,
-  createLoginFields,
-  findCardFrame,
-  getPossibleLoginResults,
-  isConnectFrame,
-} from './VisaCalHelpers.js';
+import { convertParsedDataToTransactions, findCardFrame } from './VisaCalHelpers.js';
+import { VISACAL_LOGIN_CONFIG } from './VisaCalLoginConfig.js';
 import {
   type ApiContext,
   type AuthModule,
@@ -51,7 +40,6 @@ const API_HEADERS = {
   'Sec-Fetch-Mode': 'cors',
   'Sec-Fetch-Dest': 'empty',
 };
-const LOGIN_URL = VISCAL_CFG.urls.base;
 const TRANSACTIONS_REQUEST_ENDPOINT = VISCAL_CFG.api.calTransactions!;
 const FRAMES_REQUEST_ENDPOINT = VISCAL_CFG.api.calFrames!;
 const PENDING_TRANSACTIONS_REQUEST_ENDPOINT = VISCAL_CFG.api.calPending!;
@@ -65,22 +53,39 @@ interface ScraperSpecificCredentials {
   password: string;
 }
 
-class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> {
+class VisaCalScraper extends GenericBankScraper<ScraperSpecificCredentials> {
   private authorization: string | undefined = undefined;
 
   private authTokenPromise: Promise<string | undefined> | undefined;
 
-  public openLoginPopup = async (): Promise<Frame> => {
-    LOG.debug('open login popup');
-    await waitUntilElementFound(this.page, '#ccLoginDesktopBtn', { visible: true });
-    await clickButton(this.page, '#ccLoginDesktopBtn');
-    const frame = await waitUntilIframeFound(this.page, isConnectFrame, CONNECT_IFRAME_OPTS);
-    await waitUntilElementFound(frame, '#regular-login', { timeout: 30000 });
-    LOG.debug('navigating to password login tab');
-    await clickButton(frame, '#regular-login');
-    await waitUntilElementFound(frame, '[formcontrolname="userName"]', { timeout: 45000 });
-    return frame;
-  };
+  constructor(options: ScraperOptions) {
+    super(options, VISACAL_LOGIN_CONFIG);
+  }
+
+  public override getLoginOptions(credentials: ScraperSpecificCredentials): LoginOptions {
+    this.authTokenPromise = this.interceptLoginToken();
+    const opts = super.getLoginOptions(credentials);
+    const originalPostAction = opts.postAction;
+    return {
+      ...opts,
+      postAction: async (): Promise<void> => {
+        if (originalPostAction) await originalPostAction();
+        await this.captureAuthToken();
+      },
+    };
+  }
+
+  public async fetchData(): Promise<ScraperScrapingResult> {
+    const defaultStartMoment = moment().subtract(1, 'years').subtract(6, 'months').add(1, 'day');
+    const startDate = this.options.startDate;
+    const startMoment = moment.max(defaultStartMoment, moment(startDate));
+    LOG.debug(`fetch transactions starting ${startMoment.format()}`);
+    const cards = await this.getCards();
+    const ctx = await this.buildApiContext(startDate, startMoment);
+    const accounts = await this.fetchAllCardAccounts(cards, ctx);
+    LOG.debug(`return ${accounts.length} scraped accounts`);
+    return { success: true, accounts };
+  }
 
   public async getCards(): Promise<CardInfo[]> {
     LOG.debug('fetch cards via init API (bypasses sessionStorage race)');
@@ -113,37 +118,7 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
     return Promise.resolve(VISCAL_CFG.api.calXSiteId!);
   }
 
-  public getLoginOptions(credentials: ScraperSpecificCredentials): LoginOptions {
-    this.authTokenPromise = this.interceptLoginToken();
-    return {
-      loginUrl: LOGIN_URL,
-      fields: createLoginFields(credentials),
-      submitButtonSelector: 'button[type="submit"]',
-      possibleResults: getPossibleLoginResults(),
-      checkReadiness: async () => waitUntilElementFound(this.page, '#ccLoginDesktopBtn'),
-      preAction: this.openLoginPopup,
-      postAction: () => this.handlePostLogin(),
-    };
-  }
-
-  public async fetchData(): Promise<ScraperScrapingResult> {
-    const defaultStartMoment = moment().subtract(1, 'years').subtract(6, 'months').add(1, 'day');
-    const startDate = this.options.startDate;
-    const startMoment = moment.max(defaultStartMoment, moment(startDate));
-    LOG.debug(`fetch transactions starting ${startMoment.format()}`);
-    const cards = await this.getCards();
-    const ctx = await this.buildApiContext(startDate, startMoment);
-    const accounts = await this.fetchAllCardAccounts(cards, ctx);
-    LOG.debug(`return ${accounts.length} scraped accounts`);
-    return { success: true, accounts };
-  }
-
-  private async handlePostLogin(): Promise<void> {
-    const currentUrl = await getCurrentUrl(this.page);
-    const isAlreadyLoggedIn = currentUrl.includes('cal-online.co.il/#');
-    if (!isAlreadyLoggedIn) {
-      await this.waitForPostLoginRedirect();
-    }
+  private async captureAuthToken(): Promise<void> {
     const token = await this.authTokenPromise;
     if (token) {
       LOG.debug('login token intercepted from POST response');
@@ -153,18 +128,6 @@ class VisaCalScraper extends BaseScraperWithBrowser<ScraperSpecificCredentials> 
       this.authorization = '';
     }
     LOG.debug('post-login URL: %s', await getCurrentUrl(this.page));
-  }
-
-  private async waitForPostLoginRedirect(): Promise<void> {
-    try {
-      // Old flow: redirect to digital-web; new flow: stay on cal-online.co.il/#
-      const isPostLogin = /digital-web\.cal-online\.co\.il|cal-online\.co\.il\/#|dashboard/;
-      await waitForUrl(this.page, isPostLogin, { timeout: 30000 });
-      const url = await getCurrentUrl(this.page);
-      if (url.includes('site-tutorial')) await clickButton(this.page, 'button.btn-close');
-    } catch {
-      LOG.debug('post-login redirect timeout — checking if already on dashboard');
-    }
   }
 
   private interceptLoginToken(): Promise<string | undefined> {

--- a/src/Tests/Unit/MaxLoginConfig.test.ts
+++ b/src/Tests/Unit/MaxLoginConfig.test.ts
@@ -103,22 +103,83 @@ describe('maxHandleSecondLoginStep', () => {
 
   it('fills username, password, and ID when ID field is found (Flow B)', async () => {
     const mockContext = {} as Page;
-    mockResolveFieldContext.mockResolvedValue({
-      isResolved: true,
-      selector: '#id-field',
-      context: mockContext,
-    });
     const page = makeMockPage();
+    mockResolveFieldContext
+      .mockResolvedValueOnce({ isResolved: true, selector: '#id-field', context: mockContext })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#user-name', context: page })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#password', context: page });
     await maxHandleSecondLoginStep(page, {
       username: 'testuser',
       password: 'testpass',
       id: '123456789',
     });
+    expect(mockResolveFieldContext).toHaveBeenCalledTimes(3);
     expect(mockFillInput).toHaveBeenCalledTimes(3);
-    expect(mockFillInput).toHaveBeenCalledWith(page, '#user-name', 'testuser');
-    expect(mockFillInput).toHaveBeenCalledWith(page, '#password', 'testpass');
-    expect(mockFillInput).toHaveBeenCalledWith(mockContext, '#id-field', '123456789');
     expect(mockClickButton).toHaveBeenCalled();
+  });
+
+  it('skips username fill when username resolution fails in Flow B', async () => {
+    const mockContext = {} as Page;
+    const page = makeMockPage();
+    mockResolveFieldContext
+      .mockResolvedValueOnce({ isResolved: true, selector: '#id-field', context: mockContext })
+      .mockResolvedValueOnce({ isResolved: false })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#password', context: page });
+    await maxHandleSecondLoginStep(page, { username: 'u', password: 'p', id: '123' });
+    expect(mockFillInput).toHaveBeenCalledTimes(2);
+    expect(mockClickButton).toHaveBeenCalled();
+  });
+
+  it('skips password fill when password resolution fails in Flow B', async () => {
+    const mockContext = {} as Page;
+    const page = makeMockPage();
+    mockResolveFieldContext
+      .mockResolvedValueOnce({ isResolved: true, selector: '#id-field', context: mockContext })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#user-name', context: page })
+      .mockResolvedValueOnce({ isResolved: false });
+    await maxHandleSecondLoginStep(page, { username: 'u', password: 'p', id: '123' });
+    expect(mockFillInput).toHaveBeenCalledTimes(2);
+    expect(mockClickButton).toHaveBeenCalled();
+  });
+
+  it('fills only ID when both username and password resolution fail', async () => {
+    const mockContext = {} as Page;
+    const page = makeMockPage();
+    mockResolveFieldContext
+      .mockResolvedValueOnce({ isResolved: true, selector: '#id-field', context: mockContext })
+      .mockResolvedValueOnce({ isResolved: false })
+      .mockResolvedValueOnce({ isResolved: false });
+    await maxHandleSecondLoginStep(page, { username: 'u', password: 'p', id: '123' });
+    expect(mockFillInput).toHaveBeenCalledTimes(1);
+    expect(mockClickButton).toHaveBeenCalled();
+  });
+
+  it('passes correct FieldConfig to resolveFieldContext for each field', async () => {
+    const mockContext = {} as Page;
+    const page = makeMockPage();
+    mockResolveFieldContext
+      .mockResolvedValueOnce({ isResolved: true, selector: '#id', context: mockContext })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#u', context: page })
+      .mockResolvedValueOnce({ isResolved: true, selector: '#p', context: page });
+    await maxHandleSecondLoginStep(page, { username: 'u', password: 'p', id: '123' });
+    expect(mockResolveFieldContext).toHaveBeenNthCalledWith(
+      1,
+      page,
+      expect.objectContaining({ credentialKey: 'id', selectors: [] }),
+      expect.any(String),
+    );
+    expect(mockResolveFieldContext).toHaveBeenNthCalledWith(
+      2,
+      page,
+      expect.objectContaining({ credentialKey: 'username', selectors: [] }),
+      expect.any(String),
+    );
+    expect(mockResolveFieldContext).toHaveBeenNthCalledWith(
+      3,
+      page,
+      expect.objectContaining({ credentialKey: 'password', selectors: [] }),
+      expect.any(String),
+    );
   });
 });
 

--- a/src/Tests/Unit/MizrahiLoginConfig.test.ts
+++ b/src/Tests/Unit/MizrahiLoginConfig.test.ts
@@ -1,0 +1,171 @@
+import { jest } from '@jest/globals';
+import type { Page } from 'playwright';
+
+const mockWaitUntilElementFound = jest.fn().mockResolvedValue(undefined);
+const mockWaitUntilElementDisappear = jest.fn().mockResolvedValue(undefined);
+
+jest.unstable_mockModule('../../Common/Debug.js', () => ({
+  getDebug: () => ({
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.unstable_mockModule('../../Common/ElementsInteractions.js', () => ({
+  waitUntilElementFound: mockWaitUntilElementFound,
+  waitUntilElementDisappear: mockWaitUntilElementDisappear,
+  clickButton: jest.fn().mockResolvedValue(undefined),
+  fillInput: jest.fn().mockResolvedValue(undefined),
+  elementPresentOnPage: jest.fn().mockResolvedValue(false),
+  waitUntilIframeFound: jest.fn().mockResolvedValue(undefined),
+  pageEval: jest.fn().mockResolvedValue(''),
+  capturePageText: jest.fn().mockResolvedValue(''),
+}));
+
+jest.unstable_mockModule('../../Common/Navigation.js', () => ({
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+  waitForRedirect: jest.fn().mockResolvedValue(undefined),
+  getCurrentUrl: jest.fn().mockResolvedValue(''),
+  waitForUrl: jest.fn().mockResolvedValue(undefined),
+  waitForNavigationAndDomLoad: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { MIZRAHI_CONFIG } = await import('../../Scrapers/Mizrahi/MizrahiLoginConfig.js');
+
+const mockGoto = jest.fn().mockResolvedValue(undefined);
+const mockQuery = jest.fn().mockResolvedValue(null);
+const mockQueryAll = jest.fn().mockResolvedValue([]);
+
+function makeMockPage(url = 'https://mto.mizrahi-tefahot.co.il/OnlineApp/'): Page {
+  mockGoto.mockClear();
+  mockQuery.mockClear();
+  mockQueryAll.mockClear();
+  return {
+    url: jest.fn().mockReturnValue(url),
+    goto: mockGoto,
+    $: mockQuery,
+    $$: mockQueryAll,
+  } as unknown as Page;
+}
+
+describe('MIZRAHI_CONFIG', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('has loginUrl from ScraperConfig', () => {
+    expect(MIZRAHI_CONFIG.loginUrl).toBeDefined();
+    expect(typeof MIZRAHI_CONFIG.loginUrl).toBe('string');
+  });
+
+  it('has username and password fields', () => {
+    expect(MIZRAHI_CONFIG.fields).toHaveLength(2);
+    expect(MIZRAHI_CONFIG.fields[0].credentialKey).toBe('username');
+    expect(MIZRAHI_CONFIG.fields[1].credentialKey).toBe('password');
+  });
+
+  it('uses empty selectors (wellKnown fallback) for all fields', () => {
+    for (const field of MIZRAHI_CONFIG.fields) {
+      expect(field.selectors).toEqual([]);
+    }
+  });
+
+  it('has submit selector', () => {
+    const submit = Array.isArray(MIZRAHI_CONFIG.submit)
+      ? MIZRAHI_CONFIG.submit
+      : [MIZRAHI_CONFIG.submit];
+    expect(submit.length).toBeGreaterThan(0);
+  });
+
+  it('has checkReadiness function', () => {
+    expect(typeof MIZRAHI_CONFIG.checkReadiness).toBe('function');
+  });
+
+  it('has postAction function', () => {
+    expect(typeof MIZRAHI_CONFIG.postAction).toBe('function');
+  });
+
+  describe('checkReadiness', () => {
+    it('navigates to loginRoute', async () => {
+      const page = makeMockPage();
+      await MIZRAHI_CONFIG.checkReadiness!(page);
+      expect(mockGoto).toHaveBeenCalledWith(expect.stringContaining('mizrahi'), expect.any(Object));
+    });
+
+    it('waits for overlay to disappear', async () => {
+      const page = makeMockPage();
+      await MIZRAHI_CONFIG.checkReadiness!(page);
+      expect(mockWaitUntilElementDisappear).toHaveBeenCalledWith(
+        page,
+        'div.ngx-overlay.loading-foreground',
+      );
+    });
+  });
+
+  describe('postAction', () => {
+    it('waits for dropdownBasic or invalid selector', async () => {
+      const page = makeMockPage();
+      await MIZRAHI_CONFIG.postAction!(page);
+      expect(mockWaitUntilElementFound).toHaveBeenCalledWith(page, '#dropdownBasic');
+    });
+  });
+
+  describe('possibleResults.success', () => {
+    it('regex matches Mizrahi online app URL', () => {
+      const regex = MIZRAHI_CONFIG.possibleResults.success[0] as RegExp;
+      expect(regex.test('https://mto.mizrahi-tefahot.co.il/OnlineApp/dashboard')).toBe(true);
+    });
+
+    it('regex rejects non-Mizrahi URL', () => {
+      const regex = MIZRAHI_CONFIG.possibleResults.success[0] as RegExp;
+      expect(regex.test('https://other-bank.co.il/dashboard')).toBe(false);
+    });
+
+    it('mizrahiIsLoggedIn returns true when element exists', async () => {
+      const fn = MIZRAHI_CONFIG.possibleResults.success[1] as (opts: {
+        page: Page;
+      }) => Promise<boolean>;
+      const page = makeMockPage();
+      mockQueryAll.mockResolvedValue([{}]);
+      expect(await fn({ page })).toBe(true);
+    });
+
+    it('mizrahiIsLoggedIn returns false when no page', async () => {
+      const fn = MIZRAHI_CONFIG.possibleResults.success[1] as (opts?: {
+        page?: Page;
+      }) => Promise<boolean>;
+      expect(await fn()).toBe(false);
+      expect(await fn({})).toBe(false);
+    });
+
+    it('mizrahiIsLoggedIn returns false when no element', async () => {
+      const fn = MIZRAHI_CONFIG.possibleResults.success[1] as (opts: {
+        page: Page;
+      }) => Promise<boolean>;
+      const page = makeMockPage();
+      mockQueryAll.mockResolvedValue([]);
+      expect(await fn({ page })).toBe(false);
+    });
+  });
+
+  describe('possibleResults.invalidPassword', () => {
+    it('returns true when element present', async () => {
+      const fn = MIZRAHI_CONFIG.possibleResults.invalidPassword![0] as (opts: {
+        page: Page;
+      }) => Promise<boolean>;
+      const page = makeMockPage();
+      mockQuery.mockResolvedValue({});
+      expect(await fn({ page })).toBe(true);
+    });
+
+    it('returns false when element absent', async () => {
+      const fn = MIZRAHI_CONFIG.possibleResults.invalidPassword![0] as (opts: {
+        page: Page;
+      }) => Promise<boolean>;
+      const page = makeMockPage();
+      mockQuery.mockResolvedValue(null);
+      expect(await fn({ page })).toBe(false);
+    });
+  });
+});

--- a/src/Tests/Unit/ScraperConfig.test.ts
+++ b/src/Tests/Unit/ScraperConfig.test.ts
@@ -1,0 +1,206 @@
+import { jest } from '@jest/globals';
+
+import type { SelectorCandidate } from '../../Scrapers/Base/LoginConfig.js';
+
+// ── Mocks (required by transitive imports from LoginConfig files) ────────────
+
+jest.unstable_mockModule('../../Common/Debug.js', () => ({
+  getDebug: () => ({
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.unstable_mockModule('../../Common/ElementsInteractions.js', () => ({
+  waitUntilElementFound: jest.fn(),
+  waitUntilElementDisappear: jest.fn(),
+  clickButton: jest.fn(),
+  clickLink: jest.fn(),
+  dropdownElements: jest.fn(),
+  dropdownSelect: jest.fn(),
+  fillInput: jest.fn(),
+  elementPresentOnPage: jest.fn(),
+  waitUntilIframeFound: jest.fn(),
+  pageEval: jest.fn(),
+  pageEvalAll: jest.fn(),
+  setValue: jest.fn(),
+  capturePageText: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../Common/Navigation.js', () => ({
+  waitForNavigation: jest.fn(),
+  waitForRedirect: jest.fn(),
+  getCurrentUrl: jest.fn(),
+  waitForUrl: jest.fn(),
+  waitForNavigationAndDomLoad: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../Common/Waiting.js', () => ({
+  sleep: jest.fn(),
+  humanDelay: jest.fn(),
+  waitUntil: jest.fn(),
+  raceTimeout: jest.fn(),
+  runSerial: jest.fn(),
+  TimeoutError: class TimeoutError extends Error {},
+  SECOND: 1000,
+}));
+
+jest.unstable_mockModule('../../Common/SelectorResolver.js', () => ({
+  resolveFieldContext: jest.fn(),
+  resolveFieldWithCache: jest.fn(),
+  candidateToCss: jest.fn(),
+  extractCredentialKey: jest.fn(),
+  tryInContext: jest.fn(),
+  toFirstCss: jest.fn(),
+  resolveDashboardField: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../Common/Storage.js', () => ({
+  getFromSessionStorage: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../Common/Fetch.js', () => ({
+  fetchPost: jest.fn(),
+  fetchPostWithinPage: jest.fn(),
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+const { SCRAPER_CONFIGURATION } = await import('../../Scrapers/Registry/ScraperConfig.js');
+const { BANK_REGISTRY } = await import('../../Scrapers/Registry/BankRegistry.js');
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const VALID_KINDS = ['labelText', 'css', 'placeholder', 'ariaLabel', 'name', 'xpath'] as const;
+
+const wk = SCRAPER_CONFIGURATION.wellKnownSelectors;
+type WkKey = keyof typeof wk;
+
+function keysWithCss(): string[] {
+  return Object.keys(wk).filter(k =>
+    (wk[k as WkKey] as readonly SelectorCandidate[]).some(c => c.kind === 'css'),
+  );
+}
+
+function lastIndexOfKind(arr: readonly SelectorCandidate[], kind: string): number {
+  return arr.reduce((acc, c, i) => (c.kind === kind ? i : acc), -1);
+}
+
+function firstIndexOfKind(arr: readonly SelectorCandidate[], kind: string): number {
+  return arr.findIndex(c => c.kind === kind);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('wellKnownSelectors', () => {
+  const KEYS_WITH_CSS = keysWithCss();
+
+  describe('ordering invariant — visible-text kinds before css', () => {
+    it.each(KEYS_WITH_CSS)('%s: all labelText entries before all css entries', key => {
+      const arr = wk[key as WkKey] as readonly SelectorCandidate[];
+      const lastLabel = lastIndexOfKind(arr, 'labelText');
+      const firstCss = firstIndexOfKind(arr, 'css');
+      if (lastLabel >= 0 && firstCss >= 0) {
+        expect(lastLabel).toBeLessThan(firstCss);
+      }
+    });
+
+    it.each(KEYS_WITH_CSS)('%s: all placeholder entries before all css entries', key => {
+      const arr = wk[key as WkKey] as readonly SelectorCandidate[];
+      const lastPlaceholder = lastIndexOfKind(arr, 'placeholder');
+      const firstCss = firstIndexOfKind(arr, 'css');
+      if (lastPlaceholder >= 0 && firstCss >= 0) {
+        expect(lastPlaceholder).toBeLessThan(firstCss);
+      }
+    });
+
+    it.each(KEYS_WITH_CSS)('%s: all ariaLabel entries before all css entries', key => {
+      const arr = wk[key as WkKey] as readonly SelectorCandidate[];
+      const lastAria = lastIndexOfKind(arr, 'ariaLabel');
+      const firstCss = firstIndexOfKind(arr, 'css');
+      if (lastAria >= 0 && firstCss >= 0) {
+        expect(lastAria).toBeLessThan(firstCss);
+      }
+    });
+  });
+
+  describe('each credential key has at least one labelText', () => {
+    const CREDENTIAL_KEYS: WkKey[] = [
+      'username',
+      'userCode',
+      'password',
+      'id',
+      'nationalID',
+      'num',
+    ];
+
+    it.each(CREDENTIAL_KEYS)('%s has at least one labelText candidate', key => {
+      const arr = wk[key] as readonly SelectorCandidate[];
+      const hasLabel = arr.some(c => c.kind === 'labelText');
+      expect(hasLabel).toBe(true);
+    });
+  });
+
+  describe('specific bank CSS present', () => {
+    it('Mizrahi: #userNumberDesktopHeb in username', () => {
+      const arr = wk.username as readonly SelectorCandidate[];
+      expect(arr).toContainEqual({ kind: 'css', value: '#userNumberDesktopHeb' });
+    });
+
+    it('Mizrahi: #passwordDesktopHeb in password', () => {
+      const arr = wk.password as readonly SelectorCandidate[];
+      expect(arr).toContainEqual({ kind: 'css', value: '#passwordDesktopHeb' });
+    });
+
+    it('Max: #user-name in username', () => {
+      const arr = wk.username as readonly SelectorCandidate[];
+      expect(arr).toContainEqual({ kind: 'css', value: '#user-name' });
+    });
+
+    it('__submit__ has button[type="submit"]', () => {
+      const arr = wk.__submit__ as readonly SelectorCandidate[];
+      expect(arr).toContainEqual({ kind: 'css', value: 'button[type="submit"]' });
+    });
+  });
+
+  it('__submit__ has ariaLabel before css', () => {
+    const arr = wk.__submit__ as readonly SelectorCandidate[];
+    const lastAria = lastIndexOfKind(arr, 'ariaLabel');
+    const firstCss = firstIndexOfKind(arr, 'css');
+    expect(lastAria).toBeGreaterThanOrEqual(0);
+    expect(firstCss).toBeGreaterThanOrEqual(0);
+    expect(lastAria).toBeLessThan(firstCss);
+  });
+
+  describe('all entries have valid kind', () => {
+    const allKeys = Object.keys(wk) as WkKey[];
+
+    it.each(allKeys)('%s: every candidate has a valid kind', key => {
+      const arr = wk[key] as readonly SelectorCandidate[];
+      for (const candidate of arr) {
+        expect(VALID_KINDS as readonly string[]).toContain(candidate.kind);
+      }
+    });
+  });
+
+  it('unknown key returns undefined', () => {
+    const result = (wk as Record<string, unknown>).nonExistentKey;
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('BANK_REGISTRY — all banks use selectors: []', () => {
+  const entries = Object.entries(BANK_REGISTRY) as [
+    string,
+    { fields: { selectors: unknown[] }[] },
+  ][];
+
+  it.each(entries)('%s has empty selectors on all login fields', (_bankName, config) => {
+    for (const field of config.fields) {
+      expect(field.selectors).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Mizrahi**: move `#userNumberDesktopHeb`/`#passwordDesktopHeb` to wellKnown, set fields to `selectors: []`
- **Max Flow B**: refactor `maxHandleSecondLoginStep()` to use `resolveFieldContext()` via `resolveAndFill()` helper instead of raw CSS
- **VisaCal**: migrate from `BaseScraperWithBrowser` to `GenericBankScraper` with new `VisaCalLoginConfig.ts` (SOLID factory pattern), delete `createLoginFields()` and `getPossibleLoginResults()`
- **Reorder all 9 wellKnown arrays**: visible text (labelText, placeholder, ariaLabel) → semantic HTML (name) → CSS last resort
- All 16 banks now use `selectors: []` — wellKnown handles detection
- Add VisaCal to BankRegistry

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 42 unit test suites pass (641 tests)
- [x] All 7 mock E2E suites pass (30 tests, incl. SelectorFallback)
- [x] All 5 real E2E bank tests pass (Amex, Isracard, Max, Discount, VisaCal) — transactions returned
- [x] ESLint + Prettier clean
- [x] Pre-commit hook: all 8 gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)