### PR TITLE
test(home): deduplicate click-rejection cases (M3.5)

### DIFF
--- a/src/Tests/Unit/Pipeline/Mediator/Home/ExecuteModalClick.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Home/ExecuteModalClick.test.ts
@@ -85,6 +85,62 @@ function makeExecutor(): {
   return { executor, calls };
 }
 
+/**
+ * Stage-isolation regression: live E2E showed Hapoalim/Amex/Isracard
+ * crash mid-HOME.ACTION when Playwright's locator.click throws on a
+ * 15s timeout (CDN slow under 6-bank parallel load). The handler
+ * must absorb clickElement rejection the same way MODAL does — let
+ * settleAfterClick + POST decide success via URL change. Both DIRECT
+ * and SEQUENTIAL exercise the same `.catch` path; deduplicated via
+ * `it.each` per the project's table-driven test convention
+ * (LoginFactoryTest, OtpFillFactoryTest, AuthDiscoveryFactoryTest).
+ */
+interface IRejectionStrategyCase {
+  readonly strategy: 'DIRECT' | 'SEQUENTIAL';
+  readonly label: 'DIRECT' | 'SEQUENTIAL';
+}
+
+const REJECTION_STRATEGY_CASES: readonly IRejectionStrategyCase[] = [
+  { strategy: 'DIRECT', label: 'DIRECT' },
+  { strategy: 'SEQUENTIAL', label: 'SEQUENTIAL' },
+];
+
+/**
+ * Build an executor whose `clickElement` rejects with a Playwright
+ * timeout signature; URL never changes; waits resolve cleanly.
+ * Shared between the DIRECT and SEQUENTIAL rejection cases.
+ *
+ * @param stableUrl - URL the executor reports throughout the run.
+ * @returns Action mediator stub matching `IActionMediator`.
+ */
+function makeRejectingClickExecutor(stableUrl: string): IActionMediator {
+  return {
+    /**
+     * URL never changes — click never lands navigation.
+     * @returns Stable URL.
+     */
+    getCurrentUrl: (): string => stableUrl,
+    /**
+     * Reject with the Playwright click() timeout signature.
+     * @returns Rejected promise.
+     */
+    clickElement: (): Promise<never> =>
+      Promise.reject(new Error('locator.click: Timeout 15000ms exceeded')),
+    /**
+     * Idle resolves succeed; settleAfterClick still runs.
+     * @returns Resolved succeed(true).
+     */
+    waitForNetworkIdle: (): Promise<{ success: true; value: boolean }> =>
+      Promise.resolve({ success: true, value: true }),
+    /**
+     * URL wait resolves false (no navigation occurred).
+     * @returns Resolved succeed(false).
+     */
+    waitForURL: (): Promise<{ success: true; value: boolean }> =>
+      Promise.resolve({ success: true, value: false }),
+  } as unknown as IActionMediator;
+}
+
 describe('tryClickLoginLink (Phase 7 backfill)', () => {
   it('delegates resolveAndClick to the mediator', async () => {
     const calls: string[] = [];
@@ -254,81 +310,18 @@ describe('executeModalClick (Phase 7 backfill)', () => {
     expect(didNavigate).toBe(true);
   });
 
-  it('executeHomeNavigation: DIRECT clickElement rejection resolves false (no unhandled crash)', async () => {
-    // Stage-isolation regression: live E2E showed Hapoalim/Amex/Isracard
-    // crash mid-HOME.ACTION when Playwright's locator.click throws on a
-    // 15s timeout (CDN slow under 6-bank parallel load). The handler
-    // must absorb clickElement rejection the same way MODAL does — let
-    // settleAfterClick + POST decide success via URL change.
-    const stableUrl = 'https://bank.example.com/home';
-    const rejectingClickExecutor = {
-      /**
-       * URL never changes — click never completed.
-       * @returns Stable URL.
-       */
-      getCurrentUrl: (): string => stableUrl,
-      /**
-       * Reject to simulate Playwright click() timeout under CDN slowness.
-       * @returns Rejected promise.
-       */
-      clickElement: (): Promise<never> =>
-        Promise.reject(new Error('locator.click: Timeout 15000ms exceeded')),
-      /**
-       * Idle still resolves; settleAfterClick must run.
-       * @returns Resolved succeed.
-       */
-      waitForNetworkIdle: (): Promise<{ success: true; value: boolean }> =>
-        Promise.resolve({ success: true, value: true }),
-      /**
-       * URL wait resolves false (URL didn't change).
-       * @returns Resolved succeed(false).
-       */
-      waitForURL: (): Promise<{ success: true; value: boolean }> =>
-        Promise.resolve({ success: true, value: false }),
-    } as unknown as IActionMediator;
-    const discovery = {
-      strategy: 'DIRECT' as const,
-      triggerTarget: { contextId: 'main', selector: 'a[href="/login"]' },
-    } as unknown as Parameters<typeof executeHomeNavigation>[1];
-    const didNavigate = await executeHomeNavigation(rejectingClickExecutor, discovery, NOOP_LOGGER);
-    expect(didNavigate).toBe(false);
-  });
-
-  it('executeHomeNavigation: SEQUENTIAL clickElement rejection resolves false (no unhandled crash)', async () => {
-    // Same stage-isolation regression for SEQUENTIAL banks.
-    const stableUrl = 'https://bank.example.com/home';
-    const rejectingClickExecutor = {
-      /**
-       * Stable URL — click never lands navigation.
-       * @returns Stable URL.
-       */
-      getCurrentUrl: (): string => stableUrl,
-      /**
-       * Reject with Playwright timeout signature.
-       * @returns Rejected promise.
-       */
-      clickElement: (): Promise<never> =>
-        Promise.reject(new Error('locator.click: Timeout 15000ms exceeded')),
-      /**
-       * Idle resolves succeed; settleAfterClick must run.
-       * @returns Resolved succeed(true).
-       */
-      waitForNetworkIdle: (): Promise<{ success: true; value: boolean }> =>
-        Promise.resolve({ success: true, value: true }),
-      /**
-       * URL wait resolves false (no navigation).
-       * @returns Resolved succeed(false).
-       */
-      waitForURL: (): Promise<{ success: true; value: boolean }> =>
-        Promise.resolve({ success: true, value: false }),
-    } as unknown as IActionMediator;
-    const discovery = {
-      strategy: 'SEQUENTIAL' as const,
-      triggerTarget: { contextId: 'main', selector: 'a[href="/login"]' },
-    } as unknown as Parameters<typeof executeHomeNavigation>[1];
-    const didNavigate = await executeHomeNavigation(rejectingClickExecutor, discovery, NOOP_LOGGER);
-    expect(didNavigate).toBe(false);
-  });
+  it.each(REJECTION_STRATEGY_CASES)(
+    'executeHomeNavigation: $label clickElement rejection resolves false (no unhandled crash)',
+    async ({ strategy }) => {
+      const executor = makeRejectingClickExecutor('https://bank.example.com/home');
+      const discovery = {
+        strategy,
+        triggerTarget: { contextId: 'main', selector: 'a[href="/login"]' },
+      } as unknown as Parameters<typeof executeHomeNavigation>[1];
+      const didNavigate = await executeHomeNavigation(executor, discovery, NOOP_LOGGER);
+      expect(didNavigate).toBe(false);
+    },
+  );
 
   it('executeStoreLoginSignal: stamps loginUrl into diagnostics', async () => {
     // Coverage backfill — Phase 7 squeezed margins so this exported


### PR DESCRIPTION
## Summary

PR #218 review feedback: two `it()` blocks in `ExecuteModalClick.test.ts` asserting DIRECT and SEQUENTIAL `clickElement`-rejection paths through `executeHomeNavigation` were 99% identical except for the `strategy` literal. This PR converts them to a single `it.each(REJECTION_STRATEGY_CASES)` driven by one shared `makeRejectingClickExecutor()` factory at file scope, aligning with the project's table-driven test convention already used by `LoginFactoryTest`, `OtpFillFactoryTest`, and `AuthDiscoveryFactoryTest`.

This is mission **M3.5** of the `ci-quality-hardening` plan — a NANO follow-up that closes review feedback before the larger TIMING mission lands.

## What changed

- `src/Tests/Unit/Pipeline/Mediator/Home/ExecuteModalClick.test.ts` — 2 near-duplicate `it()` blocks (DIRECT + SEQUENTIAL) replaced by 1 `it.each(REJECTION_STRATEGY_CASES)` over a 2-row case array. The `makeRejectingClickExecutor(stableUrl)` factory and `IRejectionStrategyCase` interface live at file scope (per SonarQube `S7721` — outer-scope rule).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint src/Tests/Unit/Pipeline/Mediator/Home/ExecuteModalClick.test.ts --max-warnings 0` — 0 errors
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPatterns=ExecuteModalClick` — 12/12 pass (same count as before; `it.each` produces 2 cases that replace the 2 deleted)
- [x] Pre-commit gate ladder all 5 phases green — Phase 1 Prettier, Phase 2 static analysis (tsc/eslint/biome/audit/architecture/build/canaries), Phase 3 test:pipeline + bank tests, Phase 4 mock + e2e:mock + factory, Phase 5 live E2E 6/6 banks in 616s wall

## Build safety

- Test-only refactor; zero production-code change.
- Coverage delta zero on `executeHomeNavigation`: same DIRECT and SEQUENTIAL `isSeq` branches in `settleAfterClick` are exercised; per-case names visible in jest output (`executeHomeNavigation: DIRECT clickElement rejection resolves false (no unhandled crash)` and `executeHomeNavigation: SEQUENTIAL clickElement rejection resolves false (no unhandled crash)`).
- Net delta: -7 lines (+68 / -75) — same coverage with less drift surface.

## Self-review checklist

- [x] One mission per commit (M3.5 only; no scope creep)
- [x] No `--no-verify`; pre-commit gate ladder ran all 5 phases including Phase 5 live E2E
- [x] Conventional Commits header (50 chars exact); body lines ≤ 72 chars; imperative mood; explains WHY
- [x] PII-free commit message and PR body
- [x] `it.each` typed via explicit `IRejectionStrategyCase` interface to satisfy strict-mode `noImplicitAny`
- [x] Factory hoisted to outer scope per SonarQube `S7721`
- [x] No console.log, debugger, or commented-out code in the diff

## Plan traceability

Closes M3.5 per `C:/tmp/plans/ci-quality-hardening/plan.txt` ADDENDUM (2026-05-09 23:55). Next mission per topological-ordering rule C-10 amended: **TIMING** (cut per-bank live E2E to ≤ 3 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)