### PR TITLE
fix: opt into Node.js 24 for all CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: CodeQL Security Scan

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: e2e-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     name: Validate PR Title

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analysis:
     name: Scorecard Analysis

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` as top-level env to all 9 workflow files
- Previously only `docs.yml` and `release-please.yml` had it
- Fixes Node.js 20 deprecation warnings in: codeql, dependabot-auto-merge, e2e, nodeCI, pr-title, scorecard, stale

## Test plan
- [x] All 9 workflows verified to have the env var
- [x] No source code changes — workflow-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)