### PR TITLE
fix: opt into Node.js 24 for GitHub Pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build Docs


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in `docs.yml` to suppress Node.js 20 deprecation warnings
- Affects `upload-pages-artifact@v4` and `deploy-pages@v4` (no v5 available yet)
- Node.js 20 actions will be forced to Node.js 24 starting June 2nd, 2026

## Test plan
- [x] Docs workflow runs without deprecation warnings


🤖 Generated with [Claude Code](https://claude.com/claude-code)