### PR TITLE
refactor: move imports to top in OtpFixtures, fix type assertion

### DIFF
--- a/src/Tests/E2eMocked/Helpers/OtpFixtures.ts
+++ b/src/Tests/E2eMocked/Helpers/OtpFixtures.ts
@@ -1,3 +1,10 @@
+import type { Page } from 'playwright';
+
+import type { LifecyclePromise } from '../../../Scrapers/Base/Interfaces/CallbackTypes.js';
+import { setupRequestInterception } from './RequestInterceptor.js';
+
+// ── HTML Fixtures ────────────────────────────────────────────────────────────
+
 /** Login form -> clicking "כניסה" shows the OTP selection screen (JS-rendered, no URL change) */
 export const OTP_SELECTION_HTML = `<!DOCTYPE html><html><body dir="rtl">
 <div id="login-form">
@@ -106,10 +113,7 @@ export const DASHBOARD_HTML = '<!DOCTYPE html><html><body><h1>Dashboard</h1></bo
 export const ERROR_PAGE_HTML =
   '<!DOCTYPE html><html><body><p>שם משתמש שגוי. ניסיון 2 מתוך 3</p></body></html>';
 
-import type { Page } from 'playwright';
-
-import type { LifecyclePromise } from '../../../Scrapers/Base/Interfaces/CallbackTypes.js';
-import { setupRequestInterception } from './RequestInterceptor.js';
+// ── Test Helpers ─────────────────────────────────────────────────────────────
 
 /** Route entry for request interception. */
 interface IRouteEntry {

--- a/src/Tests/E2eMocked/OtpDetection.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/OtpDetection.e2e-mocked.test.ts
@@ -103,8 +103,8 @@ describe('OTP detection', () => {
     const result = await scraper.scrape(TEST_CREDS);
     expect(result.success).toBe(true);
     expect(retrieverSpy).toHaveBeenCalledTimes(1);
-    const anyStringMatcher: string = expect.any(String) as string;
-    expect(retrieverSpy).toHaveBeenCalledWith(anyStringMatcher);
+    const isAnyString: string = expect.any(String) as unknown as string;
+    expect(retrieverSpy).toHaveBeenCalledWith(isAnyString);
   }, 30000);
 
   it('Test 3: Two-screen OTP flow (Beinleumi-like) — SMS selection then code entry → success', async () => {


### PR DESCRIPTION
## Summary
- Move imports to top of `OtpFixtures.ts` (were after HTML constants — convention violation)
- Extract `expect.any(String)` to typed variable in OtpDetection test (no-nested-call + no-unsafe-assignment)

## Test plan
- [x] Pre-commit hook passes all 8 gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)