### PR TITLE
chore: add CodeRabbit AI PR review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,46 @@
+# CodeRabbit AI PR Review Configuration
+# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: en
+reviews:
+  # Auto-review every PR
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  # Review profile: assertive catches more issues
+  profile: assertive
+
+  # What to include in reviews
+  path_instructions:
+    - path: "src/Scrapers/**"
+      instructions: >
+        Bank scraper code. Check for: hardcoded CSS/ID selectors (must use visible text),
+        missing error handling, methods over 20 lines, any types, fetch pattern violations
+        (browser scrapers must use fetchPostWithinPage/fetchGetWithinPage, not native fetch).
+    - path: "src/Common/**"
+      instructions: >
+        Shared infrastructure. Check for: breaking changes to public API,
+        missing JSDoc on exported functions, max 3 params per function.
+    - path: ".github/**"
+      instructions: >
+        CI/CD workflows. Check for: missing timeout-minutes, unpinned actions,
+        overly broad permissions, missing set -euo pipefail in shell scripts.
+
+  # Don't review these paths
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/lib/**"
+    - "!package-lock.json"
+    - "!CHANGELOG.md"
+
+  # Request changes on high-severity issues
+  request_changes_workflow: true
+
+  # Collapse walkthrough for large PRs
+  collapse_walkthrough: true
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with project-specific review instructions
- Auto-reviews every PR to main (not drafts)
- Custom path instructions for scrapers (no CSS selectors, fetch patterns), infra (JSDoc, params), and CI (timeouts, permissions)
- Filters out node_modules, lib/, package-lock.json, CHANGELOG.md

## Setup required
Install CodeRabbit GitHub App: https://github.com/marketplace/coderabbitai
(free Pro for public repos)

## Test plan
- [ ] Install CodeRabbit from Marketplace
- [ ] Merge this PR
- [ ] Next PR should get automatic AI review

🤖 Generated with [Claude Code](https://claude.com/claude-code)