### PR TITLE
chore(ci): bump sonarqube-scan-action to v8.0.0 (Node 24)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,7 +64,7 @@ jobs:
           SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Pin `SonarSource/sonarqube-scan-action` to v8.0.0 (commit `59db25f3`), which declares `runs.using: node24`.

## Why
GitHub Actions deprecated Node 20 on 2025-09-19. The previous SHA (v7.0.0, `a31c9398`) targets `node20`; CI forces it onto Node 24 with a deprecation annotation on every PR's SonarCloud Scan job.

## Scope
- **1 file changed**, +1 / −1 line.

## Test plan
- [x] `curl https://raw.githubusercontent.com/SonarSource/sonarqube-scan-action/v8.0.0/action.yml | grep using` → `node24` confirmed.
- [x] Same action surface — no SonarCloud project setting changes required.
- [x] CI's SonarCloud Scan job will run against this PR; deprecation annotation should be absent post-merge.

## Self-review checklist
- [x] SHA verified against upstream tag
- [x] Single-line edit; one purpose