### PR TITLE
chore: add GitHub funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: sergienko4
+github: sergienko4


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` with Ko-fi and GitHub Sponsors links
- Enables the "Sponsor" button on the repository page

## Test plan
- [ ] Verify "Sponsor" button appears on the repo page after merge
- [ ] Confirm Ko-fi link (`ko_fi: sergienko4`) resolves correctly
- [ ] Confirm GitHub Sponsors link (`github: sergienko4`) resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)