### PR TITLE
fix: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- Add CodeQL workflow for automated security scanning on PRs, pushes to main, and weekly schedule
- Scans JavaScript/TypeScript with `security-and-quality` query suite
- Triggers: push to main, PRs to main, weekly Monday 6am UTC

## Test plan
- [x] CodeQL workflow runs on this PR
- [x] No security findings on clean codebase


🤖 Generated with [Claude Code](https://claude.com/claude-code)