### PR TITLE
fix(otsar-hahayal): fix login flow, OTP double-send, and submit button detection

### DIFF
--- a/src/Common/Config/OtpDetectorConfig.ts
+++ b/src/Common/Config/OtpDetectorConfig.ts
@@ -31,6 +31,8 @@ export const PHONE_PATTERN = /[*]{4,}\d{2,4}/;
 
 /** Selector candidates for the OTP submit/confirm button — text-first, no element assumption. */
 export const OTP_SUBMIT_CANDIDATES: SelectorCandidate[] = [
+  { kind: 'css', value: 'input[type="button"][value="אישור"]' },
+  { kind: 'css', value: 'input[type="submit"][value="אישור"]' },
   { kind: 'textContent', value: 'אישור' },
   { kind: 'textContent', value: 'אשר' },
   { kind: 'textContent', value: 'המשך' },

--- a/src/Common/OtpDetector.ts
+++ b/src/Common/OtpDetector.ts
@@ -326,7 +326,7 @@ async function sequentialContextAttempts(
 /** XPath predicate restricting matches to interactive elements. */
 const INTERACTIVE_FILTER = [
   '(self::button or self::a or self::input',
-  'or self::select or self::textarea',
+  'or self::select or self::textarea or self::div or self::span or self::li',
   'or @role="button" or @role="link")',
 ].join(' ');
 

--- a/src/Common/OtpHandler.ts
+++ b/src/Common/OtpHandler.ts
@@ -331,7 +331,7 @@ async function pollUntilDeadline(page: Page, deadline: number, pollMs: number): 
  * @returns True if OTP page was detected.
  */
 async function waitForOtpPageInFrames(page: Page): Promise<boolean> {
-  const maxWaitMs = 15000;
+  const maxWaitMs = 30000;
   const deadline = Date.now() + maxWaitMs;
   const isFound = await pollUntilDeadline(page, deadline, 500);
   if (!isFound) LOG.debug('OTP not detected after %dms', maxWaitMs);
@@ -340,6 +340,7 @@ async function waitForOtpPageInFrames(page: Page): Promise<boolean> {
 
 /**
  * Confirm OTP delivery — click bank-specific confirm button if provided, then SMS trigger.
+ * Skips the generic SMS trigger if the bank-specific selectors already succeeded.
  * @param page - The Playwright page instance.
  * @param parsedPage - Optional parsed login page with child frame info.
  * @param triggerSelectors - Optional bank-specific confirm button selectors (from ILoginConfig.otp).
@@ -353,14 +354,16 @@ export async function handleOtpConfirm(
   await waitForOtpPageInFrames(page);
   const phoneHint = await extractPhoneHint(page);
   const childFrames = parsedPage?.childFrames;
+  let didTrigger = false;
   if (triggerSelectors) {
-    LOG.debug('OTP confirm — clicking bank-specific confirm button (phone: %s)', phoneHint);
-    await clickFromCandidates(page, triggerSelectors, childFrames);
+    didTrigger = await clickFromCandidates(page, triggerSelectors, childFrames);
     await page.waitForTimeout(OTP_TRIGGER_DELAY_MS);
   }
-  LOG.debug('OTP confirm — clicking SMS trigger (phone: %s)', phoneHint);
-  await clickOtpTriggerIfPresent(page, childFrames);
-  await page.waitForTimeout(OTP_TRIGGER_DELAY_MS);
+  if (!didTrigger) {
+    LOG.debug('OTP confirm — clicking SMS trigger (phone: %s)', phoneHint);
+    await clickOtpTriggerIfPresent(page, childFrames);
+    await page.waitForTimeout(OTP_TRIGGER_DELAY_MS);
+  }
   return phoneHint;
 }
 

--- a/src/Common/SelectorResolver.ts
+++ b/src/Common/SelectorResolver.ts
@@ -71,7 +71,8 @@ export function candidateToCss(candidate: SelectorCandidate): string {
   const lit = toXpathLiteral(v);
   if (candidate.kind === 'clickableText') return clickableTextXpath(v);
   if (candidate.kind === 'labelText') return `xpath=//label[contains(., ${lit})]`;
-  if (candidate.kind === 'textContent') return `xpath=//*[contains(text(), ${lit})]`;
+  if (candidate.kind === 'textContent')
+    return `xpath=//*[not(self::script) and not(self::style) and contains(text(), ${lit})]`;
   if (candidate.kind === 'css') return v;
   if (candidate.kind === 'placeholder') return `input[placeholder*="${v}"]`;
   if (candidate.kind === 'ariaLabel') return `input[aria-label="${v}"]`;

--- a/src/Scrapers/OtsarHahayal/OtsarHahayalScraper.ts
+++ b/src/Scrapers/OtsarHahayal/OtsarHahayalScraper.ts
@@ -1,18 +1,74 @@
-import { CompanyTypes } from '../../Definitions.js';
+import { type Page } from 'playwright-core';
+
+import { type ILoginConfig } from '../Base/Config/LoginConfig.js';
 import { type ScraperOptions } from '../Base/Interface.js';
 import BeinleumiGroupBaseScraper from '../BaseBeinleumiGroup/BaseBeinleumiGroup.js';
 import { beinleumiConfig } from '../BaseBeinleumiGroup/Config/BeinleumiLoginConfig.js';
-import { SCRAPER_CONFIGURATION } from '../Registry/Config/ScraperConfig.js';
 
-/** Scraper for Otsar Hahayal — uses Beinleumi group login flow. */
+/**
+ * The OtsarHahayal login form is loaded inside a dynamically-injected iframe
+ * (id="loginFrame") whose src is only set when the user opens the login modal.
+ * The scraper never triggers the modal, so navigating to the main bank URL
+ * leaves the iframe as about:blank and the credential fields are never found.
+ *
+ * Fix: navigate directly to the Mataf login servlet — the same page that the
+ * iframe would load — where the username/password fields are immediately available.
+ * This also removes the 15-second waitForAnyIframe timeout since the form is
+ * on the top-level page and no preAction iframe search is needed.
+ */
+const OTSAR_LOGIN_URL =
+  'https://online.bankotsar.co.il/MatafLoginService/MatafLoginServlet?bankId=OTSARPRTAL&site=Private&KODSAFA=HE';
+
+/**
+ * After OTP is accepted, OtsarHahayal stays on the MatafLoginServlet path
+ * but strips query parameters (the SPA drops ?bankId=... on transition to
+ * the authenticated state). Beinleumi-group success patterns (fibi/FibiMenu)
+ * never match bankotsar.co.il URLs, so we provide bank-specific conditions.
+ */
+const OTSAR_POSSIBLE_RESULTS = {
+  success: [
+    /online\.bankotsar\.co\.il\/MatafLoginService\/MatafLoginServlet$/, // post-OTP (no query)
+    /bankotsar\.co\.il\/wps\/portal/, // dashboard if navigation goes further
+  ],
+  invalidPassword: [/FibiMenu\/Marketing\/Private\/Home/],
+};
+
+/** Maximum ms to wait for the post-OTP URL to settle before result check. */
+const OTSAR_POST_ACTION_TIMEOUT_MS = 10000;
+
+/**
+ * Wait for the Mataf servlet URL to settle (query params stripped) after OTP.
+ * @param page - The Playwright page to watch.
+ */
+async function otsarPostAction(
+  page: Page,
+): ReturnType<NonNullable<ILoginConfig['postAction']>> {
+  try {
+    await page.waitForURL(/MatafLoginServlet$/, { timeout: OTSAR_POST_ACTION_TIMEOUT_MS });
+  } catch { /* navigation timeout — proceed to result check */ }
+}
+
+/** Scraper for Otsar Hahayal — uses Beinleumi group login flow with a direct login URL. */
 class OtsarHahayalScraper extends BeinleumiGroupBaseScraper {
   /**
-   * Build an OtsarHahayal scraper with Beinleumi group login config.
+   * Build an OtsarHahayal scraper.
    * @param options - Scraper configuration options.
    */
   constructor(options: ScraperOptions) {
-    const otsarUrl = SCRAPER_CONFIGURATION.banks[CompanyTypes.OtsarHahayal].urls.base;
-    const loginConfig = beinleumiConfig(otsarUrl);
+    const loginConfig = {
+      ...beinleumiConfig(OTSAR_LOGIN_URL),
+      // The login servlet is a plain form page — no iframe modal to wait for.
+      preAction: undefined,
+      // The submit button is <input id="continueBtn" type="button"> —
+      // its label comes from the `value` attribute, not innerText,
+      // so text-based selectors don't match it.
+      submit: [
+        { kind: 'css' as const, value: '#continueBtn' },
+        { kind: 'clickableText' as const, value: 'כניסה' },
+      ],
+      postAction: otsarPostAction,
+      possibleResults: OTSAR_POSSIBLE_RESULTS,
+    };
     super(options, loginConfig);
   }
 }

--- a/src/Tests/Unit/OtpHandler.test.ts
+++ b/src/Tests/Unit/OtpHandler.test.ts
@@ -6,6 +6,7 @@ import type { ScraperOptions } from '../../Scrapers/Base/Interface.js';
 
 const MOCK_EXTRACT_PHONE_HINT = jest.fn();
 const MOCK_CLICK_OTP_TRIGGER_IF_PRESENT = jest.fn();
+const MOCK_CLICK_FROM_CANDIDATES = jest.fn();
 const MOCK_DETECT_OTP_SCREEN = jest.fn();
 const MOCK_FILL_INPUT = jest.fn();
 const MOCK_CLICK_BUTTON = jest.fn();
@@ -56,7 +57,7 @@ jest.unstable_mockModule('../../Common/OtpDetector.js', () => ({
   extractPhoneHint: MOCK_EXTRACT_PHONE_HINT,
   clickOtpTriggerIfPresent: MOCK_CLICK_OTP_TRIGGER_IF_PRESENT,
   findOtpSubmitSelector: jest.fn().mockResolvedValue(null),
-  clickFromCandidates: jest.fn().mockResolvedValue(false),
+  clickFromCandidates: MOCK_CLICK_FROM_CANDIDATES,
   OTP_SUBMIT_CANDIDATES: [{ kind: 'xpath' as const, value: '//button[contains(.,"send")]' }],
 }));
 
@@ -121,11 +122,14 @@ function makeOptions(overrides: Partial<ScraperOptions> = {}): ScraperOptions {
 }
 
 describe('handleOtpConfirm', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MOCK_CLICK_FROM_CANDIDATES.mockResolvedValue(false);
+    MOCK_CLICK_OTP_TRIGGER_IF_PRESENT.mockResolvedValue(false);
+  });
 
   it('extracts phone hint and clicks SMS trigger', async () => {
     MOCK_EXTRACT_PHONE_HINT.mockResolvedValue('******5100');
-    MOCK_CLICK_OTP_TRIGGER_IF_PRESENT.mockResolvedValue(undefined);
     const page = makeMockPage();
 
     const hint = await OTP_HANDLER_MOD.handleOtpConfirm(page);
@@ -137,12 +141,35 @@ describe('handleOtpConfirm', () => {
 
   it('returns empty string when no phone hint found', async () => {
     MOCK_EXTRACT_PHONE_HINT.mockResolvedValue('');
-    MOCK_CLICK_OTP_TRIGGER_IF_PRESENT.mockResolvedValue(undefined);
-
     const page = makeMockPage();
+
     const hint = await OTP_HANDLER_MOD.handleOtpConfirm(page);
 
     expect(hint).toBe('');
+  });
+
+  it('skips generic SMS trigger when bank-specific trigger succeeds', async () => {
+    MOCK_EXTRACT_PHONE_HINT.mockResolvedValue('******1234');
+    MOCK_CLICK_FROM_CANDIDATES.mockResolvedValue(true);
+    const page = makeMockPage();
+    const triggerSelectors = [{ kind: 'css' as const, value: '#sendBtn' }];
+
+    await OTP_HANDLER_MOD.handleOtpConfirm(page, undefined, triggerSelectors);
+
+    expect(MOCK_CLICK_FROM_CANDIDATES).toHaveBeenCalledWith(page, triggerSelectors, undefined);
+    expect(MOCK_CLICK_OTP_TRIGGER_IF_PRESENT).not.toHaveBeenCalled();
+  });
+
+  it('falls back to generic SMS trigger when bank-specific trigger fails', async () => {
+    MOCK_EXTRACT_PHONE_HINT.mockResolvedValue('');
+    MOCK_CLICK_FROM_CANDIDATES.mockResolvedValue(false);
+    const page = makeMockPage();
+    const triggerSelectors = [{ kind: 'css' as const, value: '#sendBtn' }];
+
+    await OTP_HANDLER_MOD.handleOtpConfirm(page, undefined, triggerSelectors);
+
+    expect(MOCK_CLICK_FROM_CANDIDATES).toHaveBeenCalled();
+    expect(MOCK_CLICK_OTP_TRIGGER_IF_PRESENT).toHaveBeenCalledWith(page, undefined);
   });
 });
 

--- a/src/Tests/Unit/SelectorResolver.test.ts
+++ b/src/Tests/Unit/SelectorResolver.test.ts
@@ -294,9 +294,16 @@ describe('ariaLabel exact match', () => {
 // ── textContent kind ────────────────────────────────────────────────────────
 
 describe('textContent kind', () => {
-  it('candidateToCss converts textContent to xpath contains', () => {
+  it('candidateToCss converts textContent to xpath contains excluding script/style', () => {
     const css = SELECTOR_MOD.candidateToCss({ kind: 'textContent', value: 'כניסה' });
-    expect(css).toBe('xpath=//*[contains(text(), "כניסה")]');
+    expect(css).toBe('xpath=//*[not(self::script) and not(self::style) and contains(text(), "כניסה")]');
+  });
+
+  it('candidateToCss textContent XPath excludes script elements', () => {
+    const css = SELECTOR_MOD.candidateToCss({ kind: 'textContent', value: 'אישור' });
+    expect(css).toContain('not(self::script)');
+    expect(css).toContain('not(self::style)');
+    expect(css).toContain('contains(text(), "אישור")');
   });
 
   it('tryInContextInternal returns kind:textContent when textContent candidate resolves', async () => {


### PR DESCRIPTION
## Background

OtsarHahayal scraping was completely broken — it never successfully submitted the login form, and even after patching the login step, three more bugs in the shared OTP infrastructure prevented completion. This PR fixes all five bugs, verified end-to-end with a real OtsarHahayal account.

---

## Bug 1 — Login form never submitted (OtsarHahayal-specific)

**Root cause:** The scraper navigated to the bank's main URL (`online.bankotsar.co.il`), where the login form lives inside a dynamically-injected iframe (`id="loginFrame"`). The iframe src is only set when the user clicks a login button on the marketing page — the scraper never triggered that action, so the iframe stayed as `about:blank` and credential fields were never found.

**Fix:** Navigate directly to the Mataf login servlet — the same URL that the iframe would load — where the username/password fields are immediately available on the top-level page. `preAction` (which searched for the iframe) is set to `undefined` since no iframe is needed.

## Bug 2 — Login submit button not clicked (OtsarHahayal-specific)

**Root cause:** OtsarHahayal's submit button is `<input id="continueBtn" type="button" value="כניסה">`. Its label comes from the `value` attribute, not `textContent`/`innerText`, so all text-based selectors (XPath `contains(text(), ...)`, `clickableText`, `textContent`) failed to match it.

**Fix:** Override `submit` in `OtsarHahayalScraper` to include `{ kind: 'css', value: '#continueBtn' }` as the first candidate, falling back to `clickableText: 'כניסה'` for other Mataf-based banks in the group.

## Bug 3 — OTP SMS sent twice (shared infrastructure)

**Root cause:** `handleOtpConfirm` always called both `clickFromCandidates(triggerSelectors)` (bank-specific trigger) **and** `clickOtpTriggerIfPresent` (generic SMS trigger). Since OtsarHahayal's `DOM_OTP.triggerSelectors` contains `"שלח"` and `SMS_TRIGGER_CANDIDATES` also contains `"שלח"`, both resolved the same button — sending two SMS messages and generating two OTP codes, both of which were then expired or invalid.

**Fix:** Capture the return value of `clickFromCandidates`. If the bank-specific trigger succeeded (`true`), skip `clickOtpTriggerIfPresent`. The generic trigger is now a fallback, not always-on.

## Bug 4 — `textContent` XPath matched `<script>` elements (shared infrastructure)

**Root cause:** `candidateToCss` generated `xpath=//*[contains(text(), "אישור")]` for `textContent` candidates, which matches **any** element whose direct text contains the string — including `<script>` tags whose source code contains `"אישור"` as a JavaScript string literal. The OTP submit logic was calling `.click()` on a script node, which did nothing.

**Fix:** Exclude `script` and `style` from the XPath: `xpath=//*[not(self::script) and not(self::style) and contains(text(), ...)]`.

## Bug 5 — Post-OTP login result never matched (OtsarHahayal-specific)

**Root cause:** After OTP acceptance, OtsarHahayal stays on the `MatafLoginServlet` path but drops the `?bankId=OTSARPRTAL&...` query parameters (the SPA transitions to its authenticated state without a full navigation). The inherited Beinleumi-group `possibleResults` only contains patterns for FIBI/FibiMenu URLs (`/fibi.*accountSummary/`, `/FibiMenu\/Online/`), which never match `bankotsar.co.il`. Additionally, the inherited `postAction` waited 30 seconds for Beinleumi-specific dashboard elements that don't exist on OtsarHahayal's UI.

**Fix:** Override both in `OtsarHahayalScraper`:
- `postAction`: wait up to 10s for the URL to settle at `MatafLoginServlet` (no query params) using `page.waitForURL`, then proceed immediately
- `possibleResults.success`: add `/online\.bankotsar\.co\.il\/MatafLoginService\/MatafLoginServlet$/` (post-OTP URL) and `/bankotsar\.co\.il\/wps\/portal/` (dashboard URL)

---

## Additional improvements

- **`OTP_SUBMIT_CANDIDATES`**: Added `input[type="button"][value="אישור"]` and `input[type="submit"][value="אישור"]` as top-priority CSS candidates for banks that use `<input>` submit buttons whose label is in `value=` rather than `textContent`.
- **`INTERACTIVE_FILTER`** (XPath click predicate): Added `div`, `span`, `li` so non-standard clickable elements are matched by the text-click path. OtsarHahayal's SMS send button is a `<span>`.
- **OTP wait timeout**: Increased from 15s to 30s. OtsarHahayal's OTP page appears after the login redirect completes, which takes longer than other banks on the same infrastructure.

## Tests

- `SelectorResolver.test.ts`: Updated the `textContent` XPath assertion to reflect the new script/style exclusion; added a second test asserting both exclusions are present.
- `OtpHandler.test.ts`: Added two regression tests for the double-SMS fix — one asserting that `clickOtpTriggerIfPresent` is **not** called when the bank-specific trigger succeeds, and one asserting it **is** called as a fallback when the bank-specific trigger returns `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Hebrew-language OTP confirmation buttons
  * Extended OTP detection timeout for improved reliability
  * Enhanced OTP confirmation with better fallback handling
  * Improved element selection filtering accuracy

* **Refactor**
  * Optimized OTP detection logic across interactive elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->