### PR TITLE
fix: add bank name to all scraper log lines for CI readability

### DIFF
--- a/src/Scrapers/Base/BaseScraper.ts
+++ b/src/Scrapers/Base/BaseScraper.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import moment from 'moment-timezone';
 
-import { getDebug } from '../../Common/Debug.js';
+import { getDebug, type ScraperLogger } from '../../Common/Debug.js';
 import { formatResultSummary } from '../../Common/ResultFormatter.js';
 import { TimeoutError } from '../../Common/Waiting.js';
 import { type CompanyTypes, ScraperProgressTypes } from '../../Definitions.js';
@@ -38,7 +38,6 @@ interface IDiagnosticsState {
 
 /** Event name for scrape progress notifications. */
 const SCRAPE_PROGRESS = 'SCRAPE_PROGRESS';
-const LOG = getDebug('base-scraper');
 
 /**
  * Extract a human-readable message from an unknown error value.
@@ -82,13 +81,18 @@ export default class BaseScraper<
     warnings: [],
   };
 
+  /** Bank-scoped logger — includes `bank` field in every log line. */
+  protected readonly bankLog: ScraperLogger;
+
   private _eventEmitter = new EventEmitter();
 
   /**
    * Create a new BaseScraper with the given options.
    * @param options - Scraper configuration options.
    */
-  constructor(public options: ScraperOptions) {}
+  constructor(public options: ScraperOptions) {
+    this.bankLog = getDebug(options.companyId);
+  }
 
   /**
    * Initialize the scraper and set the default timezone.
@@ -276,7 +280,7 @@ export default class BaseScraper<
   private logResultSummary(result: IScraperScrapingResult): boolean {
     const lines = formatResultSummary(this.options.companyId, result);
     for (const line of lines) {
-      LOG.info(line);
+      this.bankLog.info(line);
     }
     return true;
   }

--- a/src/Scrapers/Base/BaseScraperHelpers.ts
+++ b/src/Scrapers/Base/BaseScraperHelpers.ts
@@ -98,14 +98,6 @@ export async function matchesAnyCondition(
 }
 
 /**
- * Create a generic error scraping result.
- * @returns A failed scraping result with Generic error type.
- */
-export function createGeneralError(): IScraperScrapingResult {
-  return { success: false, errorType: ScraperErrorTypes.Generic };
-}
-
-/**
  * Run a cleanup function, swallowing errors to avoid masking earlier failures.
  * @param cleanup - The cleanup function to execute.
  * @returns True after the cleanup attempt completes.

--- a/src/Scrapers/Base/BaseScraperWithBrowser.ts
+++ b/src/Scrapers/Base/BaseScraperWithBrowser.ts
@@ -84,7 +84,7 @@ class BaseScraperWithBrowser<
     this.emitProgress(ScraperProgressTypes.Initializing);
     const page = await this.initializePage();
     if (!page) {
-      LOG.debug('failed to initiate a browser page, exit');
+      this.bankLog.debug('failed to initiate a browser page, exit');
       return true;
     }
     await this.setupPage(page);
@@ -113,7 +113,7 @@ class BaseScraperWithBrowser<
       navOpts: { waitUntil },
       status,
       retries,
-      log: LOG,
+      log: this.bankLog,
       navigateTo: retryFn,
     });
   }
@@ -179,7 +179,7 @@ class BaseScraperWithBrowser<
     };
     const stepCtx = this.buildStepContext();
     const steps: INamedLoginStep[] = buildLoginChain(stepCtx, loginOptions, ctx);
-    const chainResult = await runLoggedChain(steps, ctx, LOG);
+    const chainResult = await runLoggedChain(steps, ctx, this.bankLog);
     if (chainResult !== null) return chainResult;
     const resultCtx = this.loginResultCtx();
     return resolveAndBuildLoginResult(resultCtx, loginOptions.possibleResults);
@@ -192,7 +192,7 @@ class BaseScraperWithBrowser<
    */
   public async terminate(isSuccess: boolean): Promise<boolean> {
     const successStr = String(isSuccess);
-    LOG.debug('terminating browser with success = %s', successStr);
+    this.bankLog.debug('terminating browser with success = %s', successStr);
     this.emitProgress(ScraperProgressTypes.Terminating);
     await this.captureFailureScreenshot(isSuccess);
     const reversed = this._cleanups.reverse();
@@ -216,7 +216,7 @@ class BaseScraperWithBrowser<
     const response = await this.page.goto(url, { waitUntil });
     if (response !== null) {
       const status = response.status();
-      LOG.debug('navigateTo %s → %d (%dms)', url, status, Date.now() - startMs);
+      this.bankLog.debug('navigateTo %s → %d (%dms)', url, status, Date.now() - startMs);
     }
     return response;
   }
@@ -309,13 +309,13 @@ class BaseScraperWithBrowser<
       this.page.setDefaultTimeout(this.options.defaultTimeout);
     }
     if (this.options.preparePage) {
-      LOG.debug('execute preparePage interceptor provided in options');
+      this.bankLog.debug('execute preparePage interceptor provided in options');
       await this.options.preparePage(this.page);
     }
     this.page.on('requestfailed', request => {
       const errorText = request.failure()?.errorText ?? 'unknown';
       const failedUrl = request.url();
-      LOG.debug('Request failed: %s %s', errorText, failedUrl);
+      this.bankLog.debug('Request failed: %s %s', errorText, failedUrl);
     });
     return true;
   }
@@ -342,10 +342,11 @@ class BaseScraperWithBrowser<
   private async launchNewBrowser(): Promise<Page> {
     const opts = this.options as IDefaultBrowserOptions;
     const { shouldShowBrowser } = opts;
-    LOG.debug('launch Camoufox headless=%s', !shouldShowBrowser);
+    this.bankLog.debug('launch Camoufox headless=%s', !shouldShowBrowser);
     const browser = await launchCamoufox(!shouldShowBrowser);
+    const bankLogger = this.bankLog;
     this._cleanups.push(async () => {
-      LOG.debug('closing the browser');
+      bankLogger.debug('closing the browser');
       await browser.close();
       return true;
     });
@@ -358,9 +359,9 @@ class BaseScraperWithBrowser<
    * @returns A new Playwright page, or undefined on failure.
    */
   private async initializePage(): Promise<Page | undefined> {
-    LOG.debug('initialize browser page');
+    this.bankLog.debug('initialize browser page');
     if ('browserContext' in this.options) {
-      LOG.debug('Using the browser context provided in options');
+      this.bankLog.debug('Using the browser context provided in options');
       return this.options.browserContext.newPage();
     }
     if ('browser' in this.options) {
@@ -374,12 +375,13 @@ class BaseScraperWithBrowser<
    * @returns A new Playwright page.
    */
   private async initializeFromExistingBrowser(): Promise<Page> {
-    LOG.debug('Using the browser instance provided in options');
+    this.bankLog.debug('Using the browser instance provided in options');
     const opts = this.options as { browser: Browser; skipCloseBrowser?: boolean };
     const { browser } = opts;
+    const bankLogger = this.bankLog;
     if (!opts.skipCloseBrowser) {
       this._cleanups.push(async () => {
-        LOG.debug('closing the browser');
+        bankLogger.debug('closing the browser');
         await browser.close();
         return true;
       });
@@ -394,12 +396,13 @@ class BaseScraperWithBrowser<
    */
   private async captureFailureScreenshot(isSuccess: boolean): Promise<boolean> {
     if (isSuccess || !this.options.storeFailureScreenShotPath) return true;
-    LOG.debug('snapshot before terminate in %s', this.options.storeFailureScreenShotPath);
+    this.bankLog.debug('snapshot before terminate in %s', this.options.storeFailureScreenShotPath);
+    const bankLogger = this.bankLog;
     await this.page
       .screenshot({ path: this.options.storeFailureScreenShotPath, fullPage: true })
       .catch((caught: unknown) => {
         const errMsg = (caught as Error).message.slice(0, 80);
-        LOG.debug('screenshot failed: %s', errMsg);
+        bankLogger.debug('screenshot failed: %s', errMsg);
       });
     return true;
   }


### PR DESCRIPTION
## Summary
- Add `bankLog` instance property to `BaseScraper` using `getDebug(companyId)`
- Replace module-level `LOG` with `this.bankLog` in all `BaseScraperWithBrowser` instance methods
- Every scraper log line now shows which bank: `module:"discount"`, `module:"visaCal"`, `module:"max"`
- Remove dead `createGeneralError()` function (zero call sites, zero coverage)

**Before:** All banks log as `module:"base-scraper-with-browser"` — impossible to grep by bank in CI
**After:** Each bank has its own module name — `grep '"module":"discount"'` shows only Discount logs

## Test plan
- [x] TSC: clean
- [x] ESLint: clean  
- [x] Prettier: clean
- [x] 70 unit test suites (896 tests) pass
- [x] All 8 pre-commit gates pass (including E2E real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)