### PR TITLE
chore(quality): SonarCloud cycles 1-2 + Amex/Hapoalim Cloudflare/hCaptcha cycle 3

### DIFF
--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -5,6 +5,17 @@ inputs:
   gh-token:
     description: GitHub token for authenticated release download fallback
     required: true
+  bank:
+    description: >-
+      Bank identifier (e.g. `amex`, `max`). When set AND the workflow
+      enables `USE_PERSISTENT_PROFILES=true` for the test step, the
+      per-bank Camoufox profile directory is restored from / saved to
+      the GH Actions cache so cookies + LocalStorage + IndexedDB carry
+      across runs (improves Cloudflare scoring + bank-side device
+      recognition). Empty input → no profile cache step runs and the
+      legacy fresh-profile-per-launch flow is preserved.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -25,6 +36,14 @@ runs:
         key: camoufox-v135.0.1-beta.24
         restore-keys: |
           camoufox-
+    - name: Cache per-bank persistent profile
+      if: ${{ inputs.bank != '' }}
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: ~/.cache/isbs/profiles/${{ inputs.bank }}
+        key: profile-${{ inputs.bank }}-${{ runner.os }}-v1
+        restore-keys: |
+          profile-${{ inputs.bank }}-${{ runner.os }}-
     - name: Install Camoufox browser
       shell: bash
       env:

--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -9,6 +9,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: 'Install Xvfb (backs Camoufox virtual headless mode)'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v Xvfb >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb
+        fi
+        Xvfb -version 2>&1 | head -n 1 || true
     - name: Cache Camoufox browser
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:

--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -21,6 +21,7 @@ runs:
   using: composite
   steps:
     - name: 'Install Xvfb (backs Camoufox virtual headless mode)'
+      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -28,7 +28,11 @@ runs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xvfb
         fi
-        Xvfb -version 2>&1 | head -n 1 || true
+        # `Xvfb -version` does not exist (X.Org never adopted GNU
+        # --version); report the installed package version via dpkg
+        # so the CI log shows a clean line instead of the misleading
+        # "Unrecognized option: -version" stderr from the binary.
+        dpkg-query -W -f='${Package} ${Version}\n' xvfb || true
     - name: Cache Camoufox browser
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:

--- a/.github/scripts/sonar-scan.mjs
+++ b/.github/scripts/sonar-scan.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform wrapper around the SonarScanner CLI.
+ *
+ * Wraps the `sonar-scanner` binary so `npm run sonar:scan` works on
+ * Windows cmd.exe in addition to POSIX shells. The package.json script
+ * previously used POSIX `${SONAR_TOKEN}` expansion which fails on
+ * Windows cmd.exe (cmd.exe needs `%SONAR_TOKEN%`). Reading the env
+ * var in Node and forwarding it as a CLI flag sidesteps the
+ * shell-syntax mismatch entirely. CodeRabbit finding on PR #235.
+ *
+ * The pre-commit hook (`.husky/pre-commit`) runs the scanner
+ * directly under bash — it does NOT go through this wrapper — so
+ * the path here is reserved for the explicit `npm run sonar:scan`
+ * developer invocation.
+ */
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+const token = process.env.SONAR_TOKEN;
+if (!token) {
+  process.stderr.write(
+    'SONAR_TOKEN is not set. Source .env or export the variable in your shell.\n',
+  );
+  process.exit(1);
+}
+
+const result = spawnSync('sonar-scanner', [`-Dsonar.token=${token}`], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+if (result.error) {
+  process.stderr.write(
+    `sonar-scanner not found on PATH. Install via 'scoop install sonar-scanner' (Windows) or the official tarball.\n`,
+  );
+  process.exit(127);
+}
+
+process.exit(result.status ?? 1);

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Persistent Camoufox profiles — defensive guard in case a misconfigured
+# `getProfileDir` ever resolves to a repo-relative path. The canonical
+# location is `~/.cache/isbs/profiles/<bank>/` (outside the repo);
+# nothing in production code writes inside the working tree.
+.profiles/
+**/.profiles/
+
 
 # Runtime data
 pids

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -246,7 +246,12 @@ run-sonar-scan() {
         # of .env (avoids the `. ./.env` arbitrary-code-execution path
         # that prints `command not found` on any non-KEY=VALUE line).
         # Tolerates surrounding double or single quotes on the value.
+        # `tr -d '\r'` strips the trailing CR that Windows-style line
+        # endings introduce so `s/['"]$//` actually matches the quote
+        # (CodeRabbit finding on PR #235 — without this, SONAR_TOKEN
+        # ends with a stray `"` and auth fails).
         SONAR_TOKEN=$(grep -E '^[[:space:]]*SONAR_TOKEN=' .env | head -1 \
+            | tr -d '\r' \
             | sed -E "s/^[[:space:]]*SONAR_TOKEN=//; s/^['\"]//; s/['\"]$//")
         [ -n "$SONAR_TOKEN" ] && export SONAR_TOKEN
     fi
@@ -262,8 +267,20 @@ run-sonar-scan() {
         return 0
     fi
     log ""
-    log "🟦 Phase 6: SonarCloud scan (180s timeout, fire-and-forget)"
-    timeout 180 sonar-scanner -Dsonar.token="$SONAR_TOKEN" 2>&1 | tee -a "$LOG_FILE"
+    log "🟦 Phase 6: SonarCloud scan (fire-and-forget)"
+    # `timeout` is GNU coreutils — not guaranteed on macOS without
+    # `brew install coreutils`. CodeRabbit finding on PR #235: without
+    # this guard, the missing binary returns exit 127, which the
+    # PIPESTATUS check then misreports as "sonar-scanner exited
+    # non-zero". When `timeout` is absent we run the scanner with no
+    # hard cap and log a notice so the dev knows to expect a longer
+    # run.
+    if command -v timeout > /dev/null 2>&1; then
+        timeout 180 sonar-scanner -Dsonar.token="$SONAR_TOKEN" 2>&1 | tee -a "$LOG_FILE"
+    else
+        log "   (note: 'timeout' binary not on PATH; running without 180s cap)"
+        sonar-scanner -Dsonar.token="$SONAR_TOKEN" 2>&1 | tee -a "$LOG_FILE"
+    fi
     if [ "${PIPESTATUS[0]}" -ne 0 ]; then
         log "⚠️  sonar-scanner exited non-zero — analysis upload may have failed"
         log "   CI's SonarCloud Scan job remains authoritative; commit proceeds."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -242,10 +242,13 @@ run-sonar-scan() {
         return 0
     fi
     if [ -z "${SONAR_TOKEN:-}" ] && [ -f .env ]; then
-        set -a
-        # shellcheck disable=SC1091
-        . ./.env
-        set +a
+        # Extract only the SONAR_TOKEN= line and never execute the rest
+        # of .env (avoids the `. ./.env` arbitrary-code-execution path
+        # that prints `command not found` on any non-KEY=VALUE line).
+        # Tolerates surrounding double or single quotes on the value.
+        SONAR_TOKEN=$(grep -E '^[[:space:]]*SONAR_TOKEN=' .env | head -1 \
+            | sed -E "s/^[[:space:]]*SONAR_TOKEN=//; s/^['\"]//; s/['\"]$//")
+        [ -n "$SONAR_TOKEN" ] && export SONAR_TOKEN
     fi
     if [ -z "${SONAR_TOKEN:-}" ]; then
         log ""

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -160,6 +160,34 @@ fi
 bg_gate "build"             "yes" bash -c 'npm run build && npx rimraf lib/Common lib/Scrapers lib/Tests && test -f lib/index.cjs'
 bg_gate "canaries"          "yes" npm run lint:canaries
 
+# ── Dockerfile + shell-script gates ───────────────────────────────────
+# Locks the CodeRabbit F6 (Dockerfile inline-comment trap) and F7
+# (hardcoded /c/tmp path in shell script) regression class. Soft-skip
+# with install instructions when the tool is missing (mirrors the
+# sonar-scanner pattern) — fail-loud enforcement lives in the
+# pr-reviewer agent's observe.sh, which the pre-push hook calls.
+STAGED_DOCKERFILES=$(echo "$STAGED_FILES" | grep -E '(^|/)Dockerfile($|\.[^/]+$)' || true)
+# Match .sh files AND husky hook scripts (which are bash but have no
+# extension — pre-commit, pre-push, commit-msg, etc.). Exclude the
+# husky-managed `_/` shim directory.
+STAGED_SHELLSCRIPTS=$(echo "$STAGED_FILES" | grep -E '\.sh$|^\.husky/[^_/][^/]*$' || true)
+
+if [ -n "$STAGED_DOCKERFILES" ]; then
+    if command -v hadolint >/dev/null 2>&1; then
+        bg_gate "hadolint" "yes" bash -c "echo \"$STAGED_DOCKERFILES\" | xargs -r hadolint"
+    else
+        log "⏭️  hadolint not on PATH — skipping Dockerfile lint. Install: scoop install hadolint / brew install hadolint"
+    fi
+fi
+
+if [ -n "$STAGED_SHELLSCRIPTS" ]; then
+    if command -v shellcheck >/dev/null 2>&1; then
+        bg_gate "shellcheck" "yes" bash -c "echo \"$STAGED_SHELLSCRIPTS\" | xargs -r shellcheck"
+    else
+        log "⏭️  shellcheck not on PATH — skipping shell-script lint. Install: scoop install shellcheck / brew install shellcheck / apt install shellcheck"
+    fi
+fi
+
 # Heavy gates — each runs Jest with its own worker pool. Capping each
 # pool to 2 workers keeps total concurrency on an 8-core box manageable
 # (≈ 5 gates × 2 workers + 7 light static gates ≈ within budget).

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -225,7 +225,52 @@ fi
 #     fi
 # fi
 
-# # ── Phase 5: Live E2E (real banks, FINAL gate) ──
+# ── Phase 5: SonarCloud scan (fire-and-forget upload) ────────────────────
+# Runs sonar-scanner when both conditions hold:
+#   1. SONAR_TOKEN is in env (CI provides it; locally we source .env).
+#   2. The `sonar-scanner` CLI binary is on PATH.
+# Otherwise skips silently. Intentionally fire-and-forget — quality-gate
+# enforcement is owned by the CI's SonarCloud Scan job (which has
+# `sonar.qualitygate.wait=true` in sonar-project.properties). This local
+# gate's value is the early-warning scanner output during commit; not a
+# hard blocker for commit. Override with SKIP_SONAR_GATE=1 to bypass even
+# when the prerequisites are met.
+run-sonar-scan() {
+    if [ -n "${SKIP_SONAR_GATE:-}" ]; then
+        log ""
+        log "⏭️  Phase 6: sonar-scanner — bypassed via SKIP_SONAR_GATE=1"
+        return 0
+    fi
+    if [ -z "${SONAR_TOKEN:-}" ] && [ -f .env ]; then
+        set -a
+        # shellcheck disable=SC1091
+        . ./.env
+        set +a
+    fi
+    if [ -z "${SONAR_TOKEN:-}" ]; then
+        log ""
+        log "⏭️  Phase 6: sonar-scanner — SONAR_TOKEN not set, skipping"
+        return 0
+    fi
+    if ! command -v sonar-scanner > /dev/null 2>&1; then
+        log ""
+        log "⏭️  Phase 6: sonar-scanner — binary not on PATH, skipping"
+        log "   (install via https://docs.sonarsource.com/sonarqube-cloud/instance-administration/analysis-functions/scanners/sonarscanner/ or 'scoop install sonar-scanner')"
+        return 0
+    fi
+    log ""
+    log "🟦 Phase 6: SonarCloud scan (180s timeout, fire-and-forget)"
+    timeout 180 sonar-scanner -Dsonar.token="$SONAR_TOKEN" 2>&1 | tee -a "$LOG_FILE"
+    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+        log "⚠️  sonar-scanner exited non-zero — analysis upload may have failed"
+        log "   CI's SonarCloud Scan job remains authoritative; commit proceeds."
+    else
+        log "✅ Phase 6: SonarCloud analysis uploaded — check sonarcloud.io for the gate result"
+    fi
+}
+run-sonar-scan
+
+# # ── Phase 6: Live E2E (real banks, FINAL gate) ──
 # # This is the last gate — if it passes, the commit proceeds.
 # # Routes through `scripts/run-real-suite.ts` (gitignored, operator-
 # # controlled bank list — typically OneZero + Beinleumi for local

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# pre-push: invoke the out-of-repo pr-reviewer agent (Phase O: Observe +
+# Orient) before allowing a push. Fails loud if shellcheck / hadolint are
+# missing or if any new deterministic-gate finding is detected on the
+# diff since origin/<base-branch>.
+#
+# The agent code lives at C:/tmp/agents/pr-reviewer/ so it can be reused
+# across worktrees and forks without duplicating it into every repo.
+set -o pipefail
+
+AGENT_HOME="${PR_REVIEWER_HOME:-/c/tmp/agents/pr-reviewer}"
+OBSERVE="${AGENT_HOME}/lib/observe.sh"
+ORIENT="${AGENT_HOME}/lib/orient.sh"
+
+if [ ! -x "$OBSERVE" ] || [ ! -x "$ORIENT" ]; then
+    cat <<EOF >&2
+ERROR: pr-reviewer agent not found at ${AGENT_HOME}.
+Install:
+  git clone <internal-mirror> ${AGENT_HOME}
+  chmod +x ${AGENT_HOME}/lib/*.sh
+Or override the location via PR_REVIEWER_HOME=/path/to/pr-reviewer.
+Push aborted — bypass with: SKIP_PR_REVIEWER=1 git push (DISCOURAGED).
+EOF
+    [ "${SKIP_PR_REVIEWER:-0}" = "1" ] && exit 0
+    exit 1
+fi
+
+# Resolve the PR id from the current branch (open PR head ref). When the
+# branch has no open PR yet (first push), use the branch name as the
+# scratch dir key so artifacts don't collide with later runs.
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PRID=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+if [ -z "$PRID" ] || [ "$PRID" = "null" ]; then
+    PRID="prebranch-${BRANCH//\//_}"
+fi
+
+echo "🔍 pr-reviewer: Observe + Orient against PR $PRID..."
+if ! bash "$OBSERVE" "$PRID"; then
+    echo "❌ pr-reviewer Observe failed — push aborted." >&2
+    exit 1
+fi
+if ! bash "$ORIENT" "$PRID"; then
+    echo "❌ pr-reviewer Orient flagged blocking findings — push aborted." >&2
+    echo "   See: /c/tmp/pr/${PRID}/orient-*.md for details." >&2
+    echo "   Re-run interactively via: /pr-review" >&2
+    exit 1
+fi
+echo "✅ pr-reviewer: no blocking findings."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,6 +8,15 @@
 # across worktrees and forks without duplicating it into every repo.
 set -o pipefail
 
+# Global bypass: SKIP_PR_REVIEWER=1 short-circuits the entire hook.
+# Reserved for emergencies (broken upstream tools, first-push
+# bootstrap on a fresh machine, force-fix landings). Use sparingly —
+# CI still runs the deterministic gates.
+if [ "${SKIP_PR_REVIEWER:-0}" = "1" ]; then
+    echo "⏭️  pr-reviewer: bypassed via SKIP_PR_REVIEWER=1"
+    exit 0
+fi
+
 AGENT_HOME="${PR_REVIEWER_HOME:-/c/tmp/agents/pr-reviewer}"
 OBSERVE="${AGENT_HOME}/lib/observe.sh"
 ORIENT="${AGENT_HOME}/lib/orient.sh"
@@ -21,7 +30,6 @@ Install:
 Or override the location via PR_REVIEWER_HOME=/path/to/pr-reviewer.
 Push aborted — bypass with: SKIP_PR_REVIEWER=1 git push (DISCOURAGED).
 EOF
-    [ "${SKIP_PR_REVIEWER:-0}" = "1" ] && exit 0
     exit 1
 fi
 

--- a/docker/Dockerfile.ci-mirror
+++ b/docker/Dockerfile.ci-mirror
@@ -24,6 +24,15 @@ ARG CAMOUFOX_VERSION=v135.0.1-beta.24
 # Mirror the apt set that the GitHub `ubuntu-24.04` runner image carries
 # that Camoufox / Firefox needs at runtime. Source list cross-checked
 # against `actions/runner-images` Ubuntu2404-Readme.md.
+#
+# Package roles (kept as Dockerfile comments rather than inline shell
+# comments — `\<newline>` joins continuation lines BEFORE bash comment
+# processing, so an inline `#` silently consumes everything after it
+# on the joined logical line):
+#   * xvfb — backs Camoufox's `headless: "virtual"` mode so the
+#     browser exposes a real display instead of true-headless
+#     detection signals (Cloudflare scoring relies on this).
+#   * wget — required by the gh CLI fallback download path below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl git unzip xz-utils gnupg \
         libgtk-3-0t64 libgbm1 libxt6 libdbus-glib-1-2 \
@@ -31,11 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libpangocairo-1.0-0 libatk1.0-0t64 libatk-bridge2.0-0t64 \
         libcups2t64 libxcomposite1 libxdamage1 libxkbcommon0 \
         fonts-liberation libdrm2 libxshmfence1 \
-        # xvfb: backs Camoufox's `headless: "virtual"` mode so the
-        # browser exposes a real display instead of true-headless
-        # detection signals (Cloudflare scoring relies on this).
         xvfb \
-        # gh CLI for Camoufox fallback download path
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.ci-mirror
+++ b/docker/Dockerfile.ci-mirror
@@ -31,6 +31,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libpangocairo-1.0-0 libatk1.0-0t64 libatk-bridge2.0-0t64 \
         libcups2t64 libxcomposite1 libxdamage1 libxkbcommon0 \
         fonts-liberation libdrm2 libxshmfence1 \
+        # xvfb: backs Camoufox's `headless: "virtual"` mode so the
+        # browser exposes a real display instead of true-headless
+        # detection signals (Cloudflare scoring relies on this).
+        xvfb \
         # gh CLI for Camoufox fallback download path
         wget \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/run-banks.sh
+++ b/docker/run-banks.sh
@@ -120,12 +120,21 @@ run_one_bank() {
     # saw all 8 parallel banks fail with `Server Not Found` on the
     # bank URL — Docker Desktop's DNS was saturated. Google + Cloudflare
     # public resolvers are intentionally redundant.
+    # NOTE: We deliberately do NOT pass `--env-file` here. Docker's
+    # env-file parser is bug-compatible with shell `source` — it does
+    # NOT strip `"..."` wrapping quotes. dotenv DOES strip them. So
+    # values like `MAX_PASSWORD="..."` (wrapped to escape the `#`
+    # comment char in dotenv) leak the literal quotes into the
+    # container env, which then get typed into bank login fields
+    # with `maxlength` limits, truncating the trailing quote and
+    # submitting an off-by-one password. Instead we rely on each
+    # test's `dotenv.config()` to load + correctly strip quotes
+    # from the mounted `/work/.env`.
     MSYS_NO_PATHCONV=1 docker run --rm \
     --name "isbs-ci-${bank,,}" \
     --dns=8.8.8.8 --dns=1.1.1.1 \
     -v "${REPO_ROOT_DOCKER}:/work" \
     -w /work \
-    --env-file "$ENV_FILE_DOCKER" \
     -e CI=true \
     -e LOG_LEVEL=trace \
     -e RUNS_ROOT=/tmp/runs \

--- a/docker/run-banks.sh
+++ b/docker/run-banks.sh
@@ -121,9 +121,15 @@ run_one_bank() {
     # bank URL — Docker Desktop's DNS was saturated. Google + Cloudflare
     # public resolvers are intentionally redundant.
     # Host-side artifact dir — pipeline.log + screenshots + network
-    # captures from the in-container run land at `C:/tmp/runs/docker/`
-    # so the host can inspect them after the container exits.
-    local RUNS_HOST_POSIX="/c/tmp/runs/docker"
+    # captures from the in-container run land here so the host can
+    # inspect them after the container exits. Resolution priority:
+    #   1. `$ISBS_DOCKER_RUNS_DIR` env override (developer choice).
+    #   2. `${TMPDIR}/isbs-runs/docker` on Linux / macOS.
+    #   3. `${TEMP}/isbs-runs/docker` on git-bash on Windows (Windows
+    #      sets `TEMP`, not `TMPDIR`).
+    #   4. `/tmp/isbs-runs/docker` last-resort POSIX default.
+    local DEFAULT_RUNS_HOST="${TMPDIR:-${TEMP:-/tmp}}/isbs-runs/docker"
+    local RUNS_HOST_POSIX="${ISBS_DOCKER_RUNS_DIR:-$DEFAULT_RUNS_HOST}"
     mkdir -p "$RUNS_HOST_POSIX"
     local RUNS_HOST_DOCKER
     if command -v cygpath >/dev/null 2>&1; then

--- a/docker/run-banks.sh
+++ b/docker/run-banks.sh
@@ -120,24 +120,39 @@ run_one_bank() {
     # saw all 8 parallel banks fail with `Server Not Found` on the
     # bank URL — Docker Desktop's DNS was saturated. Google + Cloudflare
     # public resolvers are intentionally redundant.
+    # Host-side artifact dir — pipeline.log + screenshots + network
+    # captures from the in-container run land at `C:/tmp/runs/docker/`
+    # so the host can inspect them after the container exits.
+    local RUNS_HOST_POSIX="/c/tmp/runs/docker"
+    mkdir -p "$RUNS_HOST_POSIX"
+    local RUNS_HOST_DOCKER
+    if command -v cygpath >/dev/null 2>&1; then
+        RUNS_HOST_DOCKER=$(cygpath -w "$RUNS_HOST_POSIX")
+    else
+        RUNS_HOST_DOCKER="$RUNS_HOST_POSIX"
+    fi
     # NOTE: We deliberately do NOT pass `--env-file` here. Docker's
     # env-file parser is bug-compatible with shell `source` — it does
     # NOT strip `"..."` wrapping quotes. dotenv DOES strip them. So
-    # values like `MAX_PASSWORD="..."` (wrapped to escape the `#`
-    # comment char in dotenv) leak the literal quotes into the
-    # container env, which then get typed into bank login fields
-    # with `maxlength` limits, truncating the trailing quote and
-    # submitting an off-by-one password. Instead we rely on each
-    # test's `dotenv.config()` to load + correctly strip quotes
-    # from the mounted `/work/.env`.
+    # values like `MAX_PASSWORD="8d@$wm2#*^9X!"` (wrapped to escape
+    # the `#` comment char in dotenv) would leak the literal quotes
+    # into the container env, which then get typed into bank login
+    # fields with `maxlength` limits, truncating the trailing quote
+    # and submitting an off-by-one password. Instead we mount the
+    # repo (which already includes `.env`) and rely on each test's
+    # `dotenv.config()` to load + correctly strip quotes from `.env`.
     MSYS_NO_PATHCONV=1 docker run --rm \
     --name "isbs-ci-${bank,,}" \
     --dns=8.8.8.8 --dns=1.1.1.1 \
     -v "${REPO_ROOT_DOCKER}:/work" \
+    -v "${RUNS_HOST_DOCKER}:/tmp/runs" \
     -w /work \
     -e CI=true \
     -e LOG_LEVEL=trace \
     -e RUNS_ROOT=/tmp/runs \
+    -e CAMOUFOX_HUMANIZE="${CAMOUFOX_HUMANIZE:-true}" \
+    -e CAMOUFOX_DISABLE_COOP="${CAMOUFOX_DISABLE_COOP:-true}" \
+    -e CAMOUFOX_VIRTUAL_HEADLESS="${CAMOUFOX_VIRTUAL_HEADLESS:-true}" \
     "$IMAGE" \
     node --experimental-vm-modules node_modules/jest/bin/jest.js \
     --ci \

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -185,6 +185,18 @@ const RESTRICTED_SYNTAX_RULES = [
     message:
       '🚫 PII LEAK (T16): Identifier with payload-shape name passed as LOG value. Pre-redact via PiiRedactor or pass scalar.',
   },
+
+  // T17: Pseudorandom number generator safety (SonarCloud S2245 /
+  // typescript:S2245). `Math.random()` is a PRNG, not a CSPRNG —
+  // attackers can predict its output. The project blocks all uses
+  // and only allows `node:crypto.randomBytes()`, `randomInt()`,
+  // `randomUUID()`. Reference:
+  // https://docs.sonarsource.com/sonarcloud/javascript/rules/S2245
+  {
+    selector: "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+    message:
+      "🚫 SECURITY (S2245): Math.random() is forbidden. Use node:crypto's randomBytes(), randomInt(), or randomUUID() — see SECURITY.md / cycle-3 humanize commit.",
+  },
 ];
 
 const RESTRICTED_SYNTAX_RULES_NEW = [
@@ -456,6 +468,13 @@ const RESTRICTED_SYNTAX_RULES_NEW = [
       "CallExpression[callee.object.name='LOG'][callee.property.name=/^(trace|debug|info|warn|error|fatal)$/] ObjectExpression > Property[value.type='Identifier'][value.name=/^(scrapeOutput|rawTxn|rawAccount|rawAccounts|rawTxns|fullAccounts|allTxns|accountsArr|txnsArr)$/]",
     message:
       '🚫 PII LEAK (T16): Identifier with payload-shape name passed as LOG value. Pre-redact via PiiRedactor or pass scalar.',
+  },
+  // Mirror of the legacy-rules T17 — Math.random() forbidden everywhere
+  // in the Pipeline scope too. See RESTRICTED_SYNTAX_RULES.T17 comment.
+  {
+    selector: "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+    message:
+      "🚫 SECURITY (S2245): Math.random() is forbidden. Use node:crypto's randomBytes(), randomInt(), or randomUUID().",
   },
 ];
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1017,34 +1017,20 @@ export default tseslint.config(
     },
   },
 
-  // 12. ARCHITECTURE-RULE EXCEPTION — files where the project's
-  //     `no-restricted-syntax` rule (banning bare `unknown` in function
-  //     signatures) forces a `type X = unknown;` alias that SonarJS
-  //     S6564 then flags as redundant. The architecture rule wins;
-  //     this override silences S6564 locally to keep
-  //     `eslint --max-warnings 0` green.
+  // 12. ARCHITECTURE-RULE EXCEPTION — single remaining `type X = string;`
+  //     alias deferred to a follow-up commit (ContextId branding).
+  //     Once C.5.T3 lands the brand + 37 test-fixture casts, this whole
+  //     block CAN AND MUST be deleted — the `sonarjs/redundant-type-aliases`
+  //     rule must be active for the entire codebase so any future
+  //     `type X = unknown;` workaround pattern fails lint at edit time.
   //
-  //     `LoginPhaseActions.ts` removed from this list 2026-05-18 —
-  //     its `FormAnchorSelector = string` alias was deleted (Rule #15
-  //     applied to class methods only, not the free function the
-  //     alias was wrapping).
-  //
-  //     `PipelineContext.ts:ContextId = string` remains flagged by
-  //     SonarCloud S6564; resolving via branding would cascade to
-  //     30+ test fixture sites. Deferred to a follow-up PR; tracked
-  //     by dismissing on SonarCloud as "Won't Fix" with rationale.
+  //     The 6 historical `= unknown` aliases (JsonValue×4, UntypedValue,
+  //     ApiValue) were removed 2026-05-18 in C.5.T2 by introducing the
+  //     shared `JsonValue` recursive-union type at
+  //     `src/Scrapers/Pipeline/Types/Json.ts`. Their entries are gone
+  //     from this allowlist permanently.
   {
-    files: [
-      // (a) `unknown` aliases forced by `no-restricted-syntax`
-      'src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.ts',
-      'src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts',
-      'src/Scrapers/Pipeline/Mediator/Scrape/TxnShape.ts',
-      'src/Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.ts',
-      'src/Scrapers/Pipeline/Strategy/Scrape/Account/ScrapeIdExtraction.ts',
-      'src/Scrapers/Pipeline/Strategy/Scrape/ScrapeTypes.ts',
-      // (b) ContextId = string — branding cascade deferred
-      'src/Scrapers/Pipeline/Types/PipelineContext.ts',
-    ],
+    files: ['src/Scrapers/Pipeline/Types/PipelineContext.ts'],
     rules: {
       'sonarjs/redundant-type-aliases': 'off',
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -476,6 +476,26 @@ const RESTRICTED_SYNTAX_RULES_NEW = [
     message:
       "🚫 SECURITY (S2245): Math.random() is forbidden. Use node:crypto's randomBytes(), randomInt(), or randomUUID().",
   },
+
+  // T18: Detached `child_process.spawn(..., { detached: true })` MUST
+  // be followed by `.unref()` so the parent process can exit without
+  // waiting on the detached child's stdio handle. Without `.unref()`,
+  // Jest hangs at the end of the test run and only `--forceExit` masks
+  // it. Locks CodeRabbit F9 on PR #235 (CamoufoxJsMock virtual-display
+  // spawn). Pipeline-only — production code outside the Pipeline does
+  // not spawn detached children.
+  {
+    selector:
+      "CallExpression[callee.name='spawn'][arguments.2.type='ObjectExpression'] > ObjectExpression > Property[key.name='detached'][value.value=true]",
+    message:
+      "🚫 RESOURCE LEAK (T18): spawn({ detached: true }) without proc.unref() blocks parent exit. Add `proc.unref()` immediately after the spawn call. See CodeRabbit F9.",
+  },
+
+  // T19 (path-traversal heuristic) was attempted as a global ESLint
+  // rule but was dropped — see RESTRICTED_SYNTAX_RULES head-comment.
+  // The F8 path-traversal guard lives in CamoufoxLauncher.getProfileDir
+  // (`path.basename` wrap + closed-enum bank check) and is verified by
+  // unit tests asserting `''` / `.` / `..` rejection.
 ];
 
 export default tseslint.config(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import jsdoc from 'eslint-plugin-jsdoc';
 import regexpPlugin from 'eslint-plugin-regexp';
 import sonarjs from 'eslint-plugin-sonarjs';
 import unicorn from 'eslint-plugin-unicorn';
+import jestPlugin from 'eslint-plugin-jest';
 
 /**
  * GLOBAL ARCHITECTURAL GUARDRAILS
@@ -692,6 +693,9 @@ export default tseslint.config(
       '**/mocks/**/*.ts',
       'eslint.config.mjs',
     ],
+    plugins: {
+      jest: jestPlugin,
+    },
     rules: {
       'no-console': 'off', // Allow logging in tests
       'max-lines-per-function': 'off', // Tests are naturally long
@@ -703,6 +707,34 @@ export default tseslint.config(
       // tag from Jest, not a custom invention — whitelist it for tests so
       // jsdoc/check-tag-names does not reject it.
       'jsdoc/check-tag-names': ['error', { definedTags: ['jest-environment'] }],
+
+      // SonarCloud-parity jest rules — catch S2699-class issues
+      // ("test with no assertion") at lint time, before Sonar sees them.
+      // Two explicit rules cover the SonarCloud surface (S2699 +
+      // malformed-expect detection). `jest/no-conditional-expect` is
+      // intentionally omitted because the codebase relies on
+      // conditional `expect(...)` in variant-detection tests
+      // (~680 sites in 2026-05); enabling it requires a separate
+      // architectural refactor and is not part of this PR's scope.
+      //
+      // `assertFunctionNames` whitelists the project's helper-assertion
+      // pattern. Cross-bank factory tests delegate assertions to small
+      // helpers that internally call `expect(...)` — `jest/expect-expect`
+      // cannot trace across function boundaries so it would false-positive
+      // on every factory test (~60 sites) without this whitelist. Patterns
+      // track the actual helper-naming conventions used under
+      // `src/Tests/Unit/`:
+      //   - `assert*Shape` / `assert*Run`   — direct assertion helpers.
+      //   - `**.assert*`                    — namespaced (e.g. INTEGRATION.assertFailure).
+      //   - `run*ForRow`                    — Phase H per-row factory drivers.
+      //   - `runSkipScenario`               — OtpPollerTelegram one-off.
+      'jest/expect-expect': [
+        'error',
+        {
+          assertFunctionNames: ['expect', 'assert*', '**.assert*', 'run*ForRow', 'runSkipScenario'],
+        },
+      ],
+      'jest/valid-expect': 'error',
 
       //🚨 Prevent the 'as never' / 'as any' bypass in mocks
       'no-restricted-syntax': ['error', ...RESTRICTED_SYNTAX_RULES],
@@ -965,8 +997,11 @@ export default tseslint.config(
       'sonarjs/no-misleading-array-reverse': 'error', // S4043
       'sonarjs/use-type-alias': 'error', // S4323
       'sonarjs/no-skipped-tests': 'error', // S1607
+      // typescript-eslint — type-aware Sonar parity
+      '@typescript-eslint/prefer-readonly': 'error', // S2933
       // Unicorn — modern-JS rules SonarCloud wraps
-      'unicorn/prefer-export-from': ['error', { ignoreUsedVariables: true }], // S7763
+      'unicorn/prefer-export-from': 'error', // S7763 (strict — `ignoreUsedVariables` dropped 2026-05-18)
+      'unicorn/prefer-node-protocol': 'error', // S7772
       'unicorn/prefer-string-replace-all': 'error', // S7781
       'unicorn/prefer-string-raw': 'error', // S7780
       'unicorn/prefer-at': 'error', // S7755

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1018,32 +1018,31 @@ export default tseslint.config(
   },
 
   // 12. ARCHITECTURE-RULE EXCEPTION — files where the project's
-  //     architecture rules force a NAMED type alias that SonarJS S6564
-  //     would otherwise flag as redundant.
+  //     `no-restricted-syntax` rule (banning bare `unknown` in function
+  //     signatures) forces a `type X = unknown;` alias that SonarJS
+  //     S6564 then flags as redundant. The architecture rule wins;
+  //     this override silences S6564 locally to keep
+  //     `eslint --max-warnings 0` green.
   //
-  //     Two flavours of conflict:
-  //       (a) `no-restricted-syntax` forbids bare `unknown` in function
-  //           signatures → forces `type X = unknown;` aliases.
-  //       (b) Rule #15 forbids primitive return types (`: string`,
-  //           `: number`, `: boolean`, `: void`) in Pipeline/Phases →
-  //           forces `type X = string;` aliases for return-type sites
-  //           that would be too invasive to brand (broad call-site fan-out).
+  //     `LoginPhaseActions.ts` removed from this list 2026-05-18 —
+  //     its `FormAnchorSelector = string` alias was deleted (Rule #15
+  //     applied to class methods only, not the free function the
+  //     alias was wrapping).
   //
-  //     Each file in this block also carries a `// NOSONAR` comment on
-  //     the offending alias line so SonarCloud silences the issue
-  //     server-side. The architecture rule wins; this override silences
-  //     S6564 locally to keep `eslint --max-warnings 0` green.
+  //     `PipelineContext.ts:ContextId = string` remains flagged by
+  //     SonarCloud S6564; resolving via branding would cascade to
+  //     30+ test fixture sites. Deferred to a follow-up PR; tracked
+  //     by dismissing on SonarCloud as "Won't Fix" with rationale.
   {
     files: [
-      // (a) `unknown` aliases
+      // (a) `unknown` aliases forced by `no-restricted-syntax`
       'src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.ts',
       'src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts',
       'src/Scrapers/Pipeline/Mediator/Scrape/TxnShape.ts',
       'src/Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.ts',
       'src/Scrapers/Pipeline/Strategy/Scrape/Account/ScrapeIdExtraction.ts',
       'src/Scrapers/Pipeline/Strategy/Scrape/ScrapeTypes.ts',
-      // (b) Rule #15 return-type aliases for primitives
-      'src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts',
+      // (b) ContextId = string — branding cascade deferred
       'src/Scrapers/Pipeline/Types/PipelineContext.ts',
     ],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1017,25 +1017,20 @@ export default tseslint.config(
     },
   },
 
-  // 12. ARCHITECTURE-RULE EXCEPTION — single remaining `type X = string;`
-  //     alias deferred to a follow-up commit (ContextId branding).
-  //     Once C.5.T3 lands the brand + 37 test-fixture casts, this whole
-  //     block CAN AND MUST be deleted — the `sonarjs/redundant-type-aliases`
-  //     rule must be active for the entire codebase so any future
-  //     `type X = unknown;` workaround pattern fails lint at edit time.
+  // 12. ARCHITECTURE-RULE EXCEPTION — DELETED 2026-05-18.
   //
-  //     The 6 historical `= unknown` aliases (JsonValue×4, UntypedValue,
-  //     ApiValue) were removed 2026-05-18 in C.5.T2 by introducing the
-  //     shared `JsonValue` recursive-union type at
-  //     `src/Scrapers/Pipeline/Types/Json.ts`. Their entries are gone
-  //     from this allowlist permanently.
-  {
-    files: ['src/Scrapers/Pipeline/Types/PipelineContext.ts'],
-    rules: {
-      'sonarjs/redundant-type-aliases': 'off',
-    },
-  },
-
+  //     This block previously suppressed `sonarjs/redundant-type-aliases`
+  //     on 8 production files containing `type X = unknown;` and
+  //     `type ContextId = string;` aliases that dodged other
+  //     architecture rules (`no-restricted-syntax` bare-unknown ban +
+  //     legacy Rule #15 no-primitive-returns). Phase C closed all 8
+  //     in code: 6 `= unknown` aliases were replaced with the shared
+  //     `JsonValue` recursive-union type (C.5.T2); `ContextId` was
+  //     branded via `Brand<string, 'ContextId'>` + `mintContextId`
+  //     helper (C.5.T3, this commit). The architectural canary
+  //     `EslintCanaries/redundant-type-alias.canary.ts` locks the
+  //     rule in place so this anti-pattern cannot regress.
+  //
   // 12b. TEST STUB EXCEPTION — `require-await` flags `async` methods
   //      that don't actually await. Production code MUST await; test
   //      stubs (e.g., `async fetchData() { return ScraperResult.ok }`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-check-file": "^3.3.1",
         "eslint-plugin-import-x": "^4.16.1",
+        "eslint-plugin-jest": "^29.15.2",
         "eslint-plugin-jsdoc": "^62.7.1",
         "eslint-plugin-regexp": "^3.1.0",
         "eslint-plugin-simple-import-sort": "^13.0.0",
@@ -4815,6 +4816,36 @@
           "optional": true
         },
         "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "29.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "reset": "git reset --hard && npm ci",
     "docs": "typedoc",
     "lint:architecture": "npx tsx src/Tests/Tools/lint-and-validate.ts",
-    "sonar:scan": "sonar-scanner -Dsonar.token=${SONAR_TOKEN}"
+    "sonar:scan": "node .github/scripts/sonar-scan.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "prepare": "tsup && rimraf lib/Common lib/Scrapers lib/Tests",
     "reset": "git reset --hard && npm ci",
     "docs": "typedoc",
-    "lint:architecture": "npx tsx src/Tests/Tools/lint-and-validate.ts"
+    "lint:architecture": "npx tsx src/Tests/Tools/lint-and-validate.ts",
+    "sonar:scan": "sonar-scanner -Dsonar.token=${SONAR_TOKEN}"
   },
   "repository": {
     "type": "git",
@@ -100,6 +101,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-check-file": "^3.3.1",
     "eslint-plugin-import-x": "^4.16.1",
+    "eslint-plugin-jest": "^29.15.2",
     "eslint-plugin-jsdoc": "^62.7.1",
     "eslint-plugin-regexp": "^3.1.0",
     "eslint-plugin-simple-import-sort": "^13.0.0",

--- a/src/Common/CamoufoxLauncher.ts
+++ b/src/Common/CamoufoxLauncher.ts
@@ -1,9 +1,14 @@
-import type { Browser } from 'playwright-core';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { Browser, BrowserContext } from 'playwright-core';
 
 import {
   DESKTOP_VIEWPORT_HEIGHT,
   DESKTOP_VIEWPORT_WIDTH,
   ISRAEL_LOCALE,
+  ISRAEL_TIMEZONE,
 } from './Config/BrowserConfig.js';
 
 export { ISRAEL_LOCALE } from './Config/BrowserConfig.js';
@@ -64,19 +69,164 @@ export async function launchCamoufox(headless: boolean): Promise<Browser> {
   // enable. camoufox-js's TS overloads tie `'virtual'` headless to a
   // user_data_dir-bearing variant, so we cast to bypass that quirk
   // without re-introducing the irrelevant `user_data_dir: undefined`.
-  const options: Parameters<typeof camoufoxModule.Camoufox>[0] = {
+  const options = buildEphemeralLaunchOptions(headless) as Parameters<
+    typeof camoufoxModule.Camoufox
+  >[0];
+  return camoufoxModule.Camoufox(options);
+}
+
+/** Subdirectories inside a Firefox profile that we strip post-run. */
+const STRIPPABLE_CACHE_SUBDIRS: readonly string[] = ['Cache', 'OfflineCache', 'cache2', 'crashes'];
+
+/** Pinned screen-dimension constraint applied to every Camoufox launch. */
+const PINNED_SCREEN_CONSTRAINT = {
+  minWidth: DESKTOP_VIEWPORT_WIDTH,
+  maxWidth: DESKTOP_VIEWPORT_WIDTH,
+  minHeight: DESKTOP_VIEWPORT_HEIGHT,
+  maxHeight: DESKTOP_VIEWPORT_HEIGHT,
+};
+
+/**
+ * Build the canonical ephemeral Camoufox launch options.
+ *
+ * Shared baseline for both the legacy ephemeral path and the
+ * persistent-profile path so both keep the same anti-detect knobs
+ * (humanize / disable_coop / virtual / OS / locale / screen-pin /
+ * window-size).
+ * @param headless - Caller's headless intent.
+ * @returns Options object accepted by `Camoufox()` (typed as opaque
+ *   Record because camoufox-js's own type is a generic-heavy union).
+ */
+function buildEphemeralLaunchOptions(headless: boolean): Record<string, unknown> {
+  return {
     headless: resolveHeadlessMode(headless),
     locale: ISRAEL_LOCALE,
     os: 'windows',
     humanize: envFlag('CAMOUFOX_HUMANIZE', true),
     disable_coop: envFlag('CAMOUFOX_DISABLE_COOP', true),
     window: [DESKTOP_VIEWPORT_WIDTH, DESKTOP_VIEWPORT_HEIGHT],
-    screen: {
-      minWidth: DESKTOP_VIEWPORT_WIDTH,
-      maxWidth: DESKTOP_VIEWPORT_WIDTH,
-      minHeight: DESKTOP_VIEWPORT_HEIGHT,
-      maxHeight: DESKTOP_VIEWPORT_HEIGHT,
-    },
-  } as Parameters<typeof camoufoxModule.Camoufox>[0];
+    screen: PINNED_SCREEN_CONSTRAINT,
+  };
+}
+
+/**
+ * Extend ephemeral launch options with context-level fields needed
+ * when camoufox-js routes through `playwright.launchPersistentContext`.
+ * @param headless - Caller's headless intent.
+ * @param profileDir - Absolute path to the persistent profile dir.
+ * @returns Options object accepted by `Camoufox()` in persistent mode.
+ */
+function buildPersistentLaunchOptions(
+  headless: boolean,
+  profileDir: string,
+): Record<string, unknown> {
+  return {
+    ...buildEphemeralLaunchOptions(headless),
+    user_data_dir: profileDir,
+    timezoneId: ISRAEL_TIMEZONE,
+    viewport: { width: DESKTOP_VIEWPORT_WIDTH, height: DESKTOP_VIEWPORT_HEIGHT },
+    javaScriptEnabled: true,
+  };
+}
+
+/**
+ * Whether the persistent-profile mode is enabled for the current run.
+ * Opt-in via `USE_PERSISTENT_PROFILES=true` — default is the legacy
+ * ephemeral path (a fresh profile every launch) so existing local and
+ * CI flows are unaffected.
+ * @returns True when the env flag opts in.
+ */
+export function isPersistentProfilesEnabled(): boolean {
+  return envFlag('USE_PERSISTENT_PROFILES', false);
+}
+
+/**
+ * Canonical per-bank profile directory on the host.
+ *
+ * Layout: `~/.cache/isbs/profiles/<bank>/`. Local dev keeps the dir
+ * forever (manual `RESET_PROFILES=1`-style cleanup at user discretion);
+ * CI restores + saves it via `actions/cache` so a bank-specific cache
+ * key carries the profile across runs (7-day natural eviction).
+ * @param bank - Bank identifier (case-insensitive; coerced to lowercase).
+ * @returns Absolute path to the profile directory.
+ */
+export function getProfileDir(bank: string): string {
+  const home = os.homedir();
+  const normalisedBank = bank.toLowerCase();
+  return path.join(home, '.cache', 'isbs', 'profiles', normalisedBank);
+}
+
+/**
+ * Remove Firefox cache subdirectories from a persistent profile.
+ *
+ * We keep cookies, LocalStorage, IndexedDB and prefs (the bits that
+ * contribute to anti-detect maturity) and discard HTTP cache + offline
+ * cache + cache2 + crashes (no anti-detect value, bloat the GH Actions
+ * cache). Safe to call on a directory that does not yet exist or whose
+ * subdirs are partially missing — each removal is force-mode.
+ * @param profileDir - The profile directory to clean.
+ * @returns Nothing.
+ */
+export function stripProfileCache(profileDir: string): true {
+  for (const sub of STRIPPABLE_CACHE_SUBDIRS) {
+    const target = path.join(profileDir, sub);
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+  return true;
+}
+
+/**
+ * Build a single composite cleanup that (1) closes the launcher result
+ * and (2) strips the persistent-profile cache when opted in. Pushed
+ * onto caller cleanup arrays as a single entry so callers don't have
+ * to know about the persistent-mode branching.
+ * @param result - Launcher output (Browser or BrowserContext).
+ * @param bank - Bank identifier driving the profile-cache strip.
+ * @returns Async cleanup callable resolving to true on completion.
+ */
+export function buildCloseAndStripCleanup(
+  result: Browser | BrowserContext,
+  bank: string,
+): () => Promise<true> {
+  return async (): Promise<true> => {
+    await result.close();
+    if (isPersistentProfilesEnabled()) {
+      const profileDir = getProfileDir(bank);
+      stripProfileCache(profileDir);
+    }
+    return true;
+  };
+}
+
+/**
+ * Launch a Camoufox session for a specific bank, honouring the
+ * `USE_PERSISTENT_PROFILES` opt-in.
+ *
+ * When opted in, returns a {@link BrowserContext} backed by
+ * `~/.cache/isbs/profiles/<bank>/` so cookies + LocalStorage persist
+ * across runs (improves Cloudflare scoring + device recognition for
+ * banks that remember devices). When NOT opted in, delegates to the
+ * legacy ephemeral {@link launchCamoufox} which returns a {@link Browser}.
+ *
+ * Callers must handle the union return type — typically via
+ * `'newContext' in result` narrowing (the persistent path IS already
+ * a context; the ephemeral path needs a `newContext()` call).
+ * @param headless - Caller's headless intent.
+ * @param bank - Bank identifier used to compute the profile path.
+ * @returns Browser (ephemeral) or BrowserContext (persistent).
+ */
+export async function launchCamoufoxForBank(
+  headless: boolean,
+  bank: string,
+): Promise<Browser | BrowserContext> {
+  if (!isPersistentProfilesEnabled()) {
+    return launchCamoufox(headless);
+  }
+  const profileDir = getProfileDir(bank);
+  fs.mkdirSync(profileDir, { recursive: true });
+  const camoufoxModule = await import('@hieutran094/camoufox-js');
+  const options = buildPersistentLaunchOptions(headless, profileDir) as Parameters<
+    typeof camoufoxModule.Camoufox
+  >[0];
   return camoufoxModule.Camoufox(options);
 }

--- a/src/Common/CamoufoxLauncher.ts
+++ b/src/Common/CamoufoxLauncher.ts
@@ -8,6 +8,41 @@ import {
 
 export { ISRAEL_LOCALE } from './Config/BrowserConfig.js';
 
+/** Per-platform headless override — see Pipeline/Mediator/Browser/CamoufoxLauncher.ts for rationale. */
+const VIRTUAL_HEADLESS_PLATFORMS: Record<string, 'virtual'> = { linux: 'virtual' };
+
+/** Truthy values for boolean env-var parsing in bisect experiments. */
+const TRUTHY_ENV_VALUES: ReadonlySet<string> = new Set(['true', '1', 'yes', 'on']);
+
+/**
+ * Parse a boolean env var with a documented default. Used for bisect
+ * experiments only — production defaults stay `true` for the three P0
+ * knobs; setting `CAMOUFOX_HUMANIZE=false` (etc.) at run time disables
+ * just that knob without a code edit.
+ * @param name - Env var name.
+ * @param fallback - Default when the env var is unset.
+ * @returns Parsed boolean.
+ */
+function envFlag(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const normalised = raw.toLowerCase();
+  return TRUTHY_ENV_VALUES.has(normalised);
+}
+
+/**
+ * Resolve Camoufox's headless mode for the current platform. Linux
+ * headless maps to `"virtual"` unless `CAMOUFOX_VIRTUAL_HEADLESS=false`
+ * is set (bisect / diagnostic override).
+ * @param headless - Caller's headless intent.
+ * @returns `false` when visible; `"virtual"` on Linux+headless+enabled; `true` otherwise.
+ */
+function resolveHeadlessMode(headless: boolean): boolean | 'virtual' {
+  if (!headless) return false;
+  if (!envFlag('CAMOUFOX_VIRTUAL_HEADLESS', true)) return true;
+  return VIRTUAL_HEADLESS_PLATFORMS[process.platform] ?? true;
+}
+
 /**
  * Launch a Camoufox browser (Firefox with C++-level anti-detect stealth).
  * Uses dynamic import() because camoufox-js is ESM-only.
@@ -15,15 +50,26 @@ export { ISRAEL_LOCALE } from './Config/BrowserConfig.js';
  * Pins os/window/screen to a deterministic Windows 1920x1080 fingerprint
  * so banks cannot serve mobile content via screen-size heuristics. Mirrors
  * the same fix in src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts.
+ *
+ * `humanize: true` + `disable_coop: true` are the documented Camoufox
+ * anti-detect knobs for Cloudflare managed challenges
+ * (https://camoufox.com/python/usage/) — keep both launchers in sync.
  * @param headless - Whether to launch in headless mode.
  * @returns A Playwright-compatible Browser instance.
  */
 export async function launchCamoufox(headless: boolean): Promise<Browser> {
   const camoufoxModule = await import('@hieutran094/camoufox-js');
-  return camoufoxModule.Camoufox({
-    headless,
+  // `user_data_dir` is intentionally omitted — per Camoufox docs it
+  // is only relevant when `persistent_context=True`, which we never
+  // enable. camoufox-js's TS overloads tie `'virtual'` headless to a
+  // user_data_dir-bearing variant, so we cast to bypass that quirk
+  // without re-introducing the irrelevant `user_data_dir: undefined`.
+  const options: Parameters<typeof camoufoxModule.Camoufox>[0] = {
+    headless: resolveHeadlessMode(headless),
     locale: ISRAEL_LOCALE,
     os: 'windows',
+    humanize: envFlag('CAMOUFOX_HUMANIZE', true),
+    disable_coop: envFlag('CAMOUFOX_DISABLE_COOP', true),
     window: [DESKTOP_VIEWPORT_WIDTH, DESKTOP_VIEWPORT_HEIGHT],
     screen: {
       minWidth: DESKTOP_VIEWPORT_WIDTH,
@@ -31,5 +77,6 @@ export async function launchCamoufox(headless: boolean): Promise<Browser> {
       minHeight: DESKTOP_VIEWPORT_HEIGHT,
       maxHeight: DESKTOP_VIEWPORT_HEIGHT,
     },
-  });
+  } as Parameters<typeof camoufoxModule.Camoufox>[0];
+  return camoufoxModule.Camoufox(options);
 }

--- a/src/Common/CamoufoxLauncher.ts
+++ b/src/Common/CamoufoxLauncher.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import type { Browser, BrowserContext } from 'playwright-core';
 
+import ScraperError from '../Scrapers/Base/ScraperError.js';
 import {
   DESKTOP_VIEWPORT_HEIGHT,
   DESKTOP_VIEWPORT_WIDTH,
@@ -140,20 +141,41 @@ export function isPersistentProfilesEnabled(): boolean {
   return envFlag('USE_PERSISTENT_PROFILES', false);
 }
 
+/** Banned bank identifiers after normalisation — empty, dot, dot-dot. */
+const FORBIDDEN_BANK_TOKENS: ReadonlySet<string> = new Set(['', '.', '..']);
+
 /**
  * Canonical per-bank profile directory on the host.
  *
- * Layout: `~/.cache/isbs/profiles/<bank>/`. Local dev keeps the dir
- * forever (manual `RESET_PROFILES=1`-style cleanup at user discretion);
- * CI restores + saves it via `actions/cache` so a bank-specific cache
- * key carries the profile across runs (7-day natural eviction).
+ * Layout: `<home>/.cache/isbs/profiles/<bank>/`. Local dev keeps the
+ * dir forever (manual `RESET_PROFILES=1`-style cleanup at user
+ * discretion); CI restores + saves it via `actions/cache` so a
+ * bank-specific cache key carries the profile across runs (7-day
+ * natural eviction).
+ *
+ * Defense-in-depth: `companyId` is a closed `CompanyTypes` enum today
+ * so all live callers are safe, but `path.basename` strips any
+ * separator / traversal characters and the `FORBIDDEN_BANK_TOKENS`
+ * check rejects `''`, `.` and `..` so a future widening of the input
+ * (or a typo) can never resolve the profile dir outside the profiles
+ * root. CodeRabbit F8.
+ *
+ * `homeDir` is parameterised (default `os.homedir()`) so unit tests
+ * can pass a fake without mocking `node:os` — ESM bindings are
+ * read-only and `os.homedir()` on Windows caches its result, so DI
+ * is the hermetic-test path. CodeRabbit F11.
  * @param bank - Bank identifier (case-insensitive; coerced to lowercase).
+ * @param homeDir - Home-directory root; defaults to `os.homedir()`.
  * @returns Absolute path to the profile directory.
+ * @throws ScraperError when `bank` collapses to an empty or traversal token.
  */
-export function getProfileDir(bank: string): string {
-  const home = os.homedir();
-  const normalisedBank = bank.toLowerCase();
-  return path.join(home, '.cache', 'isbs', 'profiles', normalisedBank);
+export function getProfileDir(bank: string, homeDir: string = os.homedir()): string {
+  const safeBase = path.basename(bank);
+  const normalisedBank = safeBase.toLowerCase();
+  if (FORBIDDEN_BANK_TOKENS.has(normalisedBank)) {
+    throw new ScraperError(`Invalid bank identifier for profile dir: "${bank}"`);
+  }
+  return path.join(homeDir, '.cache', 'isbs', 'profiles', normalisedBank);
 }
 
 /**

--- a/src/Scrapers/Base/BaseScraper.ts
+++ b/src/Scrapers/Base/BaseScraper.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
+
 import moment from 'moment-timezone';
 
 import { getDebug, runWithBankContext, type ScraperLogger } from '../../Common/Debug.js';
@@ -84,7 +85,7 @@ export default class BaseScraper<
   /** Bank-scoped logger — includes `bank` field in every log line. */
   protected readonly bankLog: ScraperLogger;
 
-  private _eventEmitter = new EventEmitter();
+  private readonly _eventEmitter = new EventEmitter();
 
   /**
    * Create a new BaseScraper with the given options.

--- a/src/Scrapers/Base/BaseScraperWithBrowser.ts
+++ b/src/Scrapers/Base/BaseScraperWithBrowser.ts
@@ -1,7 +1,7 @@
 import type { Browser, Frame, Page } from 'playwright-core';
 
 import { buildContextOptions } from '../../Common/Browser.js';
-import { launchCamoufox } from '../../Common/CamoufoxLauncher.js';
+import { buildCloseAndStripCleanup, launchCamoufoxForBank } from '../../Common/CamoufoxLauncher.js';
 import { runLoggedChain } from '../../Common/ChainLogger.js';
 import { getDebug } from '../../Common/Debug.js';
 import type { ILoginContext, INamedLoginStep } from '../../Common/LoginMiddleware.js';
@@ -384,22 +384,23 @@ class BaseScraperWithBrowser<
   }
 
   /**
-   * Launch a new Camoufox browser instance and return a page.
-   * @returns A new Playwright page from the launched browser.
+   * Launch Camoufox honouring USE_PERSISTENT_PROFILES opt-in.
+   * @returns A new Playwright page from the launched session.
    */
   private async launchNewBrowser(): Promise<Page> {
     const opts = this.options as IDefaultBrowserOptions;
-    const { shouldShowBrowser } = opts;
-    this.bankLog.debug('launch Camoufox headless=%s', !shouldShowBrowser);
-    const browser = await launchCamoufox(!shouldShowBrowser);
-    const bankLogger = this.bankLog;
-    this._cleanups.push(async () => {
-      bankLogger.debug('closing the browser');
-      await browser.close();
-      return true;
-    });
-    if (opts.prepareBrowser) await opts.prepareBrowser(browser);
-    return this.createContextAndPage(browser, false);
+    const bank = this.options.companyId;
+    this.bankLog.debug('launch Camoufox headless=%s', !opts.shouldShowBrowser);
+    const result = await launchCamoufoxForBank(!opts.shouldShowBrowser, bank);
+    const cleanup = buildCloseAndStripCleanup(result, bank);
+    this._cleanups.push(cleanup);
+    if ('newContext' in result) {
+      if (opts.prepareBrowser) await opts.prepareBrowser(result);
+      return this.createContextAndPage(result, false);
+    }
+    const existing = result.pages();
+    if (existing.length > 0) return existing[0];
+    return result.newPage();
   }
 
   /**

--- a/src/Scrapers/Base/BaseScraperWithBrowser.ts
+++ b/src/Scrapers/Base/BaseScraperWithBrowser.ts
@@ -12,9 +12,6 @@ import BaseScraper from './BaseScraper.js';
 import {
   type ILoginOptions,
   type ILoginResultContext,
-  LOGIN_RESULTS,
-  type LoginResults,
-  type PossibleLoginResults,
   resolveAndBuildLoginResult,
 } from './BaseScraperHelpers.js';
 import type { SelectorCandidate } from './Config/LoginConfig.js';
@@ -30,7 +27,12 @@ import { fillOneInput } from './LoginSteps.js';
 import { handleNavigationFailure } from './NavigationRetry.js';
 import ScraperError from './ScraperError.js';
 
-export { type ILoginOptions, LOGIN_RESULTS, type LoginResults, type PossibleLoginResults };
+export {
+  type ILoginOptions,
+  LOGIN_RESULTS,
+  type LoginResults,
+  type PossibleLoginResults,
+} from './BaseScraperHelpers.js';
 
 const LOG = getDebug('base-scraper-with-browser');
 
@@ -117,7 +119,7 @@ class BaseScraperWithBrowser<
 
   private _cleanups: (() => Promise<boolean>)[] = [];
 
-  private _otpPhoneHint = '';
+  private readonly _otpPhoneHint = '';
 
   /**
    * Initialize the browser page and prepare the scraper for login.

--- a/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts
@@ -29,6 +29,7 @@ function buildHapoalimPipeline(options: ScraperOptions): Procedure<IPipelineDesc
   return createPipelineBuilder()
     .withOptions(options)
     .withBrowser()
+    .withSkipHome()
     .withDeclarativeLogin(HAPOALIM_LOGIN)
     .withOtpFill(false)
     .build();

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts
@@ -54,6 +54,18 @@ function ifBrowser(state: IBuilderState): boolean {
 }
 
 /**
+ * Predicate: HOME — browser path AND no opt-out via `withSkipHome()`.
+ * Hapoalim sets `skipHome` because its bank URL is the login page
+ * directly (no marketing homepage to discover the login link on).
+ *
+ * @param state - Builder state.
+ * @returns True when HOME should run.
+ */
+function ifBrowserAndNotSkipHome(state: IBuilderState): boolean {
+  return state.hasBrowser && !state.skipHome;
+}
+
+/**
  * Predicate: PRE-LOGIN — opt-in flag plus browser path.
  *
  * @param state - Builder state.
@@ -224,7 +236,7 @@ function makeTerminate(): BasePhase {
  */
 const PHASE_CHAIN: readonly IPhaseSlot[] = [
   { factory: makeInit, enabled: ifBrowser },
-  { factory: makeHome, enabled: ifBrowser },
+  { factory: makeHome, enabled: ifBrowserAndNotSkipHome },
   { factory: makePreLogin, enabled: ifBrowserAndPreLogin },
   { factory: makeLogin, enabled: ifLoginAlways },
   { factory: makeOtpTrigger, enabled: ifOtpFillAndTrigger },

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts
@@ -78,6 +78,20 @@ class PipelineBuilder {
   }
 
   /**
+   * Skip the HOME phase. Used by banks whose `urls.base` is already
+   * the login page (no marketing homepage to traverse). When set, the
+   * assembler omits HOME from the phase chain so the pipeline goes
+   * INIT → PRE-LOGIN/LOGIN directly. Diagnostics `loginUrl` is
+   * normally populated by HOME.FINAL; downstream consumers
+   * (LOGIN bounce detection) already tolerate an empty `loginUrl`.
+   * @returns This builder.
+   */
+  public withSkipHome(): this {
+    this._s.skipHome = true;
+    return this;
+  }
+
+  /**
    * Enable OTP trigger phase (clicks "Send SMS").
    * @returns This builder.
    */

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderSetters.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderSetters.ts
@@ -28,6 +28,7 @@ interface IBuilderState {
   hasOtpFill: boolean;
   otpFillRequired: boolean;
   hasOtpTrigger: boolean;
+  skipHome: boolean;
   scrapeFn: ScrapeFn | false;
   apiDirectConfig: IApiDirectCallConfig | false;
 }
@@ -42,6 +43,7 @@ const EMPTY_STATE_DEFAULTS: Omit<IBuilderState, 'options' | 'loginMode' | 'error
   hasOtpFill: false,
   otpFillRequired: true,
   hasOtpTrigger: false,
+  skipHome: false,
   scrapeFn: false,
   apiDirectConfig: false,
 };

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderValidation.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderValidation.ts
@@ -32,6 +32,7 @@ interface IBuilderFields {
   readonly hasOtpFill: boolean;
   readonly otpFillRequired: boolean;
   readonly hasOtpTrigger: boolean;
+  readonly skipHome: boolean;
   readonly scrapeFn: ScrapeFn | false;
   readonly apiDirectConfig: IApiDirectCallConfig | false;
 }

--- a/src/Scrapers/Pipeline/Core/Builder/StepResolvers.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/StepResolvers.ts
@@ -75,6 +75,7 @@ interface IBuilderState {
   readonly hasOtpFill: boolean;
   readonly otpFillRequired: boolean;
   readonly hasOtpTrigger: boolean;
+  readonly skipHome: boolean;
   readonly loginMode: string;
   readonly loginConfig: ILoginConfig | false;
   readonly loginFn: LoginFn | false;

--- a/src/Scrapers/Pipeline/Core/Executor/PipelineReducer.ts
+++ b/src/Scrapers/Pipeline/Core/Executor/PipelineReducer.ts
@@ -4,7 +4,7 @@ import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import type { IElementMediator } from '../../Mediator/Elements/ElementMediator.js';
-import { HUMANIZE_JITTER_PHASES, PHASE_SETTLE_MS } from '../../Mediator/Timing/TimingConfig.js';
+import { isHumanizeJitterPhase, PHASE_SETTLE_MS } from '../../Mediator/Timing/TimingConfig.js';
 import { setActivePhase, setActiveStage } from '../../Types/ActiveState.js';
 import { toErrorMessage } from '../../Types/ErrorUtils.js';
 import type { Option } from '../../Types/Option.js';
@@ -115,7 +115,7 @@ async function phaseSettle(
   step: IPhaseStep,
   when: 'pre' | 'final',
 ): Promise<true> {
-  const isHumanized = HUMANIZE_JITTER_PHASES.has(step.name) && ctx.mediator.has;
+  const isHumanized = isHumanizeJitterPhase(step.name) && ctx.mediator.has;
   ctx.logger.debug({
     phase: step.name,
     event: 'phase-settle',

--- a/src/Scrapers/Pipeline/Core/Executor/PipelineReducer.ts
+++ b/src/Scrapers/Pipeline/Core/Executor/PipelineReducer.ts
@@ -3,9 +3,11 @@
 import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
-import { PHASE_SETTLE_MS } from '../../Mediator/Timing/TimingConfig.js';
+import type { IElementMediator } from '../../Mediator/Elements/ElementMediator.js';
+import { HUMANIZE_JITTER_PHASES, PHASE_SETTLE_MS } from '../../Mediator/Timing/TimingConfig.js';
 import { setActivePhase, setActiveStage } from '../../Types/ActiveState.js';
 import { toErrorMessage } from '../../Types/ErrorUtils.js';
+import type { Option } from '../../Types/Option.js';
 import type { IPipelineContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail, isOk, succeed } from '../../Types/Procedure.js';
@@ -68,6 +70,27 @@ function buildStep(tracker: IContextTracker, index: number): IPhaseStep {
 }
 
 /**
+ * Inner settle wait — either humanized mouse-jitter (pre-auth phases
+ * with a live mediator) or silent setTimeout fallback. Extracted from
+ * `phaseSettle` to keep that function inside the 15-line per-function
+ * cap while still concentrating the wait-mode branch on one site.
+ *
+ * @param mediator - Mediator option from the current context.
+ * @param isHumanized - True when the current phase is in
+ *   {@link HUMANIZE_JITTER_PHASES} AND the mediator option carries a
+ *   live mediator value.
+ * @returns True after the wait resolves.
+ */
+async function settleWait(mediator: Option<IElementMediator>, isHumanized: boolean): Promise<true> {
+  if (isHumanized && mediator.has) {
+    await mediator.value.humanizeWait(PHASE_SETTLE_MS);
+    return true as const;
+  }
+  await setTimeoutPromise(PHASE_SETTLE_MS, undefined, { ref: false });
+  return true as const;
+}
+
+/**
  * Phase settle — give the bank's SPA a fixed window to settle
  * (analytics, deferred hydration, cross-origin pixels) and to give
  * the page's anti-bot JS time to observe a "human-paused-on-page"
@@ -75,6 +98,12 @@ function buildStep(tracker: IContextTracker, index: number): IPhaseStep {
  * before phase.PRE work begins (`when='pre'`), once after phase.FINAL
  * completes (`when='final'`). FINAL settle is skipped for the
  * terminal phase so pipeline completion is not delayed.
+ *
+ * <p>For phases in {@link HUMANIZE_JITTER_PHASES} (init / home /
+ * login) the wait is humanized — small mouse-move ticks across the
+ * window so the page sees user-input signals during what would
+ * otherwise be a silent 4 s pause. Other phases get the cheap
+ * `setTimeoutPromise` settle. Branch lives in {@link settleWait}.
  *
  * @param ctx - Active pipeline context (used for structured trace).
  * @param step - The phase step entering or just-finished.
@@ -86,14 +115,15 @@ async function phaseSettle(
   step: IPhaseStep,
   when: 'pre' | 'final',
 ): Promise<true> {
+  const isHumanized = HUMANIZE_JITTER_PHASES.has(step.name) && ctx.mediator.has;
   ctx.logger.debug({
     phase: step.name,
     event: 'phase-settle',
     when,
     elapsedMs: String(PHASE_SETTLE_MS),
+    humanized: String(isHumanized),
   });
-  await setTimeoutPromise(PHASE_SETTLE_MS, undefined, { ref: false });
-  return true as const;
+  return settleWait(ctx.mediator, isHumanized);
 }
 
 /**

--- a/src/Scrapers/Pipeline/EslintCanaries/detached-spawn-needs-unref.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/detached-spawn-needs-unref.canary.ts
@@ -1,0 +1,12 @@
+// Canary: `child_process.spawn(..., { detached: true })` MUST be
+// followed by `.unref()` so the parent's event-loop handle on the
+// child is released. Without it, Node tests / scripts hang at exit
+// waiting for the detached child to die. Locks CodeRabbit F9 on
+// PR #235: the Camoufox Xvfb spawn in the Jest mock was missing
+// `.unref()` and `--forceExit` was masking the hang.
+//
+// `verify.sh` fails the build if this canary stops triggering.
+import { spawn } from 'node:child_process';
+const proc = spawn('sleep', ['0.1'], { detached: true });
+
+export { proc };

--- a/src/Scrapers/Pipeline/EslintCanaries/math-random.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/math-random.canary.ts
@@ -1,0 +1,7 @@
+// Canary: Math.random() is forbidden — use node:crypto's randomBytes /
+// randomInt / randomUUID. SonarCloud rule S2245 (weak PRNG). If this
+// file ever stops triggering an ESLint error, the architectural rule
+// was weakened or removed — `verify.sh` will fail the build.
+const weak = Math.random();
+
+export { weak };

--- a/src/Scrapers/Pipeline/EslintCanaries/redundant-type-alias.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/redundant-type-alias.canary.ts
@@ -1,0 +1,35 @@
+/**
+ * Architectural canary — `sonarjs/redundant-type-aliases` must fire on
+ * any `type X = <primitive-or-unknown>;` pattern across the Pipeline
+ * tree.
+ *
+ * Why this canary exists (2026-05-18): C.4 cycle 1 (PR #235) closed
+ * only 1 of 8 SonarCloud S6564 issues. The 7 remaining were
+ * `type JsonValue/UntypedValue/ApiValue = unknown;` workarounds added
+ * to dodge the architecture `no-restricted-syntax` rule (banning bare
+ * `unknown` in function signatures). The workarounds resolved to
+ * `unknown` semantically, so Sonar correctly flagged them as
+ * redundant. C.5 (this commit) replaced all six with a shared
+ * recursive `JsonValue` union and deleted the corresponding
+ * `eslint.config.mjs` block-12 exceptions. This canary nails down the
+ * outcome: if `sonarjs/redundant-type-aliases` is ever weakened or
+ * disabled at the global scope, the canary stops firing and
+ * `verify.sh` fails the build.
+ *
+ * Every `type` declaration below must be flagged by ESLint when
+ * `verify.sh` runs (forces `--no-ignore`). The canary file is in
+ * the global `ignores` list, so it does NOT contribute lint errors
+ * to regular runs.
+ */
+
+/** Single-`unknown` alias — the historical workaround pattern. */
+export type CanaryUnknownAlias = unknown;
+
+/** Single-`string` alias — the documentation-only nominal pattern. */
+export type CanaryStringAlias = string;
+
+/** Single-`number` alias — same class as the above. */
+export type CanaryNumberAlias = number;
+
+/** Single-`boolean` alias — same class as the above. */
+export type CanaryBooleanAlias = boolean;

--- a/src/Scrapers/Pipeline/Interceptors/PopupInterceptor.ts
+++ b/src/Scrapers/Pipeline/Interceptors/PopupInterceptor.ts
@@ -49,17 +49,13 @@ function traceNetworkDelta(
 }
 
 /**
- * Only run before these phases — the 3 transitions where the bank
- * may render a modal that blocks the next discovery / extraction.
- *
- * <p>`account-resolve` added 2026-05-07 (Phase 7d): VisaCal
- * fires the new-card promo popup on the post-login render, exactly
- * the wait window where ACCOUNT-RESOLVE.PRE blocks for the first
- * id-bearing capture. Without dismissal the popup overlay can hold
- * the SPA from firing the `account/init` request and ACCOUNT-RESOLVE
- * times out empty.
+ * Phases that bind the popup probe. `home` removed 2026-05-19 —
+ * the probe's silent locator chain stacked back-to-back with the
+ * 20 s HOME `resolveVisible` was the bot-signal Hapoalim's hCaptcha
+ * latched onto. `account-resolve` keeps VisaCal new-card popup
+ * coverage; `dashboard` keeps post-login overlay coverage.
  */
-const POPUP_PHASES: ReadonlySet<string> = new Set(['home', 'account-resolve', 'dashboard']);
+const POPUP_PHASES: ReadonlySet<string> = new Set(['account-resolve', 'dashboard']);
 
 /**
  * Attempt to dismiss one popup via WK_CLOSE_POPUP.

--- a/src/Scrapers/Pipeline/Mediator/Browser/BrowserConfig.ts
+++ b/src/Scrapers/Pipeline/Mediator/Browser/BrowserConfig.ts
@@ -1,11 +1,13 @@
-/** Default timezone for Israeli bank portals. */
-export const ISRAEL_TIMEZONE = 'Asia/Jerusalem';
-
-/** Default locale for Israeli bank portals and date formatting. */
-export const ISRAEL_LOCALE = 'he-IL';
-
-/** Desktop viewport width — Israeli banks hide login forms at smaller sizes. */
-export const DESKTOP_VIEWPORT_WIDTH = 1920;
-
-/** Desktop viewport height — standard 1080p layout for bank portals. */
-export const DESKTOP_VIEWPORT_HEIGHT = 1080;
+/**
+ * Re-exports the canonical browser-fingerprint constants from Common.
+ * Single source of truth lives at src/Common/Config/BrowserConfig.ts —
+ * this file exists only so existing pipeline-local imports
+ * (`./BrowserConfig.js`) keep resolving without churning ~20 import
+ * sites across the codebase.
+ */
+export {
+  DESKTOP_VIEWPORT_HEIGHT,
+  DESKTOP_VIEWPORT_WIDTH,
+  ISRAEL_LOCALE,
+  ISRAEL_TIMEZONE,
+} from '../../../../Common/Config/BrowserConfig.js';

--- a/src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts
+++ b/src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts
@@ -1,36 +1,8 @@
-import type { Browser } from 'playwright-core';
-
-import { DESKTOP_VIEWPORT_HEIGHT, DESKTOP_VIEWPORT_WIDTH, ISRAEL_LOCALE } from './BrowserConfig.js';
-
-export { ISRAEL_LOCALE } from './BrowserConfig.js';
-
 /**
- * Launch a Camoufox browser (Firefox with C++-level anti-detect stealth).
- * Uses dynamic import() because camoufox-js is ESM-only.
- *
- * Pins os/window/screen to a deterministic Windows 1920x1080 fingerprint
- * so banks cannot serve mobile content via screen-size heuristics. Without
- * this, Camoufox randomly picks per launch and an unlucky fingerprint can
- * trip the bank's mobile detection (observed: Isracard post-login splash
- * to /Sta… mobile-app upsell on small-screen fingerprint).
- *
- * Camoufox's `screen` option is a constraint pair (min/max); setting min
- * equal to max forces the exact desktop dimensions every run.
- * @param headless - Whether to launch in headless mode.
- * @returns A Playwright-compatible Browser instance.
+ * Re-exports the canonical Camoufox launcher from Common. Single source
+ * of truth lives at src/Common/CamoufoxLauncher.ts — this file exists
+ * only so existing pipeline-local imports
+ * (`./Mediator/Browser/CamoufoxLauncher.js`) keep resolving without
+ * churning ~20 import sites across the codebase.
  */
-export async function launchCamoufox(headless: boolean): Promise<Browser> {
-  const camoufoxModule = await import('@hieutran094/camoufox-js');
-  return camoufoxModule.Camoufox({
-    headless,
-    locale: ISRAEL_LOCALE,
-    os: 'windows',
-    window: [DESKTOP_VIEWPORT_WIDTH, DESKTOP_VIEWPORT_HEIGHT],
-    screen: {
-      minWidth: DESKTOP_VIEWPORT_WIDTH,
-      maxWidth: DESKTOP_VIEWPORT_WIDTH,
-      minHeight: DESKTOP_VIEWPORT_HEIGHT,
-      maxHeight: DESKTOP_VIEWPORT_HEIGHT,
-    },
-  });
-}
+export { ISRAEL_LOCALE, launchCamoufox } from '../../../../Common/CamoufoxLauncher.js';

--- a/src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts
+++ b/src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts
@@ -5,4 +5,12 @@
  * (`./Mediator/Browser/CamoufoxLauncher.js`) keep resolving without
  * churning ~20 import sites across the codebase.
  */
-export { ISRAEL_LOCALE, launchCamoufox } from '../../../../Common/CamoufoxLauncher.js';
+export {
+  buildCloseAndStripCleanup,
+  getProfileDir,
+  isPersistentProfilesEnabled,
+  ISRAEL_LOCALE,
+  launchCamoufox,
+  launchCamoufoxForBank,
+  stripProfileCache,
+} from '../../../../Common/CamoufoxLauncher.js';

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardDiscovery.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardDiscovery.ts
@@ -9,6 +9,7 @@ import type { SelectorCandidate } from '../../../Base/Config/LoginConfig.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import { PIPELINE_WELL_KNOWN_API } from '../../Registry/WK/ScrapeWK.js';
 import type { ScraperLogger } from '../../Types/Debug.js';
+import type { JsonValue } from '../../Types/Json.js';
 import type { IElementMediator } from '../Elements/ElementMediator.js';
 import type { IDiscoveredEndpoint, INetworkDiscovery } from '../Network/NetworkDiscovery.js';
 import { hasTxnArray } from '../Scrape/TxnShape.js';
@@ -50,7 +51,7 @@ function countTxnTraffic(network: INetworkDiscovery, sinceMs: number): number {
   const withBody = matched.filter(
     (ep): boolean => ep.responseBody !== undefined && ep.responseBody !== null,
   );
-  return withBody.filter((ep): boolean => hasTxnArray(ep.responseBody)).length;
+  return withBody.filter((ep): boolean => hasTxnArray(ep.responseBody as JsonValue)).length;
 }
 
 /** Lowercased URL schemes rejected by `resolveAbsoluteHref` —

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts
@@ -14,6 +14,7 @@ import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import { PIPELINE_WELL_KNOWN_API } from '../../Registry/WK/ScrapeWK.js';
+import type { ContextId } from '../../Types/Brand.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
 import { some } from '../../Types/Option.js';
 import type {
@@ -189,7 +190,7 @@ async function resolveDashboardTargets(
 }
 
 /** Main-frame context identifier — matches FrameRegistry.MAIN_CONTEXT_ID. */
-const MAIN_CONTEXT_ID = 'main';
+const MAIN_CONTEXT_ID = 'main' as ContextId;
 /**
  * Angular `dropdowntoggle` directive — the deterministic structural signal
  * for a real dropdown-toggle. Always present when the directive is bound,

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts
@@ -14,7 +14,6 @@ import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import { PIPELINE_WELL_KNOWN_API } from '../../Registry/WK/ScrapeWK.js';
-import type { ContextId } from '../../Types/Brand.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
 import { some } from '../../Types/Option.js';
 import type {
@@ -24,7 +23,7 @@ import type {
   IPipelineContext,
   IResolvedTarget,
 } from '../../Types/PipelineContext.js';
-import { EMPTY_TXN_HARVEST } from '../../Types/PipelineContext.js';
+import { EMPTY_TXN_HARVEST, MAIN_CONTEXT_ID } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail, succeed } from '../../Types/Procedure.js';
 import { candidateToSelector, raceResultToTarget } from '../Elements/ActionExecutors.js';
@@ -189,8 +188,10 @@ async function resolveDashboardTargets(
   };
 }
 
-/** Main-frame context identifier — matches FrameRegistry.MAIN_CONTEXT_ID. */
-const MAIN_CONTEXT_ID = 'main' as ContextId;
+// `MAIN_CONTEXT_ID` is imported from `../../Types/PipelineContext.js`
+// (which re-exports from `../../Types/Brand.js`) — the canonical
+// source. Inline `'main' as ContextId` previously duplicated this
+// value and risked drift; CodeRabbit follow-up 2026-05-18.
 /**
  * Angular `dropdowntoggle` directive — the deterministic structural signal
  * for a real dropdown-toggle. Always present when the directive is bound,

--- a/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
@@ -15,6 +15,7 @@ import {
 } from '../Timing/TimingConfig.js';
 import { humanDelay } from '../Timing/Waiting.js';
 
+export { default as buildHumanizeWait } from '../Timing/HumanizeWait.js';
 export { ELEMENTS_LOADING_DELAY_MS } from '../Timing/TimingConfig.js';
 
 const LOG = getDebug(import.meta.url);

--- a/src/Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.ts
@@ -10,6 +10,7 @@ import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import { WK_LOGIN_FORM } from '../../Registry/WK/LoginWK.js';
+import type { ContextId } from '../../Types/Brand.js';
 import { capTimeout, getDebug } from '../../Types/Debug.js';
 import { toErrorMessage } from '../../Types/ErrorUtils.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
@@ -1744,7 +1745,7 @@ function extractActionMediator(full: IElementMediator, page: Page): IActionMedia
   const registry = buildFrameRegistry(page);
   return {
     /** @inheritdoc */
-    fillInput: (ctxId: string, sel: string, val: string): Promise<true> => {
+    fillInput: (ctxId: ContextId, sel: string, val: string): Promise<true> => {
       const frame = resolveFrame(registry, ctxId);
       return fillInputImpl(frame, sel, val);
     },
@@ -1759,7 +1760,7 @@ function extractActionMediator(full: IElementMediator, page: Page): IActionMedia
       });
     },
     /** @inheritdoc */
-    pressEnter: (ctxId: string): Promise<true> => {
+    pressEnter: (ctxId: ContextId): Promise<true> => {
       const frame = resolveFrame(registry, ctxId);
       return pressEnterImpl(frame);
     },

--- a/src/Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.ts
@@ -27,6 +27,7 @@ import { resolveFieldPipeline } from '../Selector/PipelineFieldResolver.js';
 import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';
 import {
   buildFrameRegistry,
+  buildHumanizeWait,
   clickElementImpl,
   ELEMENTS_LOADING_DELAY_MS,
   fillInputImpl,
@@ -1698,6 +1699,7 @@ function createElementMediator(page: Page): IElementMediator {
     getCurrentUrl: buildGetCurrentUrl(page),
     waitForNetworkIdle: waitForNetworkIdleFn,
     raceWithNetworkIdle: buildRaceWithNetworkIdle(waitForNetworkIdleFn),
+    humanizeWait: buildHumanizeWait(page),
     checkAttribute: buildCheckAttribute(),
     getAttributeValue: buildGetAttributeValue(),
 

--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
@@ -277,6 +277,35 @@ interface IElementMediator {
   raceWithNetworkIdle(customWait: Promise<unknown>, budgetMs: number): Promise<true>;
 
   /**
+   * Humanized settle — wait approximately `budgetMs` while emitting
+   * small mouse-move events at fixed ticks so the page sees
+   * user-input signals during what would otherwise be a silent pause.
+   *
+   * <p>Mission: bank-side bot detection (Hapoalim hCaptcha, Isracard
+   * temp-fault page) profiles the pre-auth window for "human input
+   * present?" — a silent 4 s settle reads as bot and the bank
+   * responds with a challenge / error page. The mediator emits
+   * roughly one mouse-move every `HUMANIZE_TICK_MS` across the
+   * window, each within a small jitter radius of the previous
+   * position, then parks the cursor at the top-left so the next
+   * phase's element-discovery runs against a deterministic mouse
+   * position.
+   *
+   * <p>Used by the central `phaseSettle` in
+   * `Core/Executor/PipelineReducer.ts` for the phase whitelist in
+   * {@link "../Timing/TimingConfig.js"} `HUMANIZE_JITTER_PHASES`
+   * (`init` / `home` / `login`). Other phases get the cheap
+   * `setTimeoutPromise` settle.
+   *
+   * <p>Best-effort: any mouse-move failure (e.g. page closed mid-wait
+   * during retry) is swallowed so the settle still resolves.
+   *
+   * @param budgetMs - Total wall-clock budget for the humanized wait.
+   * @returns True after the budget elapses and the cursor is parked.
+   */
+  humanizeWait(budgetMs: number): Promise<true>;
+
+  /**
    * Wait for URL to match a glob pattern (SPA navigation wait).
    * Non-fatal: returns succeed(false) on timeout.
    * @param pattern - Glob pattern (e.g. '**\/login**').

--- a/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
@@ -8,10 +8,7 @@
 import type { Frame, Page } from 'playwright-core';
 
 import ScraperError from '../../../Base/ScraperError.js';
-import { type ContextId, mintContextId } from '../../Types/Brand.js';
-
-/** Main page context identifier constant. */
-const MAIN_CONTEXT_ID: ContextId = mintContextId('main');
+import { type ContextId, MAIN_CONTEXT_ID, mintContextId } from '../../Types/Brand.js';
 
 /** Iframe context identifier prefix. */
 const IFRAME_PREFIX = 'iframe:';
@@ -105,4 +102,5 @@ function resolveFrame(registry: FrameRegistryMap, contextId: ContextId): Page | 
 }
 
 export type { FrameRegistryMap };
-export { buildFrameRegistry, computeContextId, MAIN_CONTEXT_ID, resolveFrame };
+export { buildFrameRegistry, computeContextId, resolveFrame };
+export { MAIN_CONTEXT_ID } from '../../Types/Brand.js';

--- a/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
@@ -8,13 +8,13 @@
 import type { Frame, Page } from 'playwright-core';
 
 import ScraperError from '../../../Base/ScraperError.js';
-import type { ContextId } from '../../Types/PipelineContext.js';
+import { type ContextId, mintContextId } from '../../Types/Brand.js';
 
 /** Main page context identifier constant. */
-const MAIN_CONTEXT_ID: ContextId = 'main';
+const MAIN_CONTEXT_ID: ContextId = mintContextId('main');
 
 /** Iframe context identifier prefix. */
-const IFRAME_PREFIX: ContextId = 'iframe:';
+const IFRAME_PREFIX = 'iframe:';
 
 /**
  * Compute a stable opaque contextId for a Page or Frame.
@@ -30,12 +30,12 @@ const IFRAME_PREFIX: ContextId = 'iframe:';
  * @param rawUrl - Full URL with potential query params.
  * @returns Origin + pathname only.
  */
-function stableUrl(rawUrl: ContextId): ContextId {
+function stableUrl(rawUrl: string): ContextId {
   try {
     const parsed = new URL(rawUrl);
-    return `${parsed.origin}${parsed.pathname}`;
+    return mintContextId(`${parsed.origin}${parsed.pathname}`);
   } catch {
-    return rawUrl;
+    return mintContextId(rawUrl);
   }
 }
 
@@ -54,9 +54,12 @@ function computeContextId(context: Page | Frame, page: Page): ContextId {
   const url = frame.url();
   const name = frame.name();
   const hasRealUrl = url !== 'about:blank' && url.length > 0;
-  const stableIdMap: Record<string, ContextId> = { true: stableUrl(url), false: name };
+  const stableIdMap: Record<string, ContextId> = {
+    true: stableUrl(url),
+    false: mintContextId(name),
+  };
   const stableId = stableIdMap[String(hasRealUrl)];
-  return `${IFRAME_PREFIX}${stableId}`;
+  return mintContextId(`${IFRAME_PREFIX}${stableId}`);
 }
 
 /** Immutable frame registry — maps contextId → actual Frame. */

--- a/src/Scrapers/Pipeline/Mediator/Form/LoginFormActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Form/LoginFormActions.ts
@@ -11,6 +11,7 @@ import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import type { IFieldConfig } from '../../../Base/Interfaces/Config/FieldConfig.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
+import type { ContextId } from '../../Types/Brand.js';
 import type { ScraperLogger } from '../../Types/Debug.js';
 import { type MaskedText, maskVisibleText } from '../../Types/LogEvent.js';
 import type { ILoginFieldDiscovery, IResolvedTarget } from '../../Types/PipelineContext.js';
@@ -282,7 +283,7 @@ async function tryEnterFromDiscovery(
   logger: ScraperLogger,
 ): Promise<boolean> {
   logger.debug({ method: 'enter', url: maskVisibleText(activeFrameId) });
-  await executor.pressEnter(activeFrameId).catch((): false => false);
+  await executor.pressEnter(activeFrameId as ContextId).catch((): false => false);
   return true;
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Init/InitActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Init/InitActions.ts
@@ -66,7 +66,7 @@ async function executeLaunchBrowser(input: IPipelineContext): Promise<Procedure<
     });
     return succeed({ ...input, browser: some(state) });
   } catch (error) {
-    await closeBrowserSafe(launchResult);
+    await closeBrowserSafe(launchResult, input.companyId);
     const msg = toErrorMessage(error as Error);
     return fail(ScraperErrorTypes.Generic, `INIT PRE: browser launch failed — ${msg}`);
   }

--- a/src/Scrapers/Pipeline/Mediator/Init/InitActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Init/InitActions.ts
@@ -51,17 +51,22 @@ async function coldStartIfDumping(context: BrowserContext): Promise<boolean> {
  * @returns Updated context with browser state, or failure.
  */
 async function executeLaunchBrowser(input: IPipelineContext): Promise<Procedure<IPipelineContext>> {
-  let browser: Browser | false = false;
+  let launchResult: Browser | BrowserContext | false = false;
   try {
-    browser = await launchBrowser(input.options);
-    const launched = await createContextAndPage(browser);
+    launchResult = await launchBrowser(input.options);
+    const launched = await createContextAndPage(launchResult);
     await coldStartIfDumping(launched.context);
     await installMockContextRoute(launched.context, input.companyId);
     await setupPage(launched.page, input.options);
-    const state = buildBrowserState(launched.page, launched.context, browser);
+    const state = buildBrowserState({
+      page: launched.page,
+      context: launched.context,
+      launchResult,
+      bank: input.companyId,
+    });
     return succeed({ ...input, browser: some(state) });
   } catch (error) {
-    await closeBrowserSafe(browser);
+    await closeBrowserSafe(launchResult);
     const msg = toErrorMessage(error as Error);
     return fail(ScraperErrorTypes.Generic, `INIT PRE: browser launch failed — ${msg}`);
   }

--- a/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts
@@ -230,10 +230,6 @@ function normalizeSubmitConfig(submit: ILoginConfig['submit']): readonly Selecto
   return WK_LOGIN_FORM.submit;
 }
 
-/** Trustworthy form-anchor selector (id/name/class) or empty string sentinel. */
-// NOSONAR — Rule #15 (no-primitive-returns) requires a named alias here.
-type FormAnchorSelector = string;
-
 /**
  * Extract form-anchor selector ONLY when the anchor is trustworthy:
  *   - `#id`             (e.g. Amex/Isracard `#otpLobbyFormPassword`)
@@ -246,7 +242,7 @@ type FormAnchorSelector = string;
  * @param formAnchor - Optional form anchor option.
  * @returns Trustworthy CSS selector or empty string.
  */
-function extractFormAnchorSelector(formAnchor: Option<IFormAnchor>): FormAnchorSelector {
+function extractFormAnchorSelector(formAnchor: Option<IFormAnchor>): string {
   if (!formAnchor.has) return '';
   const selector = formAnchor.value.selector;
   if (selector.length === 0) return '';

--- a/src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.ts
@@ -22,6 +22,7 @@ import type { Page, Response } from 'playwright-core';
 
 import { PIPELINE_WELL_KNOWN_API } from '../../Registry/WK/ScrapeWK.js';
 import { getDebug } from '../../Types/Debug.js';
+import type { JsonValue, MaybeJsonValue } from '../../Types/Json.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
 
 const LOG = getDebug(import.meta.url);
@@ -34,13 +35,6 @@ const FAIL_STATUS_MAX = 499;
 
 /** Classifier label distinguishing which detector layer fired. */
 type AuthFailureClassifier = 'http-4xx' | 'body-error';
-/**
- * Parsed-JSON sentinel passed to body classifiers. Aliased so the
- * function signature does not include the bare `unknown` keyword
- * (forbidden by the architecture lint rule).
- */
-// NOSONAR — architecture rule no-restricted-syntax requires named alias for 'unknown'
-type JsonValue = unknown;
 
 /**
  * Pattern row matching a body field whose value indicates an auth failure.
@@ -84,7 +78,7 @@ function isErrorCodeFailure(v: JsonValue): boolean {
  * @returns True when v indicates a populated error.
  */
 function isErrorObjectFailure(v: JsonValue): boolean {
-  if (v === null || v === undefined) return false;
+  if (v === null) return false;
   if (typeof v === 'string') return v.length > 0;
   if (typeof v === 'object') return Object.keys(v).length > 0;
   return false;
@@ -207,7 +201,7 @@ function matchInRecord(record: Record<string, JsonValue>): string | false {
  * @param body - Parsed JSON response body.
  * @returns Matching pattern note when failure detected, false otherwise.
  */
-function classifyBodyAsFailure(body: JsonValue): string | false {
+function classifyBodyAsFailure(body: MaybeJsonValue): string | false {
   if (body === null || typeof body !== 'object') return false;
   const topRecord = body as Record<string, JsonValue>;
   const topHit = matchInRecord(topRecord);

--- a/src/Scrapers/Pipeline/Mediator/Network/NetworkDiscovery.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/NetworkDiscovery.ts
@@ -21,6 +21,7 @@ import type { IFetchOpts } from '../../Strategy/Fetch/FetchStrategy.js';
 import { getActivePhase, getActiveStage } from '../../Types/ActiveState.js';
 import { getDebug } from '../../Types/Debug.js';
 import { toErrorMessage } from '../../Types/ErrorUtils.js';
+import type { JsonValue } from '../../Types/Json.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
 import { redactJsonBody, redactUrl, redactUrlFull } from '../../Types/PiiRedactor.js';
 import { getSubStepNetworkDumpDir } from '../../Types/TraceConfig.js';
@@ -544,7 +545,9 @@ function tierPick(
   );
   if (urlMatches.length === 0) return { endpoint: false, tier: 'none', matches: 0 };
   const matches = urlMatches.length;
-  const shapePassing = urlMatches.filter((ep): boolean => hasTxnArray(ep.responseBody));
+  const shapePassing = urlMatches.filter((ep): boolean =>
+    hasTxnArray(ep.responseBody as JsonValue),
+  );
   const postWithShape = shapePassing.find(isReplayablePost);
   if (postWithShape) return { endpoint: postWithShape, tier: 'postWithShape', matches };
   const anyReplayablePost = urlMatches.find(isReplayablePost);

--- a/src/Scrapers/Pipeline/Mediator/OtpFill/OtpFillPhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/OtpFill/OtpFillPhaseActions.ts
@@ -367,10 +367,5 @@ function succeedWithDiag(input: IPipelineContext, action: string): Procedure<IPi
   return succeed({ ...input, diagnostics: diag });
 }
 
-export {
-  DEFAULT_OTP_TIMEOUT_MS,
-  executeFillAction,
-  executeFillFinal,
-  executeFillPost,
-  executeFillPre,
-};
+export { DEFAULT_OTP_TIMEOUT_MS } from '../Timing/TimingConfig.js';
+export { executeFillAction, executeFillFinal, executeFillPost, executeFillPre };

--- a/src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts
@@ -18,6 +18,7 @@ import {
 } from '../../Registry/WK/ScrapeWK.js';
 import { getDebug } from '../../Types/Debug.js';
 import type { IFieldMatch } from '../../Types/FieldMatch.js';
+import type { JsonValue } from '../../Types/Json.js';
 import type {
   ITxnEndpoint,
   ITxnEndpointInternal,
@@ -40,23 +41,6 @@ const LOG = getDebug(import.meta.url);
 
 /** API response record — wraps Record to hide `unknown` from function signatures. */
 type ApiRecord = Record<string, unknown>;
-
-/**
- * Untyped value crossing module boundaries. The named alias is
- * required because the architecture ESLint rule
- * (`no-restricted-syntax` selectors blocking `unknown` in function
- * signatures, lines 373-380 of `eslint.config.mjs`) forces an alias.
- * Sonar S6564 + `sonarjs/redundant-type-aliases` flagging the alias
- * is an acknowledged tradeoff; the `eslint.config.mjs` Section 12
- * file-scoped allowlist suppresses the redundant-alias rule on the
- * sibling parser at `Mediator/Scrape/ScrapeAutoMapper.ts`. Phase 7e
- * relocated the parser without expanding that allowlist (per the
- * "do not modify eslint config" directive); the alias stays here
- * because eliminating it would either fire the bare-`unknown` rule
- * or require a 14-site closed-union refactor with type-narrowing
- * casts at every boundary — out-of-scope for this commit.
- */
-type UntypedValue = unknown;
 
 /**
  * Result of probing a record for a scalar field — the raw scalar
@@ -146,7 +130,7 @@ interface ISearchItem {
  * @param val - Value to check.
  * @returns True if val is a non-null, non-array object.
  */
-function isSearchableObject(val: UntypedValue): boolean {
+function isSearchableObject(val: JsonValue): boolean {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
@@ -222,7 +206,7 @@ function enqueueChildren(
 ): boolean {
   if (depth >= MAX_SEARCH_DEPTH) return false;
   const nextDepth = depth + 1;
-  const recordValues = Object.values(record) as readonly UntypedValue[];
+  const recordValues = Object.values(record) as readonly JsonValue[];
   const children = recordValues.filter(isSearchableObject).map(
     (child): ISearchItem => ({
       value: child as Record<string, unknown>,
@@ -319,7 +303,7 @@ const TXN_SIGNATURE_FIELDS = new Set(
  * @param item - Object to score.
  * @returns Number of matching WK transaction fields.
  */
-function scoreTxnSignature(item: UntypedValue): number {
+function scoreTxnSignature(item: JsonValue): number {
   if (!isSearchableObject(item)) return 0;
   const keys = Object.keys(item as object).map((k): string => k.toLowerCase());
   return keys.filter((k): boolean => TXN_SIGNATURE_FIELDS.has(k)).length;
@@ -348,7 +332,7 @@ interface IArrayNodeCtx {
  */
 function pushArrayChildren(
   stack: IStackEntry[],
-  items: readonly UntypedValue[],
+  items: readonly JsonValue[],
   depth: number,
 ): number {
   const objects = items.filter((item): boolean => typeof item === 'object' && item !== null);
@@ -384,10 +368,10 @@ function pushObjectChildren(
  */
 function handleArrayNode(ctx: IArrayNodeCtx): boolean {
   if (ctx.node.length === 0) return false;
-  const firstNode = ctx.node[0];
+  const firstNode = ctx.node[0] as JsonValue;
   const score = scoreTxnSignature(firstNode);
   if (score < MIN_TXN_SCORE) {
-    pushArrayChildren(ctx.stack, ctx.node, ctx.depth);
+    pushArrayChildren(ctx.stack, ctx.node as readonly JsonValue[], ctx.depth);
     return false;
   }
   for (const item of ctx.node) ctx.collected.push(item);
@@ -403,7 +387,7 @@ function handleArrayNode(ctx: IArrayNodeCtx): boolean {
  */
 function processStackEntry(
   entry: IStackEntry,
-  collected: UntypedValue[],
+  collected: JsonValue[],
   stack: IStackEntry[],
 ): boolean {
   if (entry.depth > MAX_ARRAY_DEPTH) return false;
@@ -434,7 +418,7 @@ function processStackEntry(
  * @param collected - Mutable accumulator.
  * @returns True if stack is now empty.
  */
-function processOneLifo(stack: IStackEntry[], collected: UntypedValue[]): boolean {
+function processOneLifo(stack: IStackEntry[], collected: JsonValue[]): boolean {
   // `Array.pop` returns `undefined` on an empty stack, consolidating the
   // "stack is drained" signal into a single check.
   const entry = stack.pop();
@@ -456,7 +440,7 @@ const MAX_DRAIN_ITERATIONS = 1_000_000;
  * @param collected - Mutable accumulator.
  * @returns Collected items.
  */
-function drainLifoStack(stack: IStackEntry[], collected: UntypedValue[]): readonly UntypedValue[] {
+function drainLifoStack(stack: IStackEntry[], collected: JsonValue[]): readonly JsonValue[] {
   // `every` short-circuits when the predicate returns false. Each
   // step calls `processOneLifo`; when it returns true (stack drained)
   // the negation short-circuits `every` and the loop ends.
@@ -473,10 +457,10 @@ function drainLifoStack(stack: IStackEntry[], collected: UntypedValue[]): readon
  * @param obj - Root API record to search.
  * @returns First array of searchable items found.
  */
-function findFirstArray(obj: ApiRecord): readonly UntypedValue[] {
+function findFirstArray(obj: ApiRecord): readonly JsonValue[] {
   const initial: IStackEntry = { node: obj, depth: 0 };
   const stack: IStackEntry[] = [initial];
-  const collected: UntypedValue[] = [];
+  const collected: JsonValue[] = [];
   drainLifoStack(stack, collected);
   if (collected.length > 0) {
     LOG.debug({ message: `findFirstArray: collected ${String(collected.length)} items` });
@@ -486,12 +470,12 @@ function findFirstArray(obj: ApiRecord): readonly UntypedValue[] {
     message: 'findFirstArray: falling back to BFS',
   });
   const allObjects = flattenObjectTree(obj);
-  const arrays = allObjects.map((o): readonly UntypedValue[] | false => {
+  const arrays = allObjects.map((o): readonly JsonValue[] | false => {
     const arr = Object.values(o).find(Array.isArray);
-    if (arr) return arr as readonly UntypedValue[];
+    if (arr) return arr as readonly JsonValue[];
     return false;
   });
-  const hit = arrays.find((a): a is readonly UntypedValue[] => a !== false);
+  const hit = arrays.find((a): a is readonly JsonValue[] => a !== false);
   return hit ?? [];
 }
 
@@ -647,7 +631,7 @@ function autoMapTransaction(raw: ApiRecord): ITransaction | false {
  * @param items - Raw items to filter and cast.
  * @returns Typed record array.
  */
-function castSearchable(items: readonly UntypedValue[]): readonly ApiRecord[] {
+function castSearchable(items: readonly JsonValue[]): readonly ApiRecord[] {
   return items.filter((i): boolean => isSearchableObject(i)).map((i): ApiRecord => i as ApiRecord);
 }
 
@@ -704,7 +688,7 @@ function traceRawShape(responseBody: ApiRecord): true {
  * @param v - Candidate value.
  * @returns True when v looks like an account record.
  */
-function looksLikeAccountRecord(v: UntypedValue): boolean {
+function looksLikeAccountRecord(v: JsonValue): boolean {
   if (!isSearchableObject(v)) return false;
   const hit = findFieldValue(v as ApiRecord, WK_ACCT.id);
   return hit !== false;
@@ -720,7 +704,7 @@ function looksLikeAccountRecord(v: UntypedValue): boolean {
  */
 function rootAccountArray(responseBody: ApiRecord): readonly ApiRecord[] {
   if (!Array.isArray(responseBody)) return [];
-  const arr = responseBody as readonly unknown[];
+  const arr = responseBody as readonly JsonValue[];
   if (arr.length === 0) return [];
   if (!looksLikeAccountRecord(arr[0])) return [];
   return arr.filter(looksLikeAccountRecord).map((v): ApiRecord => v as ApiRecord);
@@ -1092,7 +1076,7 @@ function processHuntArray(args: IHuntArrayArgs): boolean {
   const { objects, depth, collected, stack } = args;
   if (objects.length === 0) return false;
   const firstObj = objects[0] as ApiRecord;
-  const score = scoreTxnSignature(firstObj);
+  const score = scoreTxnSignature(firstObj as JsonValue);
   if (score >= MIN_TXN_SCORE) {
     collected.push(...(objects as ApiRecord[]));
     return true;
@@ -1196,7 +1180,7 @@ function extractTransactions(responseBody: ApiRecord): readonly ITransaction[] {
 function findIndexedSubtree(body: ApiRecord, cardId: string): ApiRecord | false {
   const indexKey = `Index${cardId}`;
   const values = Object.values(body);
-  const nested = values.filter((v): boolean => isSearchableObject(v));
+  const nested = values.filter((v): boolean => isSearchableObject(v as JsonValue));
   const records = nested.map((v): ApiRecord => v as ApiRecord);
   const match = records.find((rec): boolean => indexKey in rec);
   if (match) return match[indexKey] as ApiRecord;

--- a/src/Scrapers/Pipeline/Mediator/Scrape/TxnShape.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/TxnShape.ts
@@ -16,6 +16,7 @@
 import { PIPELINE_WELL_KNOWN_TXN_FIELDS as WK_FIELDS } from '../../Registry/WK/ScrapeFieldMappings.js';
 import { PIPELINE_WELL_KNOWN_API } from '../../Registry/WK/ScrapeWK.js';
 import type { Brand } from '../../Types/Brand.js';
+import type { JsonValue, MaybeJsonValue } from '../../Types/Json.js';
 
 /** Whether a response body carries a non-empty txn array. */
 type HasTxnArray = Brand<boolean, 'HasTxnArray'>;
@@ -23,16 +24,8 @@ type HasTxnArray = Brand<boolean, 'HasTxnArray'>;
 /** Whether a URL matches a known dashboard-PREVIEW / widget pattern. */
 type IsTxnWidgetUrl = Brand<boolean, 'IsTxnWidgetUrl'>;
 
-/** Record alias — avoids literal Record<string, unknown> in annotations. */
-type JsonObject = Record<string, unknown>;
-
-/**
- * Untyped JSON value crossing module boundaries. The named alias is
- * required because the architecture ESLint rule (`no-restricted-syntax`)
- * forbids the literal `unknown` keyword in function signatures.
- */
-// NOSONAR: typescript:S6564 — alias is required by `no-restricted-syntax`.
-type JsonValue = unknown;
+/** Record alias — narrow JSON-typed record so type guards from JsonValue work. */
+type JsonObject = Record<string, JsonValue>;
 
 /** Max BFS depth when scanning a captured body for a txn array.
  *  Banks nest: body.result.bankAccounts[].debitDates[].transactions[]
@@ -78,14 +71,14 @@ function recordCarriesTxnArray(record: JsonObject): boolean {
 function recordCarriesShapedArray(record: JsonObject): boolean {
   return Object.values(record).some((value): boolean => {
     if (!Array.isArray(value) || value.length === 0) return false;
-    const first: JsonValue = value[0];
+    const first = value[0] as JsonValue;
     if (!isPlainRecord(first)) return false;
     const head = first;
-    const hasDate = WK_FIELDS.date.some((key): boolean => head[key] !== undefined);
+    const hasDate = WK_FIELDS.date.some((key): boolean => key in head);
     const hasAmount =
-      WK_FIELDS.amount.some((key): boolean => head[key] !== undefined) ||
-      WK_FIELDS.creditAmount.some((key): boolean => head[key] !== undefined) ||
-      WK_FIELDS.debitAmount.some((key): boolean => head[key] !== undefined);
+      WK_FIELDS.amount.some((key): boolean => key in head) ||
+      WK_FIELDS.creditAmount.some((key): boolean => key in head) ||
+      WK_FIELDS.debitAmount.some((key): boolean => key in head);
     return hasDate && hasAmount;
   });
 }
@@ -96,8 +89,13 @@ function recordCarriesShapedArray(record: JsonObject): boolean {
  * @returns Flattened children to enqueue at the next BFS depth.
  */
 function expandForBfs(v: JsonValue): readonly JsonValue[] {
-  if (Array.isArray(v)) return v;
-  if (isPlainRecord(v)) return Object.values(v);
+  // `Array.isArray` is typed as `v is any[]` in lib.d.ts, so the narrow
+  // path needs an explicit re-cast back to the value type.
+  if (Array.isArray(v)) return v as readonly JsonValue[];
+  if (isPlainRecord(v)) {
+    const record: Record<string, JsonValue> = v;
+    return Object.values(record);
+  }
   return [];
 }
 
@@ -129,9 +127,9 @@ function bfsStep(state: IBfsFrontier): IBfsFrontier {
  * @param body - Captured JSON response body (any shape).
  * @returns True when a non-empty txn array is reachable within the depth budget.
  */
-export function hasTxnArray(body: JsonValue): HasTxnArray {
+export function hasTxnArray(body: MaybeJsonValue): HasTxnArray {
   const depths = Array.from({ length: TXN_SCAN_MAX_DEPTH }, (_, i): number => i);
-  const initial: IBfsFrontier = { level: [body], found: false };
+  const initial: IBfsFrontier = { level: [body as JsonValue], found: false };
   const final = depths.reduce((acc): IBfsFrontier => bfsStep(acc), initial);
   return final.found as HasTxnArray;
 }

--- a/src/Scrapers/Pipeline/Mediator/Timing/HumanizeWait.ts
+++ b/src/Scrapers/Pipeline/Mediator/Timing/HumanizeWait.ts
@@ -16,6 +16,7 @@
  * `resolveVisible` runs against a deterministic position.
  */
 
+import { randomInt } from 'node:crypto';
 import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 
 import type { Page } from 'playwright-core';
@@ -45,8 +46,15 @@ interface IJitterCursor {
  * @returns Next position tuple.
  */
 function nextJitterPosition(prevX: number, prevY: number): readonly [number, number] {
-  const dx = Math.round((Math.random() - 0.5) * 2 * HUMANIZE_JITTER_RADIUS_PX);
-  const dy = Math.round((Math.random() - 0.5) * 2 * HUMANIZE_JITTER_RADIUS_PX);
+  // `node:crypto.randomInt(min, max)` returns an int in [min, max).
+  // Using ±(radius+1) gives a symmetric offset and satisfies the
+  // project's "no Math.random()" rule (SC S2245 / typescript:S2245).
+  // Mouse jitter doesn't need crypto-grade entropy per se, but the
+  // architecture rule centralises pseudo-random calls on the secure
+  // generator so security-sensitive code can never accidentally adopt
+  // Math.random() in the future.
+  const dx = randomInt(-HUMANIZE_JITTER_RADIUS_PX, HUMANIZE_JITTER_RADIUS_PX + 1);
+  const dy = randomInt(-HUMANIZE_JITTER_RADIUS_PX, HUMANIZE_JITTER_RADIUS_PX + 1);
   const nextX = Math.max(0, prevX + dx);
   const nextY = Math.max(0, prevY + dy);
   return [nextX, nextY] as const;

--- a/src/Scrapers/Pipeline/Mediator/Timing/HumanizeWait.ts
+++ b/src/Scrapers/Pipeline/Mediator/Timing/HumanizeWait.ts
@@ -1,0 +1,129 @@
+/**
+ * Humanized settle — mouse-jitter implementation used by the central
+ * `phaseSettle` in `Core/Executor/PipelineReducer.ts` for the
+ * pre-auth phase whitelist (INIT, HOME, LOGIN). Extracted into its
+ * own module so `CreateElementMediator.ts` only pulls in the single
+ * builder factory rather than four `TimingConfig` constants — keeping
+ * the mediator file inside the `import-x/max-dependencies` cap.
+ *
+ * <p>Mission: bank-side bot detection (Hapoalim hCaptcha, Isracard
+ * temp-fault page) profiles the pre-auth window for "human input
+ * present?". A silent 4 s settle reads as bot and the bank responds
+ * with a challenge / error page. This helper emits roughly one
+ * mouse-move every {@link HUMANIZE_TICK_MS} across the budget, each
+ * within {@link HUMANIZE_JITTER_RADIUS_PX} of the previous position,
+ * then parks the cursor at the top-left so downstream
+ * `resolveVisible` runs against a deterministic position.
+ */
+
+import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
+
+import type { Page } from 'playwright-core';
+
+import type { IElementMediator } from '../Elements/ElementMediator.js';
+import {
+  HUMANIZE_END_X,
+  HUMANIZE_END_Y,
+  HUMANIZE_JITTER_RADIUS_PX,
+  HUMANIZE_TICK_MS,
+} from './TimingConfig.js';
+
+/** Mutable cursor position threaded through the reduce chain. */
+interface IJitterCursor {
+  x: number;
+  y: number;
+}
+
+/**
+ * Compute the next jitter pixel position bounded inside the
+ * `HUMANIZE_JITTER_RADIUS_PX` band around the previous position.
+ * Coordinates clamped to non-negative integers so Playwright never
+ * sees a negative pixel.
+ *
+ * @param prevX - Previous cursor X.
+ * @param prevY - Previous cursor Y.
+ * @returns Next position tuple.
+ */
+function nextJitterPosition(prevX: number, prevY: number): readonly [number, number] {
+  const dx = Math.round((Math.random() - 0.5) * 2 * HUMANIZE_JITTER_RADIUS_PX);
+  const dy = Math.round((Math.random() - 0.5) * 2 * HUMANIZE_JITTER_RADIUS_PX);
+  const nextX = Math.max(0, prevX + dx);
+  const nextY = Math.max(0, prevY + dy);
+  return [nextX, nextY] as const;
+}
+
+/**
+ * Resolve the cursor start position. Centre of the Camoufox viewport
+ * so the random walk has equal room in every direction before it
+ * parks at the corner.
+ *
+ * @param page - The Playwright page bound to this mediator instance.
+ * @returns Starting cursor coordinates.
+ */
+function startCursor(page: Page): IJitterCursor {
+  const vp = page.viewportSize();
+  const w = vp?.width ?? HUMANIZE_JITTER_RADIUS_PX * 24;
+  const h = vp?.height ?? HUMANIZE_JITTER_RADIUS_PX * 14;
+  return { x: Math.floor(w / 2), y: Math.floor(h / 2) };
+}
+
+/**
+ * Run a single jitter tick — move the cursor once + wait one tick.
+ * Best-effort: any `mouse.move` rejection is swallowed so a closing
+ * page does not break the settle.
+ *
+ * @param page - The Playwright page.
+ * @param cursor - Mutable cursor (updated in place).
+ * @returns True after the tick completes.
+ */
+async function runJitterTick(page: Page, cursor: IJitterCursor): Promise<true> {
+  const [nextX, nextY] = nextJitterPosition(cursor.x, cursor.y);
+  cursor.x = nextX;
+  cursor.y = nextY;
+  await page.mouse.move(cursor.x, cursor.y).catch((): true => true);
+  await setTimeoutPromise(HUMANIZE_TICK_MS, undefined, { ref: false });
+  return true as const;
+}
+
+/**
+ * Park the cursor at the top-left after the last jitter tick, after
+ * exhausting any remaining time in the budget.
+ *
+ * @param page - The Playwright page.
+ * @param remainingMs - Leftover budget time after the tick chain.
+ * @returns True after parking.
+ */
+async function parkCursor(page: Page, remainingMs: number): Promise<true> {
+  if (remainingMs > 0) {
+    await setTimeoutPromise(remainingMs, undefined, { ref: false });
+  }
+  await page.mouse.move(HUMANIZE_END_X, HUMANIZE_END_Y).catch((): true => true);
+  return true as const;
+}
+
+/**
+ * Build the `humanizeWait` mediator method bound to a Playwright Page.
+ *
+ * @param page - The Playwright page.
+ * @returns Mediator humanizeWait function.
+ */
+export default function buildHumanizeWait(page: Page): IElementMediator['humanizeWait'] {
+  return async (budgetMs: number): Promise<true> => {
+    const start = Date.now();
+    const cursor = startCursor(page);
+    // `-1` reserves one tick's worth of budget so `parkCursor` always
+    // has time to land at the corner before the wall-clock window
+    // ends — keeps the total wait inside `budgetMs` even after
+    // mouse-move CDP overhead per tick (~5-20 ms).
+    const tickCount = Math.max(0, Math.floor(budgetMs / HUMANIZE_TICK_MS) - 1);
+    const ticks = Array.from({ length: tickCount }, (_, i): number => i);
+    const initialPromise: Promise<true> = Promise.resolve(true as const);
+    const tickChain = ticks.reduce<Promise<true>>(async (prev): Promise<true> => {
+      await prev;
+      return runJitterTick(page, cursor);
+    }, initialPromise);
+    await tickChain;
+    const remaining = Math.max(0, budgetMs - (Date.now() - start));
+    return parkCursor(page, remaining);
+  };
+}

--- a/src/Scrapers/Pipeline/Mediator/Timing/TimingConfig.ts
+++ b/src/Scrapers/Pipeline/Mediator/Timing/TimingConfig.ts
@@ -56,6 +56,52 @@ export const HUMAN_DELAY_MAX_MS = 1200;
  */
 export const PHASE_SETTLE_MS = 4000;
 
+/**
+ * Phases that consume a HUMANIZED settle window — small mouse-move
+ * events emitted at fixed ticks across {@link PHASE_SETTLE_MS} so the
+ * page sees user-input signals instead of a silent 4 s pause. Limited
+ * to the pre-auth phases where bank-side bot detection runs:
+ * INIT (initial navigation), HOME (login-link discovery), LOGIN (form
+ * fill). Post-auth phases keep the cheap `setTimeoutPromise` settle
+ * because the session is already authenticated and bot detection is
+ * not re-applied per call.
+ *
+ * <p>Mission: closes the silent-settle window that Hapoalim's hCaptcha
+ * and Isracard's temp-fault page surface (HOME-PRE-FAIL screenshots
+ * from PR #235 cycle 2, 2026-05-18). The cursor is parked at
+ * {@link HUMANIZE_END_X}, {@link HUMANIZE_END_Y} after the final tick so
+ * downstream `resolveVisible` runs against a deterministic mouse
+ * position.
+ */
+export const HUMANIZE_JITTER_PHASES: ReadonlySet<string> = new Set(['init', 'home', 'login']);
+
+/**
+ * Interval between humanized mouse-move ticks (ms). At 400 ms over a
+ * 4 s settle window the mediator emits ~10 small moves before the
+ * final park. Sized so the per-tick wall is well above the
+ * sub-100 ms scheduler jitter floor and well below the 1 s window in
+ * which a bot-detection heuristic would notice "no input ever".
+ */
+export const HUMANIZE_TICK_MS = 400;
+
+/**
+ * Maximum jitter pixel offset per tick (X and Y). Camoufox window
+ * is pinned at 1920x1080; the cursor walks inside a small region
+ * around the previous position so the trajectory looks like idle
+ * micro-motion rather than a teleport.
+ */
+export const HUMANIZE_JITTER_RADIUS_PX = 40;
+
+/**
+ * Park-position X after the last jitter tick. Origin (top-left)
+ * keeps the cursor out of the way of any clickable element the next
+ * phase will resolve via `resolveVisible`.
+ */
+export const HUMANIZE_END_X = 0;
+
+/** Park-position Y after the last jitter tick. See {@link HUMANIZE_END_X}. */
+export const HUMANIZE_END_Y = 0;
+
 // ── Auth-discovery thresholds (non-time) ──────────────────────────
 
 /**

--- a/src/Scrapers/Pipeline/Mediator/Timing/TimingConfig.ts
+++ b/src/Scrapers/Pipeline/Mediator/Timing/TimingConfig.ts
@@ -73,7 +73,26 @@ export const PHASE_SETTLE_MS = 4000;
  * downstream `resolveVisible` runs against a deterministic mouse
  * position.
  */
-export const HUMANIZE_JITTER_PHASES: ReadonlySet<string> = new Set(['init', 'home', 'login']);
+const HUMANIZE_JITTER_PHASE_LIST = ['init', 'home', 'login'] as const;
+
+/** Phase-name literal union — phases that opt into the humanized settle. */
+export type HumanizeJitterPhase = (typeof HUMANIZE_JITTER_PHASE_LIST)[number];
+
+const HUMANIZE_JITTER_PHASES_SET: ReadonlySet<HumanizeJitterPhase> = new Set(
+  HUMANIZE_JITTER_PHASE_LIST,
+);
+
+/**
+ * Type-narrowing predicate — returns true if `name` is one of the
+ * phases that humanizes its phase-settle window. Use instead of a
+ * bare `Set.has(...)` so callers get a `name is HumanizeJitterPhase`
+ * narrowing, not just a boolean.
+ * @param name - Phase name to check against the whitelist.
+ * @returns Whether the phase opts into humanized settle.
+ */
+export function isHumanizeJitterPhase(name: string): name is HumanizeJitterPhase {
+  return (HUMANIZE_JITTER_PHASES_SET as ReadonlySet<string>).has(name);
+}
 
 /**
  * Interval between humanized mouse-move ticks (ms). At 400 ms over a

--- a/src/Scrapers/Pipeline/Phases/Init/InitBrowserSetup.ts
+++ b/src/Scrapers/Pipeline/Phases/Init/InitBrowserSetup.ts
@@ -7,7 +7,10 @@ import type { Browser, BrowserContext, Page } from 'playwright-core';
 
 import type { IDefaultBrowserOptions, ScraperOptions } from '../../../Base/Interface.js';
 import { buildContextOptions } from '../../Mediator/Browser/BrowserContextBuilder.js';
-import { launchCamoufox } from '../../Mediator/Browser/CamoufoxLauncher.js';
+import {
+  buildCloseAndStripCleanup,
+  launchCamoufoxForBank,
+} from '../../Mediator/Browser/CamoufoxLauncher.js';
 import type { Brand } from '../../Types/Brand.js';
 import type { IBrowserState } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
@@ -17,24 +20,39 @@ import { succeed } from '../../Types/Procedure.js';
 type DidLifecycleStep = Brand<boolean, 'DidLifecycleStep'>;
 
 /**
- * Launch a new Camoufox browser.
- * @param options - Scraper options with browser config.
- * @returns Launched browser instance.
+ * Launch result discriminator — the persistent-profile path returns
+ * a {@link BrowserContext}, the ephemeral path returns a {@link Browser}.
+ * Callers must narrow before treating the result.
  */
-async function launchBrowser(options: ScraperOptions): Promise<Browser> {
+type LaunchResult = Browser | BrowserContext;
+
+/**
+ * Launch a Camoufox session for the bank identified by `companyId`.
+ *
+ * When `USE_PERSISTENT_PROFILES=true`, the resulting session is backed
+ * by a per-bank profile dir; otherwise a fresh ephemeral browser is
+ * launched (legacy behaviour). Either way the optional
+ * `prepareBrowser` hook still runs on the Browser-typed handle when
+ * present — the persistent-context path skips it since there is no
+ * Browser handle to pass.
+ * @param options - Scraper options with browser config and `companyId`.
+ * @returns Launched browser (ephemeral) or browser context (persistent).
+ */
+async function launchBrowser(options: ScraperOptions): Promise<LaunchResult> {
   const opts = options as IDefaultBrowserOptions;
   const isHeadless = !opts.shouldShowBrowser;
-  const browser = await launchCamoufox(isHeadless);
-  if (opts.prepareBrowser) await opts.prepareBrowser(browser);
-  return browser;
+  const result = await launchCamoufoxForBank(isHeadless, options.companyId);
+  if (opts.prepareBrowser && 'newContext' in result) await opts.prepareBrowser(result);
+  return result;
 }
 
 /**
- * Create browser context and page from a browser.
- * @param browser - The browser to create context from.
- * @returns Object with context and page.
+ * Open a page on a freshly-created ephemeral context, closing the
+ * context if `newPage` throws so the caller doesn't leak.
+ * @param browser - Browser handle from the ephemeral launcher path.
+ * @returns Resolved context + page pair.
  */
-async function createContextAndPage(
+async function ephemeralContextAndPage(
   browser: Browser,
 ): Promise<{ context: BrowserContext; page: Page }> {
   const contextOpts = buildContextOptions();
@@ -43,9 +61,43 @@ async function createContextAndPage(
     const page = await context.newPage();
     return { context, page };
   } catch (error) {
-    await context.close().catch((): DidLifecycleStep => false as DidLifecycleStep);
+    const closed = context.close();
+    await closed.catch((): DidLifecycleStep => false as DidLifecycleStep);
     throw error;
   }
+}
+
+/**
+ * Reuse the first page of a persistent context, opening a new one when
+ * the restored profile has none yet.
+ * @param context - Persistent context from the bank-scoped launcher.
+ * @returns Resolved context + page pair.
+ */
+async function persistentContextAndPage(
+  context: BrowserContext,
+): Promise<{ context: BrowserContext; page: Page }> {
+  const existing = context.pages();
+  if (existing.length > 0) return { context, page: existing[0] };
+  const page = await context.newPage();
+  return { context, page };
+}
+
+/**
+ * Materialise a browser context + first page from the launcher result.
+ *
+ * Ephemeral path (Browser): creates a fresh context via `newContext`
+ * with {@link buildContextOptions}. Persistent path (BrowserContext):
+ * the context already exists with context-level options baked in at
+ * launch time; we reuse its first page, opening a new one only if
+ * none exists yet.
+ * @param result - Launcher output (Browser or BrowserContext).
+ * @returns Resolved context + page pair.
+ */
+async function createContextAndPage(
+  result: LaunchResult,
+): Promise<{ context: BrowserContext; page: Page }> {
+  if ('newContext' in result) return ephemeralContextAndPage(result);
+  return persistentContextAndPage(result);
 }
 
 /**
@@ -80,40 +132,75 @@ function closeHandler(closeable: ICloseable): () => Promise<Procedure<void>> {
 }
 
 /**
+ * Bundled descriptor of everything `buildBrowserState` / `buildCleanups`
+ * need. Bundled because the project's per-function parameter cap is 3.
+ */
+interface IBuiltBrowserComponents {
+  readonly page: Page;
+  readonly context: BrowserContext;
+  readonly launchResult: LaunchResult;
+  readonly bank: string;
+}
+
+/**
+ * Wrap the launcher's composite close+strip cleanup so it conforms to
+ * the `IBrowserState['cleanups']` element shape, which expects
+ * `() => Promise<Procedure<void>>` (the pipeline's Procedure-typed
+ * status), not the raw `() => Promise<true>` the launcher returns.
+ * @param launchResult - Launch result (Browser or BrowserContext).
+ * @param bank - Bank identifier driving the strip-cache branch.
+ * @returns Pipeline-shaped cleanup callable.
+ */
+function launchCloseHandler(
+  launchResult: LaunchResult,
+  bank: string,
+): () => Promise<Procedure<void>> {
+  const inner = buildCloseAndStripCleanup(launchResult, bank);
+  return (): Promise<Procedure<void>> => inner().then((): Procedure<void> => succeed(undefined));
+}
+
+/**
  * Build cleanup handlers for browser lifecycle.
- * @param thePage - The page to close.
- * @param theContext - The browser context to close.
- * @param theBrowser - The browser to close.
+ *
+ * Ordering — ephemeral path follows the legacy Browser → Context →
+ * Page convention. Persistent path skips the duplicate close because
+ * `launchResult === context`. The launcher's composite cleanup folds
+ * strip-cache inside its own close so the ordered list only carries
+ * the resource-close entries.
+ * @param components - Page/context/launchResult/bank bundle.
  * @returns Ordered cleanup array.
  */
-function buildCleanups(
-  thePage: Page,
-  theContext: BrowserContext,
-  theBrowser: Browser,
-): IBrowserState['cleanups'] {
-  return [closeHandler(theBrowser), closeHandler(theContext), closeHandler(thePage)];
+function buildCleanups(components: IBuiltBrowserComponents): IBrowserState['cleanups'] {
+  const { page, context, launchResult, bank } = components;
+  const launchCleanup = launchCloseHandler(launchResult, bank);
+  if (launchResult === context) {
+    return [launchCleanup];
+  }
+  return [launchCleanup, closeHandler(context), closeHandler(page)];
 }
 
 /**
  * Build the browser state from launched components.
- * @param page - The Playwright page.
- * @param context - The browser context.
- * @param browser - The browser instance.
+ * @param components - Page/context/launchResult/bank bundle.
  * @returns IBrowserState with page, context, and cleanups.
  */
-function buildBrowserState(page: Page, context: BrowserContext, browser: Browser): IBrowserState {
-  const cleanups = buildCleanups(page, context, browser);
-  return { page, context, cleanups };
+function buildBrowserState(components: IBuiltBrowserComponents): IBrowserState {
+  const cleanups = buildCleanups(components);
+  return { page: components.page, context: components.context, cleanups };
 }
 
 /**
- * Close a browser handle if it was successfully launched.
- * @param browser - Browser handle or false if not yet launched.
- * @returns True if closed, false if no browser or close failed.
+ * Close a launcher result if one was successfully launched.
+ *
+ * Used by the InitPhase rollback path when a downstream step throws
+ * after the browser/context was acquired but before the full
+ * IBrowserState was assembled. Tolerant of either union arm.
+ * @param launchResult - Launch result or false if not yet launched.
+ * @returns True if closed, false if no launch or close failed.
  */
-async function closeBrowserSafe(browser: Browser | false): Promise<DidLifecycleStep> {
-  if (!browser) return false as DidLifecycleStep;
-  return browser
+async function closeBrowserSafe(launchResult: LaunchResult | false): Promise<DidLifecycleStep> {
+  if (!launchResult) return false as DidLifecycleStep;
+  return launchResult
     .close()
     .then((): DidLifecycleStep => true as DidLifecycleStep)
     .catch((): DidLifecycleStep => false as DidLifecycleStep);

--- a/src/Scrapers/Pipeline/Phases/Init/InitBrowserSetup.ts
+++ b/src/Scrapers/Pipeline/Phases/Init/InitBrowserSetup.ts
@@ -195,15 +195,44 @@ function buildBrowserState(components: IBuiltBrowserComponents): IBrowserState {
  * Used by the InitPhase rollback path when a downstream step throws
  * after the browser/context was acquired but before the full
  * IBrowserState was assembled. Tolerant of either union arm.
+ *
+ * When `bank` is supplied AND the launch succeeded, the strip-aware
+ * composite cleanup runs so a persistent-profile `Cache/` /
+ * `cache2/` / `OfflineCache/` directory left behind by the partially
+ * initialised launch doesn't survive into the next run. Without the
+ * bank, falls back to the legacy bare `.close()` so existing
+ * unit-test fixtures still drive the no-strip branch.
  * @param launchResult - Launch result or false if not yet launched.
+ * @param bank - Optional bank id; enables strip-aware cleanup.
  * @returns True if closed, false if no launch or close failed.
  */
-async function closeBrowserSafe(launchResult: LaunchResult | false): Promise<DidLifecycleStep> {
+async function closeBrowserSafe(
+  launchResult: LaunchResult | false,
+  bank?: string,
+): Promise<DidLifecycleStep> {
   if (!launchResult) return false as DidLifecycleStep;
-  return launchResult
-    .close()
+  const cleanup = pickRollbackCleanup(launchResult, bank);
+  return cleanup()
     .then((): DidLifecycleStep => true as DidLifecycleStep)
     .catch((): DidLifecycleStep => false as DidLifecycleStep);
+}
+
+/**
+ * Pick the rollback cleanup for `closeBrowserSafe` — the strip-aware
+ * composite when a bank is supplied (so persistent-profile launches
+ * scrub `Cache/` etc.) or a bare close that resolves true on success.
+ * @param launchResult - Live Browser or BrowserContext to close.
+ * @param bank - Optional bank id; presence enables strip-cache.
+ * @returns Cleanup callable resolving true after close.
+ */
+function pickRollbackCleanup(launchResult: LaunchResult, bank?: string): () => Promise<true> {
+  if (bank === undefined) {
+    return async (): Promise<true> => {
+      await launchResult.close();
+      return true;
+    };
+  }
+  return buildCloseAndStripCleanup(launchResult, bank);
 }
 
 export { buildBrowserState, closeBrowserSafe, createContextAndPage, launchBrowser, setupPage };

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
@@ -24,7 +24,12 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
     urls: { base: 'https://www.discountbank.co.il' },
   },
   [CompanyTypes.Hapoalim]: {
-    urls: { base: 'https://www.bankhapoalim.co.il' },
+    // Hapoalim: navigate directly to the login page so the pipeline
+    // can skip HOME entirely (see `.withSkipHome()` in HapoalimPipeline.ts).
+    // The marketing homepage at `www.bankhapoalim.co.il` exposes the silent
+    // DOM-scan window that triggers the chronic hCaptcha challenge in CI;
+    // going straight to the login-page subdomain bypasses that surface.
+    urls: { base: 'https://login.bankhapoalim.co.il/ng-portals/auth/he/' },
   },
   [CompanyTypes.Massad]: {
     urls: { base: 'https://www.bankmassad.co.il' },

--- a/src/Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.ts
@@ -18,11 +18,10 @@
 
 import { ScraperErrorTypes } from '../../../../Base/ErrorTypes.js';
 import { findFieldValue } from '../../../Mediator/Scrape/ScrapeAutoMapper.js';
+import type { JsonValue, MaybeJsonValue } from '../../../Types/Json.js';
 import type { Procedure } from '../../../Types/Procedure.js';
 import { fail, succeed } from '../../../Types/Procedure.js';
 
-// NOSONAR — architecture rule no-restricted-syntax requires named alias for 'unknown'
-type JsonValue = unknown;
 type JsonObject = Record<string, JsonValue>;
 type MaybeRecord = JsonObject | null | undefined;
 
@@ -31,7 +30,7 @@ type MaybeRecord = JsonObject | null | undefined;
  * @param v - Value to test.
  * @returns True if v is a record.
  */
-export function isRecord(v: JsonValue): v is JsonObject {
+export function isRecord(v: MaybeJsonValue): v is JsonObject {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 

--- a/src/Scrapers/Pipeline/Strategy/Scrape/Account/ScrapeIdExtraction.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/Account/ScrapeIdExtraction.ts
@@ -12,6 +12,7 @@ import type { Brand } from '../../../Types/Brand.js';
 import { getDebug as createLogger } from '../../../Types/Debug.js';
 import type { IAccountIdentity, IFieldMatch } from '../../../Types/FieldMatch.js';
 import { buildFallbackMatch } from '../../../Types/FieldMatch.js';
+import type { JsonValue } from '../../../Types/Json.js';
 import type { Procedure } from '../../../Types/Procedure.js';
 import { fail, isOk, succeed } from '../../../Types/Procedure.js';
 
@@ -128,9 +129,7 @@ function extractCardId(record: Record<string, unknown>): string | false {
 /** Error message when no captured endpoint carries a displayId. */
 const NO_DISPLAY_ID_IN_STORE = 'no displayId field in any captured endpoint';
 
-// NOSONAR — architecture rule no-restricted-syntax requires named alias for 'unknown'
-type JsonValue = unknown;
-/** Plain-record alias — composes JsonValue to keep function sigs clean. */
+/** Plain-record alias — narrow JSON-typed record for clean type guards. */
 type JsonObject = Record<string, JsonValue>;
 
 /**
@@ -154,7 +153,7 @@ function extractDisplayFromBody(body: JsonValue): string | false {
 function resolveDisplayIdFromCapturedEndpoints(network: INetworkDiscovery): Procedure<string> {
   const hit = network
     .getAllEndpoints()
-    .map((ep): string | false => extractDisplayFromBody(ep.responseBody))
+    .map((ep): string | false => extractDisplayFromBody(ep.responseBody as JsonValue))
     .find((v): v is string => v !== false);
   if (typeof hit === 'string') return succeed(hit);
   return fail(ScraperErrorTypes.Generic, NO_DISPLAY_ID_IN_STORE);

--- a/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeDataActions.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeDataActions.ts
@@ -18,6 +18,7 @@ import {
 } from '../../Registry/WK/ScrapeWK.js';
 import type { Brand } from '../../Types/Brand.js';
 import { getDebug as createLogger } from '../../Types/Debug.js';
+import type { JsonObject, JsonValue } from '../../Types/Json.js';
 import { redactAccount } from '../../Types/PiiRedactor.js';
 import type { IApiFetchContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
@@ -465,7 +466,7 @@ async function buildAccountResult(
 }
 
 /** Captured record list — concrete type avoids null/undefined in signatures. */
-type CapturedRecords = readonly Record<string, unknown>[];
+type CapturedRecords = readonly JsonObject[];
 
 /**
  * Project one captured endpoint to a 0- or 1-element record array.
@@ -474,8 +475,8 @@ type CapturedRecords = readonly Record<string, unknown>[];
  * @returns Single-element array if responseBody is a plain record, else empty.
  */
 function projectEndpointBody(ep: IDiscoveredEndpoint): CapturedRecords {
-  if (!isRecord(ep.responseBody)) return [];
-  return [ep.responseBody];
+  if (!isRecord(ep.responseBody as JsonValue)) return [];
+  return [ep.responseBody as JsonObject];
 }
 
 /**
@@ -548,7 +549,7 @@ function resolveBalanceFromCapturedEndpoints(
  */
 async function resolveBalance(ctx: IAccountAssemblyCtx): Promise<number> {
   const aliases = balanceAliasesFor(ctx);
-  const fromRecord = resolveRecordBalance(ctx.rawRecord, aliases);
+  const fromRecord = resolveRecordBalance(ctx.rawRecord as JsonObject | undefined, aliases);
   if (typeof fromRecord === 'number') return fromRecord;
   const fromStore = resolveBalanceFromCapturedEndpoints(ctx.fc.network, aliases);
   if (isOk(fromStore)) return fromStore.value;

--- a/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeTypes.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeTypes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { INetworkDiscovery } from '../../Mediator/Network/NetworkDiscovery.js';
+import type { JsonValue } from '../../Types/Json.js';
 import type {
   IApiFetchContext,
   IBillingCycleCatalog,
@@ -40,15 +41,8 @@ const EMPTY_TXN_ENDPOINT: ITxnEndpoint = {
 
 /** API response payload — wraps Record to hide `unknown` from function signatures. */
 type ApiPayload = Record<string, unknown>;
-/**
- * Untyped API value — named alias kept to satisfy the architecture
- * `no-restricted-syntax` rule that forbids bare `unknown` in function
- * signatures. NOSONAR rationale below.
- */
-// NOSONAR — architecture rule no-restricted-syntax requires named alias for 'unknown'
-type ApiValue = unknown;
-/** Untyped API array — wraps `unknown[]` to satisfy no-unknown-in-signatures ESLint rule. */
-type ApiValueArray = ApiValue[];
+/** Untyped JSON array — composes the shared JsonValue. */
+type JsonValueArray = JsonValue[];
 
 /**
  * Bundled context for fetching one account's data. Phase 7f: TXN
@@ -170,10 +164,9 @@ interface IFetchAllAccountsCtx {
 }
 
 export { EMPTY_FIELD_MAP, EMPTY_TXN_ENDPOINT };
+export type { JsonValue } from '../../Types/Json.js';
 export type {
   ApiPayload,
-  ApiValue,
-  ApiValueArray,
   IAccountAssemblyCtx,
   IAccountFetchCtx,
   IAccountFetchOpts,
@@ -181,4 +174,5 @@ export type {
   IChunkingCtx,
   IFetchAllAccountsCtx,
   IPostFetchCtx,
+  JsonValueArray,
 };

--- a/src/Scrapers/Pipeline/Types/Brand.ts
+++ b/src/Scrapers/Pipeline/Types/Brand.ts
@@ -152,3 +152,24 @@ export type PhaseStepLabel = Brand<string, 'PhaseStepLabel'>;
 export function mintPhaseStepLabel(raw: string): PhaseStepLabel {
   return raw as PhaseStepLabel;
 }
+
+/**
+ * Opaque frame identifier — 'main' or 'iframe:<stable-url>'. Used by
+ * the FrameRegistry to look up a Playwright `Frame` from a string
+ * that crosses Mediator boundaries. Mint at the FrameRegistry
+ * boundary; consumers receive the brand and round-trip it.
+ *
+ * Re-exported from `PipelineContext.ts` to preserve existing import
+ * paths — the canonical declaration lives here to avoid a cyclic
+ * import between `Brand` and `PipelineContext`.
+ */
+export type ContextId = Brand<string, 'ContextId'>;
+
+/**
+ * Mints a ContextId from a raw string.
+ * @param raw - Raw identifier built from frame URL or name.
+ * @returns The same string typed as ContextId.
+ */
+export function mintContextId(raw: string): ContextId {
+  return raw as ContextId;
+}

--- a/src/Scrapers/Pipeline/Types/Brand.ts
+++ b/src/Scrapers/Pipeline/Types/Brand.ts
@@ -173,3 +173,12 @@ export type ContextId = Brand<string, 'ContextId'>;
 export function mintContextId(raw: string): ContextId {
   return raw as ContextId;
 }
+
+/**
+ * Canonical main-frame identifier. Exported as a const so callers
+ * (FrameRegistry, DashboardPhaseActions, and any future Mediator that
+ * needs to address the main frame) share a single source of truth
+ * instead of repeating `mintContextId('main')` or `'main' as ContextId`
+ * inline (CodeRabbit follow-up 2026-05-18).
+ */
+export const MAIN_CONTEXT_ID: ContextId = mintContextId('main');

--- a/src/Scrapers/Pipeline/Types/Json.ts
+++ b/src/Scrapers/Pipeline/Types/Json.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared JSON value type — the structural shape of parsed-JSON data
+ * crossing Pipeline boundaries.
+ *
+ * Created 2026-05-18 to replace six `type JsonValue/UntypedValue/
+ * ApiValue = unknown` local aliases that each independently satisfied
+ * the architecture `no-restricted-syntax` rule banning bare `unknown`
+ * in function signatures. The local-aliases pattern triggered SonarCloud
+ * S6564 (redundant type alias) seven times — replacing them with this
+ * concrete recursive union both closes the Sonar finding and aligns
+ * with the architecture rule's stated intent ("Define a specific
+ * Interface").
+ *
+ * Semantically aligned with `JSON.parse` return values — any value
+ * reachable from parsing a JSON document. Call-sites still need type
+ * guards (`typeof v === 'string'` etc.) before accessing members,
+ * exactly as they did with the previous `= unknown` aliases. The
+ * narrower union means `unknown` values from outside JSON sources
+ * (e.g. arbitrary `Record<string, unknown>` from test fixtures) need
+ * an explicit `as JsonValue` cast at the boundary.
+ */
+
+/**
+ * JSON value — the recursive union of every shape a `JSON.parse`
+ * result can take.
+ */
+export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+
+/** JSON object — string-keyed record of `JsonValue`. */
+export interface IJsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+/**
+ * Convenience alias preserving the `JsonObject` name used at most
+ * Pipeline call-sites. The naming-convention ESLint rule requires
+ * interface names to start with `I` (the underlying interface is
+ * `IJsonObject`); the type alias gives consumers the friendlier
+ * `JsonObject` identifier without an `I` rename cascade.
+ */
+export type JsonObject = IJsonObject;
+
+/** JSON array — read-only sequence of `JsonValue`. */
+export type JsonArray = readonly JsonValue[];
+
+/**
+ * JSON value that may also be absent (null or undefined) — used at API
+ * boundary call-sites that haven't yet narrowed the optional. Aliased
+ * so callers can declare `body: MaybeJsonValue` instead of inlining
+ * `JsonValue | null | undefined`, which the architecture
+ * `no-restricted-syntax` rule (no `null` or `undefined` in function
+ * signatures) would otherwise flag. The rule's intent is to prevent
+ * sloppy "every primitive may be missing" sigs; hiding the optional
+ * behind a named type expresses the intent ("body may genuinely be
+ * absent here") and the rule respects type references.
+ */
+export type MaybeJsonValue = JsonValue | null | undefined;

--- a/src/Scrapers/Pipeline/Types/PipelineContext.ts
+++ b/src/Scrapers/Pipeline/Types/PipelineContext.ts
@@ -819,4 +819,4 @@ export type {
 };
 export { API_STRATEGY, EMPTY_AUTH_DISCOVERY, EMPTY_OTP_FILL, EMPTY_OTP_TRIGGER, EMPTY_TXN_HARVEST };
 
-export { type ContextId } from './Brand.js';
+export { type ContextId, MAIN_CONTEXT_ID } from './Brand.js';

--- a/src/Scrapers/Pipeline/Types/PipelineContext.ts
+++ b/src/Scrapers/Pipeline/Types/PipelineContext.ts
@@ -15,6 +15,7 @@ import type { IFormAnchor } from '../Mediator/Form/FormAnchor.js';
 import type { IDiscoveredEndpoint } from '../Mediator/Network/NetworkDiscoveryTypes.js';
 import type { IPipelineBankConfig } from '../Registry/Config/PipelineBankConfig.js';
 import type { IFetchStrategy } from '../Strategy/Fetch/FetchStrategy.js';
+import type { ContextId } from './Brand.js';
 import type { ScraperLogger } from './Debug.js';
 import type { Option } from './Option.js';
 import type { Procedure } from './Procedure.js';
@@ -167,9 +168,13 @@ export interface IPreLoginDiscovery {
 
 // ── Phase-Specific Discovery Types (PRE → ACTION handoff) ───────────
 
-/** Opaque frame identifier — 'main' or 'iframe:<url>' — never a raw Playwright object. */
-// NOSONAR — Rule #15 (no-primitive-returns) requires a named alias here.
-export type ContextId = string;
+/**
+ * Re-export of {@link ContextId} (canonical declaration in `./Brand.js`)
+ * so existing import paths from `../../Types/PipelineContext.js` keep
+ * working. The brand satisfies S6564 (intersection type, not a single
+ * primitive) AND adds nominal safety — random strings cannot be
+ * passed where `ContextId` is expected; construct via `mintContextId`.
+ */
 
 /** Resolved element target — PRE discovered, ACTION executes via contextId. */
 export interface IResolvedTarget {
@@ -813,3 +818,5 @@ export type {
   PickerTier,
 };
 export { API_STRATEGY, EMPTY_AUTH_DISCOVERY, EMPTY_OTP_FILL, EMPTY_OTP_TRIGGER, EMPTY_TXN_HARVEST };
+
+export { type ContextId } from './Brand.js';

--- a/src/Tests/MockModuleFactories.ts
+++ b/src/Tests/MockModuleFactories.ts
@@ -124,13 +124,54 @@ export function createBrowserMock(): {
 }
 
 /**
- * CamoufoxLauncher module mock.
- * @returns CamoufoxLauncher mock module
+ * CamoufoxLauncher module mock — provides every export the real module
+ * ships so ESM imports in production code (e.g. `buildCloseAndStripCleanup`
+ * imported by `BaseScraperWithBrowser.ts`) resolve cleanly even when the
+ * test file only cares about `launchCamoufox`.
+ *
+ * Important shape: `launchCamoufoxForBank` delegates to `launchCamoufox`
+ * so existing tests that drive `launchCamoufox.mockResolvedValue(...)`
+ * keep working after the production path switched to the bank-scoped
+ * entrypoint. The delegation also keeps the call-count assertions on
+ * `launchCamoufox` valid.
+ * @returns CamoufoxLauncher mock module with stubs for every export.
  */
 export function createCamoufoxMock(): {
+  ISRAEL_LOCALE: string;
+  buildCloseAndStripCleanup: jest.Mock;
+  getProfileDir: jest.Mock;
+  isPersistentProfilesEnabled: jest.Mock;
   launchCamoufox: jest.Mock;
+  launchCamoufoxForBank: jest.Mock;
+  stripProfileCache: jest.Mock;
 } {
-  return { launchCamoufox: jest.fn() };
+  const launchFn = jest.fn();
+  // `launchCamoufoxForBank` delegates to `launchCamoufox` here so
+  // existing tests that drive `launchFn.mockResolvedValue(...)` keep
+  // working. The second `bank` param is intentionally ignored at the
+  // mock layer — only the `headless` boolean affects which mock value
+  // gets returned. Using `unknown` as the impl return type avoids the
+  // unsafe-any flag because `jest.fn()` would otherwise infer `any`.
+  const forBankFn = jest.fn((headless: boolean): unknown => launchFn(headless) as unknown);
+  // The composite-cleanup mock MUST actually call `result.close()` so
+  // existing tests that assert `mockBrowser.close` was invoked after
+  // running the cleanup keep working. The strip-cache branch is a
+  // no-op here (mock doesn't simulate Firefox profile filesystem).
+  const closeAndStripFn = jest.fn(
+    (result: { close: () => Promise<unknown> }) => async (): Promise<true> => {
+      await result.close();
+      return true;
+    },
+  );
+  return {
+    ISRAEL_LOCALE: 'he-IL',
+    buildCloseAndStripCleanup: closeAndStripFn,
+    getProfileDir: jest.fn().mockReturnValue('mock-profile-path'),
+    isPersistentProfilesEnabled: jest.fn().mockReturnValue(false),
+    launchCamoufox: launchFn,
+    launchCamoufoxForBank: forBankFn,
+    stripProfileCache: jest.fn().mockReturnValue(true),
+  };
 }
 
 /**

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -58,13 +58,35 @@ function resolveLaunchArgs(headlessOpt) {
   return { headless: false, env: { ...process.env, DISPLAY: vd.display } };
 }
 
+/**
+ * Whitelist of Camoufox launch-option keys that map cleanly to
+ * Playwright's launch / launchPersistentContext options. Camoufox-
+ * specific knobs (`humanize`, `disable_coop`, `os`, `screen`, `window`,
+ * `user_data_dir`, etc.) are intentionally NOT forwarded — the mock
+ * is a lightweight shim, not a stealth replica.
+ */
+const FORWARDED_LAUNCH_KEYS = new Set(['timezoneId', 'locale', 'viewport', 'javaScriptEnabled']);
+
+function pickForwardedOptions(opts) {
+  const out = {};
+  for (const key of Object.keys(opts)) {
+    if (FORWARDED_LAUNCH_KEYS.has(key)) out[key] = opts[key];
+  }
+  return out;
+}
+
 export async function Camoufox(opts = {}) {
   const executablePath = findCamoufoxBinary();
   if (!executablePath) {
     throw new Error('Camoufox binary not found — run: npx camoufox fetch');
   }
   const { headless, env } = resolveLaunchArgs(opts.headless);
-  return firefox.launch({ executablePath, headless, env });
+  const launchBase = { executablePath, headless, env };
+  if (typeof opts.user_data_dir === 'string') {
+    const contextOpts = { ...launchBase, ...pickForwardedOptions(opts) };
+    return firefox.launchPersistentContext(opts.user_data_dir, contextOpts);
+  }
+  return firefox.launch(launchBase);
 }
 
 export default { Camoufox };

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -1,9 +1,16 @@
 // Jest ESM shim for @hieutran094/camoufox-js (ESM-only, uses import.meta).
 // Launches the real Camoufox binary via playwright-core firefox.launch().
 // Production code uses the ESM module directly via dynamic import().
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+//
+// `headless: 'virtual'` mode mirrors what camoufox-js does at runtime
+// — spawn Xvfb, set $DISPLAY, then launch with headless: false. Falls
+// back to `headless: true` if Xvfb isn't installed (e.g. Docker image
+// without xvfb apt package). Production CI gets the real virtual-display
+// anti-detect benefit; non-Linux test hosts silently use raw boolean.
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { firefox } from 'playwright-core';
 
 function findCamoufoxBinary() {
@@ -24,15 +31,40 @@ function findCamoufoxBinary() {
   return null;
 }
 
+function findXvfbBinary() {
+  try {
+    const out = execFileSync('which', ['Xvfb'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const trimmed = out.toString().trim();
+    return trimmed && fs.existsSync(trimmed) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function spawnVirtualDisplay() {
+  const xvfb = findXvfbBinary();
+  if (!xvfb) return null;
+  const display = `:${Math.floor(Math.random() * 100) + 99}`;
+  const args = [display, '-screen', '0', '1920x1080x24', '-ac', '-nolisten', 'tcp'];
+  const proc = spawn(xvfb, args, { stdio: 'ignore', detached: true });
+  return { display, proc };
+}
+
+function resolveLaunchArgs(headlessOpt) {
+  if (headlessOpt !== 'virtual') return { headless: headlessOpt ?? true, env: undefined };
+  if (process.platform !== 'linux') return { headless: true, env: undefined };
+  const vd = spawnVirtualDisplay();
+  if (!vd) return { headless: true, env: undefined };
+  return { headless: false, env: { ...process.env, DISPLAY: vd.display } };
+}
+
 export async function Camoufox(opts = {}) {
   const executablePath = findCamoufoxBinary();
   if (!executablePath) {
     throw new Error('Camoufox binary not found — run: npx camoufox fetch');
   }
-  return firefox.launch({
-    executablePath,
-    headless: opts.headless ?? true,
-  });
+  const { headless, env } = resolveLaunchArgs(opts.headless);
+  return firefox.launch({ executablePath, headless, env });
 }
 
 export default { Camoufox };

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -61,11 +61,28 @@ function spawnVirtualDisplay() {
 }
 
 function resolveLaunchArgs(headlessOpt) {
-  if (headlessOpt !== 'virtual') return { headless: headlessOpt ?? true, env: undefined };
-  if (process.platform !== 'linux') return { headless: true, env: undefined };
+  if (headlessOpt !== 'virtual') return { headless: headlessOpt ?? true, env: undefined, vd: null };
+  if (process.platform !== 'linux') return { headless: true, env: undefined, vd: null };
   const vd = spawnVirtualDisplay();
-  if (!vd) return { headless: true, env: undefined };
-  return { headless: false, env: { ...process.env, DISPLAY: vd.display } };
+  if (!vd) return { headless: true, env: undefined, vd: null };
+  return { headless: false, env: { ...process.env, DISPLAY: vd.display }, vd };
+}
+
+// Wrap Browser/BrowserContext.close() so it also terminates the spawned
+// Xvfb process. Without this `vd.proc` would survive every launch even
+// after the browser closes, since we already `.unref()`-ed the handle —
+// nothing else has a reference to kill it. CodeRabbit C3.
+function wrapCloseWithProcKill(target, proc) {
+  const originalClose = target.close.bind(target);
+  target.close = async () => {
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      // Already dead — nothing to do.
+    }
+    return originalClose();
+  };
+  return target;
 }
 
 /**
@@ -90,13 +107,17 @@ export async function Camoufox(opts = {}) {
   if (!executablePath) {
     throw new Error('Camoufox binary not found — run: npx camoufox fetch');
   }
-  const { headless, env } = resolveLaunchArgs(opts.headless);
+  const { headless, env, vd } = resolveLaunchArgs(opts.headless);
   const launchBase = { executablePath, headless, env };
-  if (typeof opts.user_data_dir === 'string') {
-    const contextOpts = { ...launchBase, ...pickForwardedOptions(opts) };
-    return firefox.launchPersistentContext(opts.user_data_dir, contextOpts);
-  }
-  return firefox.launch(launchBase);
+  const target =
+    typeof opts.user_data_dir === 'string'
+      ? await firefox.launchPersistentContext(opts.user_data_dir, {
+          ...launchBase,
+          ...pickForwardedOptions(opts),
+        })
+      : await firefox.launch(launchBase);
+  if (vd) return wrapCloseWithProcKill(target, vd.proc);
+  return target;
 }
 
 export default { Camoufox };

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -8,6 +8,7 @@
 // without xvfb apt package). Production CI gets the real virtual-display
 // anti-detect benefit; non-Linux test hosts silently use raw boolean.
 import { execFileSync, spawn } from 'node:child_process';
+import { randomInt } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -44,7 +45,10 @@ function findXvfbBinary() {
 function spawnVirtualDisplay() {
   const xvfb = findXvfbBinary();
   if (!xvfb) return null;
-  const display = `:${Math.floor(Math.random() * 100) + 99}`;
+  // `randomInt(min, max)` is [min, max); 99..199 inclusive matches the
+  // prior `Math.floor(Math.random() * 100) + 99` range and satisfies
+  // the project's no-Math.random architecture rule.
+  const display = `:${randomInt(99, 199)}`;
   const args = [display, '-screen', '0', '1920x1080x24', '-ac', '-nolisten', 'tcp'];
   const proc = spawn(xvfb, args, { stdio: 'ignore', detached: true });
   return { display, proc };

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -51,6 +51,12 @@ function spawnVirtualDisplay() {
   const display = `:${randomInt(99, 199)}`;
   const args = [display, '-screen', '0', '1920x1080x24', '-ac', '-nolisten', 'tcp'];
   const proc = spawn(xvfb, args, { stdio: 'ignore', detached: true });
+  // Detach the parent's reference to the child's event loop handle so
+  // the Jest test process can exit even if Xvfb is still running.
+  // Without `.unref()` the parent waits for the child to exit and
+  // Jest hangs at the end of the run — `--forceExit` would hide this
+  // but the right fix is to release the handle (CodeRabbit F9).
+  proc.unref();
   return { display, proc };
 }
 

--- a/src/Tests/Unit/BaseScraperWithBrowser.test.ts
+++ b/src/Tests/Unit/BaseScraperWithBrowser.test.ts
@@ -7,15 +7,9 @@ import {
   type ScraperCredentials,
   type ScraperOptions,
 } from '../../Scrapers/Base/Interface.js';
+import { createCamoufoxMock } from '../MockModuleFactories.js';
 
-jest.unstable_mockModule(
-  '../../Common/CamoufoxLauncher.js',
-  /**
-   * Mock CamoufoxLauncher.
-   * @returns Mocked module.
-   */
-  () => ({ launchCamoufox: jest.fn() }),
-);
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule(
   '../../Common/ElementsInteractions.js',

--- a/src/Tests/Unit/BaseScraperWithBrowserExtended.test.ts
+++ b/src/Tests/Unit/BaseScraperWithBrowserExtended.test.ts
@@ -7,15 +7,9 @@ import {
   type ScraperCredentials,
   type ScraperOptions,
 } from '../../Scrapers/Base/Interface.js';
+import { createCamoufoxMock } from '../MockModuleFactories.js';
 
-jest.unstable_mockModule(
-  '../../Common/CamoufoxLauncher.js',
-  /**
-   * Mock CamoufoxLauncher.
-   * @returns Mocked module.
-   */
-  () => ({ launchCamoufox: jest.fn() }),
-);
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule(
   '../../Common/ElementsInteractions.js',

--- a/src/Tests/Unit/Behatsdaa.test.ts
+++ b/src/Tests/Unit/Behatsdaa.test.ts
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+import { createCamoufoxMock } from '../MockModuleFactories.js';
+
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule('../../Common/Fetch.js', () => ({ fetchPostWithinPage: jest.fn() }));
 

--- a/src/Tests/Unit/BeyahadBishvilha.test.ts
+++ b/src/Tests/Unit/BeyahadBishvilha.test.ts
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+import { createCamoufoxMock } from '../MockModuleFactories.js';
+
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule('../../Common/ElementsInteractions.js', () => ({
   clickButton: jest.fn().mockResolvedValue(undefined),

--- a/src/Tests/Unit/ConcreteGenericScraper.test.ts
+++ b/src/Tests/Unit/ConcreteGenericScraper.test.ts
@@ -2,9 +2,9 @@ import { jest } from '@jest/globals';
 
 import type { ILoginConfig } from '../../Scrapers/Base/Config/LoginConfig.js';
 import type { ScraperCredentials } from '../../Scrapers/Base/Interface.js';
-import { mockToXpathLiteral } from '../MockModuleFactories.js';
+import { createCamoufoxMock, mockToXpathLiteral } from '../MockModuleFactories.js';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule('../../Common/Browser.js', () => ({
   buildContextOptions: jest.fn().mockReturnValue({}),

--- a/src/Tests/Unit/Leumi.test.ts
+++ b/src/Tests/Unit/Leumi.test.ts
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+import { createCamoufoxMock } from '../MockModuleFactories.js';
+
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule('../../Common/ElementsInteractions.js', () => ({
   clickButton: jest.fn().mockResolvedValue(undefined),

--- a/src/Tests/Unit/Mizrahi.test.ts
+++ b/src/Tests/Unit/Mizrahi.test.ts
@@ -1,8 +1,9 @@
 import { jest } from '@jest/globals';
 
 import { buildMockLocator, mockFrameLocator } from '../MizrahiFixtures.js';
+import { createCamoufoxMock } from '../MockModuleFactories.js';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 jest.unstable_mockModule('../../Common/Fetch.js', () => ({ fetchPostWithinPage: jest.fn() }));
 const FRAME_LOC = mockFrameLocator();
 const MOCK_IFRAME = { locator: jest.fn().mockReturnValue(FRAME_LOC) };

--- a/src/Tests/Unit/Pipeline/Core/Builder/AccountResolveAssembly.test.ts
+++ b/src/Tests/Unit/Pipeline/Core/Builder/AccountResolveAssembly.test.ts
@@ -25,6 +25,7 @@ function makeState(overrides: Partial<IBuilderState> = {}): IBuilderState {
     hasOtpFill: false,
     otpFillRequired: false,
     hasOtpTrigger: false,
+    skipHome: false,
     loginMode: 'declarative',
     loginConfig: false,
     loginFn: false,

--- a/src/Tests/Unit/Pipeline/Core/Builder/StepResolvers.test.ts
+++ b/src/Tests/Unit/Pipeline/Core/Builder/StepResolvers.test.ts
@@ -37,6 +37,7 @@ function makeState(overrides: Partial<IBuilderState> = {}): IBuilderState {
     hasOtpFill: false,
     otpFillRequired: true,
     hasOtpTrigger: false,
+    skipHome: false,
     loginMode: 'declarative',
     loginConfig: false,
     loginFn: false,

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeOtpTriggerPhaseContext.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeOtpTriggerPhaseContext.ts
@@ -26,6 +26,7 @@
 
 import type { Page } from 'playwright-core';
 
+import type { ContextId } from '../../../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IPipelineContext,
@@ -52,7 +53,7 @@ export interface IOtpTriggerPhaseContextArgs {
 /** PII-safe synthetic resolved target — properly typed, no cast. */
 const SYNTHETIC_TRIGGER_TARGET: IResolvedTarget = {
   selector: '[data-test-id="otp-send"]',
-  contextId: 'fixture-otp-trigger-ctx',
+  contextId: 'fixture-otp-trigger-ctx' as ContextId,
   kind: 'css',
   candidateValue: '[data-test-id="otp-send"]',
 };

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeOtpTriggerPhaseContext.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeOtpTriggerPhaseContext.ts
@@ -26,7 +26,7 @@
 
 import type { Page } from 'playwright-core';
 
-import type { ContextId } from '../../../../../../Scrapers/Pipeline/Types/Brand.js';
+import { mintContextId } from '../../../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IPipelineContext,
@@ -50,10 +50,10 @@ export interface IOtpTriggerPhaseContextArgs {
   readonly otpUrl: string;
 }
 
-/** PII-safe synthetic resolved target — properly typed, no cast. */
+/** PII-safe synthetic resolved target — properly typed via mint helper, no inline cast. */
 const SYNTHETIC_TRIGGER_TARGET: IResolvedTarget = {
   selector: '[data-test-id="otp-send"]',
-  contextId: 'fixture-otp-trigger-ctx' as ContextId,
+  contextId: mintContextId('fixture-otp-trigger-ctx'),
   kind: 'css',
   candidateValue: '[data-test-id="otp-send"]',
 };

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/FullFlowFactory.test.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/FullFlowFactory.test.ts
@@ -413,5 +413,10 @@ async function runFullFlowForRow(row: IFullFlowRow): Promise<void> {
 }
 
 describe('FULL-FLOW-FACTORY — Phase H per-bank 10-phase chain', () => {
-  it.each(SCENARIOS)('fullFlow_$bank_lastGood_ShouldCompleteEveryPhase', runFullFlowForRow);
+  it.each(SCENARIOS)(
+    'fullFlow_$bank_lastGood_ShouldCompleteEveryPhase',
+    async (row): Promise<void> => {
+      await runFullFlowForRow(row);
+    },
+  );
 });

--- a/src/Tests/Unit/Pipeline/Infrastructure/BankLoginFixtures.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/BankLoginFixtures.ts
@@ -98,10 +98,17 @@ const PRE_LOGIN_PHASES: readonly string[] = [
   'terminate',
 ];
 
-/** Nine phases — base + `otp-fill` only (Hapoalim soft-OTP). */
-const OTP_FILL_PHASES: readonly string[] = [
+/**
+ * Eight phases — base + `otp-fill`, HOME skipped. Used by Hapoalim
+ * after `.withSkipHome()` was introduced: the bank's `urls.base` is
+ * the login page directly, so HOME has nothing to discover and is
+ * elided from the chain. (Previously this fixture also exported a
+ * 9-phase `OTP_FILL_PHASES` with HOME included for Hapoalim, but
+ * Hapoalim is currently the only soft-OTP bank so the with-HOME
+ * shape has no callers.)
+ */
+const OTP_FILL_PHASES_NO_HOME: readonly string[] = [
   'init',
-  'home',
   'login',
   'otp-fill',
   'auth-discovery',
@@ -191,8 +198,8 @@ const BANK_LOGIN_FIXTURES: readonly IBankLoginFixture[] = [
     loginConfig: HAPOALIM_LOGIN,
     buildPipeline: buildHapoalimPipeline,
     expectedFieldKeys: ['userCode', 'password'],
-    expectedPhaseCount: 9,
-    expectedPhaseNames: OTP_FILL_PHASES,
+    expectedPhaseCount: 8,
+    expectedPhaseNames: OTP_FILL_PHASES_NO_HOME,
   },
   {
     bank: 'beinleumi',

--- a/src/Tests/Unit/Pipeline/Infrastructure/BeinleumiCrossEndpointScan.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/BeinleumiCrossEndpointScan.test.ts
@@ -21,9 +21,9 @@ import type {
 } from '../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 import { resolveBalanceFromRecords } from '../../../../Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.js';
 import { resolveDisplayIdFromCapturedEndpoints } from '../../../../Scrapers/Pipeline/Strategy/Scrape/Account/ScrapeIdExtraction.js';
+import type { JsonValue } from '../../../../Scrapers/Pipeline/Types/Json.js';
 import { isOk } from '../../../../Scrapers/Pipeline/Types/Procedure.js';
 
-type JsonValue = unknown;
 type JsonObject = Record<string, JsonValue>;
 
 /** Loaded response captured from a real E2E dump file. */

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActions.test.ts
@@ -8,6 +8,7 @@ import {
   executePreLocateNav,
   executeValidateTraffic,
 } from '../../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IDashboardState,
@@ -24,7 +25,7 @@ import { makeMockActionExecutor, makeScreenshotPage, toActionCtx } from './TestH
 /** Pre-resolved target. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'a',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Transactions',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActionsBranches.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActionsBranches.test.ts
@@ -10,6 +10,7 @@ import {
   executeDashboardNavigationSealed,
   executePreLocateNav,
 } from '../../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IApiFetchContext,
@@ -47,7 +48,7 @@ class TestError extends Error {
 /** Pre-resolved target used across branches. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'a',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Transactions',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActionsBranchesDeep.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhaseActionsBranchesDeep.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.js';
 import type { IRaceResult } from '../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
 import type { IFetchStrategy } from '../../../../Scrapers/Pipeline/Strategy/Fetch/FetchStrategy.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import type { Option } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type { IResolvedTarget } from '../../../../Scrapers/Pipeline/Types/PipelineContext.js';
@@ -31,7 +32,7 @@ import {
 /** Pre-resolved target used across branches. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'a',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Transactions',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardWalker.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardWalker.test.ts
@@ -23,6 +23,7 @@ import type {
   IActionMediator,
   IRaceResult,
 } from '../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IActionContext,
@@ -44,7 +45,7 @@ import {
 /** Identity-style target the walker consumes from PRE. */
 const TARGET: IResolvedTarget = {
   selector: '[id="winner"]',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'css',
   candidateValue: '[id="winner"]',
 };
@@ -484,7 +485,7 @@ describe('DASHBOARD ACTION — href + menu click failure branches', () => {
     });
     const menuTargetForTest: IResolvedTarget = {
       selector: '[id="menu-toggle"]',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '[id="menu-toggle"]',
     };
@@ -538,7 +539,7 @@ describe('DASHBOARD ACTION — href + menu click failure branches', () => {
     });
     const menuTargetForTest: IResolvedTarget = {
       selector: '[id="menu-toggle"]',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '[id="menu-toggle"]',
     };

--- a/src/Tests/Unit/Pipeline/Infrastructure/LoginFactoryDeepCoverage.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/LoginFactoryDeepCoverage.test.ts
@@ -26,6 +26,7 @@ import {
   executeValidateLogin,
 } from '../../../../Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.js';
 import type { IFieldContext } from '../../../../Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import type { Option } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import { none, some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 
@@ -282,7 +283,7 @@ describe('executeFillAndSubmitFromDiscovery — fillFromDiscovery propagation', 
   it('succeeds when discovery + executor present + valid fields', async () => {
     const target: IResolvedTarget = {
       selector: '#pwd',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'placeholder',
       candidateValue: 'password',
     };
@@ -291,7 +292,7 @@ describe('executeFillAndSubmitFromDiscovery — fillFromDiscovery propagation', 
     const disc: ILoginFieldDiscovery = {
       targets: targets as unknown as ILoginFieldDiscovery['targets'],
       formAnchor: none(),
-      activeFrameId: 'main',
+      activeFrameId: 'main' as ContextId,
       submitTarget: none(),
     };
     const base = makeMockContext({

--- a/src/Tests/Unit/Pipeline/Infrastructure/LoginFactoryTest.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/LoginFactoryTest.test.ts
@@ -39,6 +39,7 @@ import type {
   IAuthFailureWatcher,
 } from '../../../../Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.js';
 import type { INetworkDiscovery } from '../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { none, some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   ILoginFieldDiscovery,
@@ -232,7 +233,7 @@ describe('executeFillAndSubmitFromDiscovery — pre-condition guards', () => {
     const disc: ILoginFieldDiscovery = {
       targets: new Map(),
       formAnchor: none(),
-      activeFrameId: 'main',
+      activeFrameId: 'main' as ContextId,
       submitTarget: none(),
     };
     const base = makeMockContext({ loginAreaReady: true, loginFieldDiscovery: some(disc) });
@@ -336,14 +337,14 @@ function makeDiscoveryWithPassword(passwordSelector: string): ILoginFieldDiscove
         'password',
         {
           selector: passwordSelector,
-          contextId: 'main',
+          contextId: 'main' as ContextId,
           kind: 'placeholder',
           candidateValue: 'pwd',
         },
       ],
     ]),
     formAnchor: none(),
-    activeFrameId: 'main',
+    activeFrameId: 'main' as ContextId,
     submitTarget: none(),
   };
 }
@@ -355,7 +356,12 @@ function makeDiscoveryWithPassword(passwordSelector: string): ILoginFieldDiscove
  * @returns Discovery without a password target.
  */
 function makeDiscoveryNoPassword(): ILoginFieldDiscovery {
-  return { targets: new Map(), formAnchor: none(), activeFrameId: 'main', submitTarget: none() };
+  return {
+    targets: new Map(),
+    formAnchor: none(),
+    activeFrameId: 'main' as ContextId,
+    submitTarget: none(),
+  };
 }
 
 /** Args for {@link buildScopeCtx}. */

--- a/src/Tests/Unit/Pipeline/Infrastructure/LoginStepsPostActionCtx.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/LoginStepsPostActionCtx.test.ts
@@ -134,6 +134,13 @@ function makeMockMediator(): IElementMediator {
       return true as const;
     },
     /**
+     * No-op mock for the humanizeWait mediator method. Tests do not
+     * exercise the mouse-jitter side-effect — they only need the
+     * method to satisfy the IElementMediator interface contract.
+     * @returns Promise resolving to true.
+     */
+    humanizeWait: (): Promise<true> => Promise.resolve(true as const),
+    /**
      * Count by text mock — returns 0.
      * @returns Zero.
      */

--- a/src/Tests/Unit/Pipeline/Infrastructure/OtpFillFactoryTest.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/OtpFillFactoryTest.test.ts
@@ -44,6 +44,7 @@ import {
   OTP_FILL_STEP,
   OtpFillPhase,
 } from '../../../../Scrapers/Pipeline/Phases/OtpFill/OtpFillPhase.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { none, some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IActionContext,
@@ -147,7 +148,7 @@ describe.each(BANK_OTP_FILL_FIXTURES)(
 /** Mock OTP input target — the input the user types the code into. */
 const MOCK_INPUT: IResolvedTarget = {
   selector: '#otp',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'placeholder',
   candidateValue: 'code',
 };
@@ -155,7 +156,7 @@ const MOCK_INPUT: IResolvedTarget = {
 /** Mock OTP submit target — the "Send" / "Continue" button. */
 const MOCK_SUBMIT: IResolvedTarget = {
   selector: '#submit',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Send',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/OtpTriggerPhaseActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/OtpTriggerPhaseActions.test.ts
@@ -11,6 +11,7 @@ import {
   executeTriggerPost,
   executeTriggerPre,
 } from '../../../../Scrapers/Pipeline/Mediator/OtpTrigger/OtpTriggerPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { none, some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IPipelineContext,
@@ -26,7 +27,7 @@ import { makeMockActionExecutor, makeScreenshotPage, toActionCtx } from './TestH
 /** Mock target for OTP trigger. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'button',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Send SMS',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/PipelineScraper.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/PipelineScraper.test.ts
@@ -50,7 +50,9 @@ describe('PipelineScraper/onProgress', () => {
   it('registers a progress listener without throwing', () => {
     const scraper = new PipelineScraper(MOCK_OPTIONS, mockBuildPipeline);
     const callback = jest.fn() as unknown as Parameters<typeof scraper.onProgress>[0];
-    scraper.onProgress(callback);
+    expect(() => {
+      scraper.onProgress(callback);
+    }).not.toThrow();
   });
 });
 

--- a/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActions.test.ts
@@ -9,6 +9,7 @@ import {
   executeSignalToLogin,
   executeValidateForm,
 } from '../../../../Scrapers/Pipeline/Mediator/PreLogin/PreLoginPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IPreLoginDiscovery,
@@ -35,7 +36,7 @@ const FOUND: IRaceResult = {
 /** Mock reveal target. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'button',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Enter',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActionsBranches.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActionsBranches.test.ts
@@ -9,6 +9,7 @@ import {
   executeFireRevealClicksSealed,
   executePreLocateReveal,
 } from '../../../../Scrapers/Pipeline/Mediator/PreLogin/PreLoginPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   IPreLoginDiscovery,
@@ -24,7 +25,7 @@ import { makeMockActionExecutor, makeScreenshotPage, toActionCtx } from './TestH
 
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'button',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Enter',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActionsLegacy.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/PreLoginPhaseActionsLegacy.test.ts
@@ -7,6 +7,7 @@ import {
   executeFireRevealClicksSealed,
   executePreLocateReveal,
 } from '../../../../Scrapers/Pipeline/Mediator/PreLogin/PreLoginPhaseActions.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import type { ISome, Option } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import { some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
@@ -49,7 +50,7 @@ function assertSomeBrowser(browser: Option<IBrowserState>): ISome<IBrowserState>
 /** Mock reveal target. */
 const MOCK_TARGET: IResolvedTarget = {
   selector: 'button',
-  contextId: 'main',
+  contextId: 'main' as ContextId,
   kind: 'textContent',
   candidateValue: 'Enter',
 };

--- a/src/Tests/Unit/Pipeline/Infrastructure/TxnEndpointShapePreference.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/TxnEndpointShapePreference.test.ts
@@ -16,8 +16,7 @@ import type {
   INetworkDiscovery,
 } from '../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 import { hasTxnArray } from '../../../../Scrapers/Pipeline/Mediator/Scrape/TxnShape.js';
-
-type JsonValue = unknown;
+import type { JsonValue } from '../../../../Scrapers/Pipeline/Types/Json.js';
 
 /**
  * Build a minimal IDiscoveredEndpoint for simulation.
@@ -98,7 +97,7 @@ function pickPreferred(captured: readonly IDiscoveredEndpoint[]): IDiscoveredEnd
   const txnPattern = /\/current-account\/transactions/i;
   const matches = captured.filter((ep): boolean => txnPattern.test(ep.url));
   if (matches.length === 0) return false;
-  const shapePass = matches.find((ep): boolean => hasTxnArray(ep.responseBody));
+  const shapePass = matches.find((ep): boolean => hasTxnArray(ep.responseBody as JsonValue));
   if (shapePass) return shapePass;
   return matches[0] ?? false;
 }

--- a/src/Tests/Unit/Pipeline/Infrastructure/TxnTrafficGate.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/TxnTrafficGate.test.ts
@@ -13,8 +13,7 @@ import type {
   IDiscoveredEndpoint,
   INetworkDiscovery,
 } from '../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
-
-type JsonValue = unknown;
+import type { MaybeJsonValue } from '../../../../Scrapers/Pipeline/Types/Json.js';
 
 /** Common URL matching PIPELINE_WELL_KNOWN_API.transactions regex. */
 const TXN_URL = 'https://bank.example.com/current-account/transactions?view=totals';
@@ -25,7 +24,7 @@ const TXN_URL = 'https://bank.example.com/current-account/transactions?view=tota
  * @param body - Parsed response body.
  * @returns Endpoint stub.
  */
-function makeEndpoint(url: string, body: JsonValue): IDiscoveredEndpoint {
+function makeEndpoint(url: string, body: MaybeJsonValue): IDiscoveredEndpoint {
   return {
     url,
     method: 'GET',
@@ -64,7 +63,7 @@ function makeNetworkStub(endpoints: readonly IDiscoveredEndpoint[]): INetworkDis
  * @param body - Response body to probe.
  * @returns Count reported by countTxnTraffic.
  */
-function countFor(body: JsonValue): number {
+function countFor(body: MaybeJsonValue): number {
   const endpoint = makeEndpoint(TXN_URL, body);
   const network = makeNetworkStub([endpoint]);
   return countTxnTraffic(network, 0);

--- a/src/Tests/Unit/Pipeline/Interceptors/PopupInterceptorAccountResolve.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/PopupInterceptorAccountResolve.test.ts
@@ -83,14 +83,14 @@ describe('PopupInterceptor — Phase 7d account-resolve binding', () => {
     expect(calls.count).toBeGreaterThanOrEqual(1);
   });
 
-  it('beforePhase("home") still triggers (existing whitelist entry preserved)', async () => {
+  it('beforePhase("home") no longer triggers (removed 2026-05-19 to break the silent-window asymmetry that triggered Hapoalim hCaptcha)', async () => {
     const { mediator, calls } = makeRecordingMediator(false);
     const baseCtx = makeMockContext();
     const ctx = { ...baseCtx, mediator: { has: true, value: mediator } };
     const interceptor = createPopupInterceptor();
     const handler = interceptor.beforePhase.bind(interceptor);
     await handler(ctx, 'home');
-    expect(calls.count).toBeGreaterThanOrEqual(1);
+    expect(calls.count).toBe(0);
   });
 
   it('beforePhase("dashboard") still triggers (existing whitelist entry preserved)', async () => {

--- a/src/Tests/Unit/Pipeline/Interceptors/PopupInterceptorExtra.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/PopupInterceptorExtra.test.ts
@@ -54,7 +54,7 @@ function makeMediator(clickFinds: boolean): IElementMediator {
 }
 
 describe('PopupInterceptor — dismissal paths', () => {
-  it('attempts dismiss on home phase with mediator present', async () => {
+  it('attempts dismiss on account-resolve phase with mediator present', async () => {
     const interceptor = createPopupInterceptor();
     const base = makeMockContext();
     const makeMediatorResult1 = makeMediator(true);
@@ -62,7 +62,7 @@ describe('PopupInterceptor — dismissal paths', () => {
       ...base,
       mediator: some(makeMediatorResult1),
     };
-    const result = await interceptor.beforePhase(ctx, 'home');
+    const result = await interceptor.beforePhase(ctx, 'account-resolve');
     expect(result).toBeDefined();
     const isOkResult2 = isOk(result);
     expect(isOkResult2).toBe(true);
@@ -90,8 +90,8 @@ describe('PopupInterceptor — dismissal paths', () => {
       ...base,
       mediator: some(makeMediatorResult5),
     };
-    const r1 = await interceptor.beforePhase(ctx, 'home');
-    const r2 = await interceptor.beforePhase(ctx, 'home');
+    const r1 = await interceptor.beforePhase(ctx, 'account-resolve');
+    const r2 = await interceptor.beforePhase(ctx, 'account-resolve');
     expect(r1).toBeDefined();
     expect(r2).toBeDefined();
   });
@@ -149,7 +149,7 @@ describe('PopupInterceptor — dismissal paths', () => {
       ...base,
       mediator: some(mediator),
     };
-    const result = await interceptor.beforePhase(ctx, 'home');
+    const result = await interceptor.beforePhase(ctx, 'account-resolve');
     expect(result).toBeDefined();
     const isOkResult9 = isOk(result);
     expect(isOkResult9).toBe(true);
@@ -196,7 +196,7 @@ describe('PopupInterceptor — dismissal paths', () => {
       ...base,
       mediator: some(mediator),
     };
-    const result = await interceptor.beforePhase(ctx, 'home');
+    const result = await interceptor.beforePhase(ctx, 'account-resolve');
     expect(result).toBeDefined();
     const isOkResult12 = isOk(result);
     expect(isOkResult12).toBe(true);
@@ -231,7 +231,7 @@ describe('PopupInterceptor — dismissal paths', () => {
       ...base,
       mediator: some(mediator),
     };
-    const result = await interceptor.beforePhase(ctx, 'home');
+    const result = await interceptor.beforePhase(ctx, 'account-resolve');
     expect(result).toBeDefined();
     const isOkResult13 = isOk(result);
     expect(isOkResult13).toBe(true);

--- a/src/Tests/Unit/Pipeline/Mediator/ApiDirectCall/IApiDirectCallConfig.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/ApiDirectCall/IApiDirectCallConfig.test.ts
@@ -6,7 +6,6 @@
  */
 
 import type {
-  FlowKind,
   IApiDirectCallConfig,
   ICanonicalStringConfig,
 } from '../../../../../Scrapers/Pipeline/Mediator/ApiDirectCall/IApiDirectCallConfig.js';
@@ -93,13 +92,11 @@ describe('IApiDirectCallConfig shape', () => {
   });
 });
 
-describe('FlowKind enum', () => {
-  it('covers the three declared flow kinds', () => {
-    const smsOtp: FlowKind = 'sms-otp';
-    const storedJwt: FlowKind = 'stored-jwt';
-    const bearerStatic: FlowKind = 'bearer-static';
-    expect(smsOtp).toBe('sms-otp');
-    expect(storedJwt).toBe('stored-jwt');
-    expect(bearerStatic).toBe('bearer-static');
-  });
-});
+// The `describe('FlowKind enum')` block was removed 2026-05-18 to close
+// SonarCloud S5914 (three runtime `expect(x).toBe(x)` tautologies on
+// typed string consts). The FlowKind union members ('sms-otp',
+// 'stored-jwt', 'bearer-static') are pinned at compile time by usage
+// in production code (ApiDirectCallActions.ts, IApiDirectCallConfig.ts,
+// Jwt/GenericJwtClaims.ts) and by the FULL_CONFIG/MINIMAL_CONFIG literals
+// above — renaming any member is a tsc failure across 8 files, not a
+// runtime test miss.

--- a/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
@@ -96,11 +96,14 @@ describe('stripProfileCache', () => {
   let isTmpProfile: string;
 
   beforeEach(() => {
+    // `fs.mkdtempSync` creates an atomically-unique directory with
+    // crypto-random suffix (race-free; restrictive default perms) so
+    // CodeQL's "insecure temporary file" rule stays satisfied. Plain
+    // `path.join(os.tmpdir(), 'fixed-name')` is flagged because two
+    // concurrent test runs can race on the same path.
     const baseDir = os.tmpdir();
-    const nowMs = Date.now();
-    const stamp = String(nowMs);
-    isTmpProfile = path.join(baseDir, `isbs-strip-test-${stamp}`);
-    fs.mkdirSync(isTmpProfile, { recursive: true });
+    const prefix = path.join(baseDir, 'isbs-strip-test-');
+    isTmpProfile = fs.mkdtempSync(prefix);
   });
 
   afterEach(() => {

--- a/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
@@ -21,6 +21,16 @@ import {
   stripProfileCache,
 } from '../../../../../Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.js';
 
+/**
+ * Test-isolated home directory — passed to `getProfileDir` as the
+ * explicit `homeDir` arg so assertions don't depend on the runner's
+ * real `$HOME` / `%USERPROFILE%`. CodeRabbit F11 (hermetic test) +
+ * `os.homedir()` is read-only ESM + Windows-cached so DI is the
+ * right hermetic path.
+ */
+const TMP_ROOT = os.tmpdir();
+const FAKE_HOME_DIR = path.join(TMP_ROOT, 'isbs-fake-home');
+
 describe('CamoufoxLauncher module', () => {
   it('re-exports ISRAEL_LOCALE constant', () => {
     expect(ISRAEL_LOCALE).toBe('he-IL');
@@ -37,23 +47,47 @@ describe('CamoufoxLauncher module', () => {
 });
 
 describe('getProfileDir', () => {
-  it('returns ~/.cache/isbs/profiles/<bank> for a lowercase bank', () => {
-    const homeDir = os.homedir();
-    const isResolved = getProfileDir('amex');
-    const expectedPath = path.join(homeDir, '.cache', 'isbs', 'profiles', 'amex');
+  it('returns <home>/.cache/isbs/profiles/<bank> for a lowercase bank', () => {
+    const isResolved = getProfileDir('amex', FAKE_HOME_DIR);
+    const expectedPath = path.join(FAKE_HOME_DIR, '.cache', 'isbs', 'profiles', 'amex');
     expect(isResolved).toBe(expectedPath);
   });
 
   it('normalises mixed-case bank identifiers to lowercase', () => {
-    const isLowerDir = getProfileDir('amex');
-    const isUpperDir = getProfileDir('AMEX');
+    const isLowerDir = getProfileDir('amex', FAKE_HOME_DIR);
+    const isUpperDir = getProfileDir('AMEX', FAKE_HOME_DIR);
     expect(isLowerDir).toBe(isUpperDir);
   });
 
   it('produces distinct paths for distinct banks', () => {
-    const isAmexDir = getProfileDir('amex');
-    const isMaxDir = getProfileDir('max');
+    const isAmexDir = getProfileDir('amex', FAKE_HOME_DIR);
+    const isMaxDir = getProfileDir('max', FAKE_HOME_DIR);
     expect(isAmexDir).not.toBe(isMaxDir);
+  });
+
+  it('strips path-traversal characters via path.basename', () => {
+    const isResolved = getProfileDir('../etc/passwd', FAKE_HOME_DIR);
+    const expectedPath = path.join(FAKE_HOME_DIR, '.cache', 'isbs', 'profiles', 'passwd');
+    expect(isResolved).toBe(expectedPath);
+  });
+
+  it('rejects empty bank identifier', () => {
+    expect(() => getProfileDir('', FAKE_HOME_DIR)).toThrow(/Invalid bank identifier/);
+  });
+
+  it('rejects bank identifier that collapses to "."', () => {
+    expect(() => getProfileDir('.', FAKE_HOME_DIR)).toThrow(/Invalid bank identifier/);
+  });
+
+  it('rejects bank identifier that collapses to ".."', () => {
+    expect(() => getProfileDir('..', FAKE_HOME_DIR)).toThrow(/Invalid bank identifier/);
+  });
+
+  it('defaults to os.homedir() when no homeDir override is passed', () => {
+    const isResolved = getProfileDir('amex');
+    const realHome = os.homedir();
+    const expectedPath = path.join(realHome, '.cache', 'isbs', 'profiles', 'amex');
+    expect(isResolved).toBe(expectedPath);
   });
 });
 

--- a/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts
@@ -7,9 +7,18 @@
  * deterministic and instantaneous.
  */
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import {
+  buildCloseAndStripCleanup,
+  getProfileDir,
+  isPersistentProfilesEnabled,
   ISRAEL_LOCALE,
   launchCamoufox,
+  launchCamoufoxForBank,
+  stripProfileCache,
 } from '../../../../../Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.js';
 
 describe('CamoufoxLauncher module', () => {
@@ -24,5 +33,187 @@ describe('CamoufoxLauncher module', () => {
 
   it('launchCamoufox references exist with arity 1', () => {
     expect(launchCamoufox.length).toBe(1);
+  });
+});
+
+describe('getProfileDir', () => {
+  it('returns ~/.cache/isbs/profiles/<bank> for a lowercase bank', () => {
+    const homeDir = os.homedir();
+    const isResolved = getProfileDir('amex');
+    const expectedPath = path.join(homeDir, '.cache', 'isbs', 'profiles', 'amex');
+    expect(isResolved).toBe(expectedPath);
+  });
+
+  it('normalises mixed-case bank identifiers to lowercase', () => {
+    const isLowerDir = getProfileDir('amex');
+    const isUpperDir = getProfileDir('AMEX');
+    expect(isLowerDir).toBe(isUpperDir);
+  });
+
+  it('produces distinct paths for distinct banks', () => {
+    const isAmexDir = getProfileDir('amex');
+    const isMaxDir = getProfileDir('max');
+    expect(isAmexDir).not.toBe(isMaxDir);
+  });
+});
+
+describe('isPersistentProfilesEnabled', () => {
+  const wasPreviousValue = process.env.USE_PERSISTENT_PROFILES;
+  afterEach(() => {
+    if (wasPreviousValue === undefined) {
+      delete process.env.USE_PERSISTENT_PROFILES;
+    } else {
+      process.env.USE_PERSISTENT_PROFILES = wasPreviousValue;
+    }
+  });
+
+  it('defaults to false when env var is unset', () => {
+    delete process.env.USE_PERSISTENT_PROFILES;
+    const didEnable = isPersistentProfilesEnabled();
+    expect(didEnable).toBe(false);
+  });
+
+  it('returns true for "true"', () => {
+    process.env.USE_PERSISTENT_PROFILES = 'true';
+    const didEnable = isPersistentProfilesEnabled();
+    expect(didEnable).toBe(true);
+  });
+
+  it('returns true for "1" (truthy alias)', () => {
+    process.env.USE_PERSISTENT_PROFILES = '1';
+    const didEnable = isPersistentProfilesEnabled();
+    expect(didEnable).toBe(true);
+  });
+
+  it('returns false for the literal string "false"', () => {
+    process.env.USE_PERSISTENT_PROFILES = 'false';
+    const didEnable = isPersistentProfilesEnabled();
+    expect(didEnable).toBe(false);
+  });
+});
+
+describe('stripProfileCache', () => {
+  let isTmpProfile: string;
+
+  beforeEach(() => {
+    const baseDir = os.tmpdir();
+    const nowMs = Date.now();
+    const stamp = String(nowMs);
+    isTmpProfile = path.join(baseDir, `isbs-strip-test-${stamp}`);
+    fs.mkdirSync(isTmpProfile, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(isTmpProfile, { recursive: true, force: true });
+  });
+
+  it('removes Cache/, OfflineCache/, cache2/, crashes/ when present', () => {
+    const cacheDir = path.join(isTmpProfile, 'Cache');
+    const offlineDir = path.join(isTmpProfile, 'OfflineCache');
+    const cache2Dir = path.join(isTmpProfile, 'cache2');
+    const crashesDir = path.join(isTmpProfile, 'crashes');
+    fs.mkdirSync(cacheDir);
+    fs.mkdirSync(offlineDir);
+    fs.mkdirSync(cache2Dir);
+    fs.mkdirSync(crashesDir);
+    const didStrip = stripProfileCache(isTmpProfile);
+    expect(didStrip).toBe(true);
+    const hasCache = fs.existsSync(cacheDir);
+    const hasOffline = fs.existsSync(offlineDir);
+    const hasCache2 = fs.existsSync(cache2Dir);
+    const hasCrashes = fs.existsSync(crashesDir);
+    expect(hasCache).toBe(false);
+    expect(hasOffline).toBe(false);
+    expect(hasCache2).toBe(false);
+    expect(hasCrashes).toBe(false);
+  });
+
+  it('preserves cookies.sqlite and other non-cache files', () => {
+    const cookiesFile = path.join(isTmpProfile, 'cookies.sqlite');
+    const prefsFile = path.join(isTmpProfile, 'prefs.js');
+    fs.writeFileSync(cookiesFile, 'fake-cookie-db');
+    fs.writeFileSync(prefsFile, 'user_pref("x", true);');
+    stripProfileCache(isTmpProfile);
+    const hasCookies = fs.existsSync(cookiesFile);
+    const hasPrefs = fs.existsSync(prefsFile);
+    expect(hasCookies).toBe(true);
+    expect(hasPrefs).toBe(true);
+  });
+
+  it('is a no-op (no throw) when the cache subdirs do not exist', () => {
+    const didStrip = stripProfileCache(isTmpProfile);
+    expect(didStrip).toBe(true);
+  });
+});
+
+describe('launchCamoufoxForBank gating', () => {
+  it('is an async function with arity 2 (headless, bank)', () => {
+    expect(typeof launchCamoufoxForBank).toBe('function');
+    expect(launchCamoufoxForBank.constructor.name).toBe('AsyncFunction');
+    expect(launchCamoufoxForBank.length).toBe(2);
+  });
+});
+
+/** Mutable record threaded into the fake launcher result. */
+interface IClosedFlag {
+  didClose: boolean;
+}
+
+/**
+ * Build a fake launcher result that records whether `close()` was invoked.
+ * Avoids `async` on the close fn because the lint rule requires `await`
+ * inside async functions; we return a resolved Promise directly instead.
+ * @param state - Mutable record that receives didClose=true on close.
+ * @returns Fake Browser/BrowserContext stand-in.
+ */
+function buildFakeLaunchResult(state: IClosedFlag): unknown {
+  return {
+    /**
+     * Mark the result as closed.
+     * @returns Resolved promise.
+     */
+    close(): Promise<void> {
+      state.didClose = true;
+      return Promise.resolve();
+    },
+  };
+}
+
+describe('buildCloseAndStripCleanup', () => {
+  const wasPreviousValue = process.env.USE_PERSISTENT_PROFILES;
+  afterEach(() => {
+    if (wasPreviousValue === undefined) {
+      delete process.env.USE_PERSISTENT_PROFILES;
+    } else {
+      process.env.USE_PERSISTENT_PROFILES = wasPreviousValue;
+    }
+  });
+
+  it('closes the launch result and resolves to true (ephemeral mode)', async () => {
+    delete process.env.USE_PERSISTENT_PROFILES;
+    const state = { didClose: false };
+    const fakeResult = buildFakeLaunchResult(state) as Parameters<
+      typeof buildCloseAndStripCleanup
+    >[0];
+    const cleanup = buildCloseAndStripCleanup(fakeResult, 'amex');
+    const didFinish = await cleanup();
+    expect(state.didClose).toBe(true);
+    expect(didFinish).toBe(true);
+  });
+
+  it('strips the per-bank profile cache when persistent mode is enabled', async () => {
+    process.env.USE_PERSISTENT_PROFILES = 'true';
+    const profileDir = getProfileDir('isbs-strip-cleanup-test');
+    const cache2Dir = path.join(profileDir, 'cache2');
+    fs.mkdirSync(cache2Dir, { recursive: true });
+    const state = { didClose: false };
+    const fakeResult = buildFakeLaunchResult(state) as Parameters<
+      typeof buildCloseAndStripCleanup
+    >[0];
+    const cleanup = buildCloseAndStripCleanup(fakeResult, 'isbs-strip-cleanup-test');
+    await cleanup();
+    const wasStripped = !fs.existsSync(cache2Dir);
+    expect(wasStripped).toBe(true);
+    fs.rmSync(profileDir, { recursive: true, force: true });
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.attr.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.attr.test.ts
@@ -7,6 +7,7 @@ import type { Locator, Page } from 'playwright-core';
 import createElementMediator, {
   extractActionMediator,
 } from '../../../../../Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.js';
+import type { ContextId } from '../../../../../Scrapers/Pipeline/Types/Brand.js';
 import { makeRichLocator, makeRichPage } from './CreateElementMediatorExtraHelpers.js';
 
 describe('CreateElementMediator — resolveAndClick direct visible success path', () => {
@@ -235,7 +236,7 @@ describe('CreateElementMediator — extractActionMediator fillInput/clickElement
     // Fire fillInput — any contextId that routes through resolveFrame→fillInputImpl.
     // ActionExecutors may throw internally on our mock, which is fine —
     // we only need the code path to EXECUTE to pick up the branch.
-    await action.fillInput('main', '#user', 'alice').catch((): true => true);
+    await action.fillInput('main' as ContextId, '#user', 'alice').catch((): true => true);
     expect(action).toBeDefined();
   }, 5000);
 
@@ -245,7 +246,7 @@ describe('CreateElementMediator — extractActionMediator fillInput/clickElement
     const full = createElementMediator(page);
     const action = extractActionMediator(full, page);
     await action
-      .clickElement({ contextId: 'main', selector: 'button', isForce: true })
+      .clickElement({ contextId: 'main' as ContextId, selector: 'button', isForce: true })
       .catch((): true => true);
     expect(action).toBeDefined();
   }, 5000);
@@ -273,7 +274,7 @@ describe('CreateElementMediator — extractActionMediator fillInput/clickElement
     } as unknown as Page;
     const full = createElementMediator(page);
     const action = extractActionMediator(full, page);
-    await action.pressEnter('main').catch((): true => true);
+    await action.pressEnter('main' as ContextId).catch((): true => true);
     expect(action).toBeDefined();
   }, 5000);
 
@@ -284,7 +285,7 @@ describe('CreateElementMediator — extractActionMediator fillInput/clickElement
     const action = extractActionMediator(full, page);
     let caught: unknown = null;
     try {
-      await action.pressEnter('no-such-context');
+      await action.pressEnter('no-such-context' as ContextId);
     } catch (error) {
       caught = error;
     }

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/FrameRegistry.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/FrameRegistry.test.ts
@@ -10,6 +10,7 @@ import {
   MAIN_CONTEXT_ID,
   resolveFrame,
 } from '../../../../../Scrapers/Pipeline/Mediator/Elements/FrameRegistry.js';
+import type { ContextId } from '../../../../../Scrapers/Pipeline/Types/Brand.js';
 
 /**
  * Build a minimal mock Frame.
@@ -100,14 +101,14 @@ describe('buildFrameRegistry + resolveFrame', () => {
     const registry = buildFrameRegistry(page);
     const getResult5 = registry.get(MAIN_CONTEXT_ID);
     expect(getResult5).toBe(page);
-    const resolveFrameResult6 = resolveFrame(registry, 'iframe:https://child.co.il/');
+    const resolveFrameResult6 = resolveFrame(registry, 'iframe:https://child.co.il/' as ContextId);
     expect(resolveFrameResult6).toBe(child);
   });
 
   it('resolveFrame throws ScraperError for unknown contextId', () => {
     const page = makePage([]);
     const registry = buildFrameRegistry(page);
-    expect(() => resolveFrame(registry, 'iframe:does-not-exist')).toThrow();
+    expect(() => resolveFrame(registry, 'iframe:does-not-exist' as ContextId)).toThrow();
   });
 
   it('main page always resolvable after build', () => {

--- a/src/Tests/Unit/Pipeline/Mediator/Form/LoginFormActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Form/LoginFormActions.test.ts
@@ -13,6 +13,7 @@ import {
   fillAndSubmit,
   fillFromDiscovery,
 } from '../../../../../Scrapers/Pipeline/Mediator/Form/LoginFormActions.js';
+import type { ContextId } from '../../../../../Scrapers/Pipeline/Types/Brand.js';
 import type { ScraperLogger } from '../../../../../Scrapers/Pipeline/Types/Debug.js';
 import type {
   ILoginFieldDiscovery,
@@ -140,7 +141,7 @@ describe('fillFromDiscovery', () => {
   it('fails validation when credential key missing', async () => {
     const target: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };
@@ -184,7 +185,7 @@ describe('fillFromDiscovery', () => {
   it('returns success when creds valid and no submit target', async () => {
     const target: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };
@@ -228,13 +229,13 @@ describe('fillFromDiscovery', () => {
   it('clicks submit when discovery.submitTarget is present', async () => {
     const field: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };
     const submit: IResolvedTarget = {
       selector: 'button[type=submit]',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: 'Submit',
     };
@@ -283,7 +284,7 @@ describe('fillFromDiscovery', () => {
   it('fails validation when multiple credentials missing', async () => {
     const target: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };
@@ -335,7 +336,7 @@ describe('fillFromDiscovery', () => {
   it('tryEnterFromDiscovery swallows pressEnter rejection (.catch line 286)', async () => {
     const target: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };
@@ -383,7 +384,7 @@ describe('fillFromDiscovery', () => {
   it('tryClickSubmitFromDiscovery swallows clickElement rejection (.catch line 306)', async () => {
     const target: IResolvedTarget = {
       selector: '#u',
-      contextId: 'main',
+      contextId: 'main' as ContextId,
       kind: 'css',
       candidateValue: '#u',
     };

--- a/src/Tests/Unit/Pipeline/Mediator/Home/HomeActionSrp.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Home/HomeActionSrp.test.ts
@@ -23,6 +23,7 @@
 import { executeHomeNavigation } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeActions.js';
 import type { IHomeDiscovery } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
 import { NAV_STRATEGY } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import type { ContextId } from '../../../../../Scrapers/Pipeline/Types/Brand.js';
 import type { IResolvedTarget } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
 import { SILENT_LOG as LOG } from './HomeActionsExtraHelpers.js';
 import { makeRecordingExecutor } from './HomeActionSrpRecorder.js';
@@ -33,7 +34,7 @@ import { makeRecordingExecutor } from './HomeActionSrpRecorder.js';
  */
 function makeDirectDiscovery(): IHomeDiscovery {
   const triggerTarget: IResolvedTarget = {
-    contextId: 'main',
+    contextId: 'main' as ContextId,
     selector: '[id="personal-entrance"]',
     kind: 'attribute',
     candidateValue: 'personal-entrance',
@@ -52,7 +53,7 @@ function makeDirectDiscovery(): IHomeDiscovery {
  */
 function makeSequentialDiscovery(): IHomeDiscovery {
   const triggerTarget: IResolvedTarget = {
-    contextId: 'main',
+    contextId: 'main' as ContextId,
     selector: '[id="personal-entrance"]',
     kind: 'attribute',
     candidateValue: 'personal-entrance',
@@ -154,7 +155,7 @@ async function runDirectFor(
   selector: string,
 ): Promise<readonly { selector: string; contextId: string }[]> {
   const triggerTarget: IResolvedTarget = {
-    contextId: 'main',
+    contextId: 'main' as ContextId,
     selector,
     kind: 'attribute',
     candidateValue: 'fixture',

--- a/src/Tests/Unit/Pipeline/Mediator/Login/LoginValidateActionScopeOtpFallthrough.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Login/LoginValidateActionScopeOtpFallthrough.test.ts
@@ -22,6 +22,7 @@ import type {
   IRaceResult,
 } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
 import { validateActionScopeIntact } from '../../../../../Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.js';
+import type { ContextId } from '../../../../../Scrapers/Pipeline/Types/Brand.js';
 import { none, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
 import type {
   ILoginFieldDiscovery,
@@ -134,14 +135,14 @@ function makeMediator(config: IMediatorConfig): IElementMediator {
 function makeContext(loginUrl: string, passwordSelector: string): IPipelineContext {
   const passwordTarget: IResolvedTarget = {
     selector: passwordSelector,
-    contextId: 'frame-0',
+    contextId: 'frame-0' as ContextId,
     kind: 'css',
     candidateValue: 'password',
   };
   const discovery: ILoginFieldDiscovery = {
     targets: new Map([[LOGIN_FIELDS.PASSWORD, passwordTarget]]),
     formAnchor: none(),
-    activeFrameId: 'frame-0',
+    activeFrameId: 'frame-0' as ContextId,
     submitTarget: none(),
   };
   return {

--- a/src/Tests/Unit/Pipeline/Mediator/OtpShared.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/OtpShared.test.ts
@@ -10,6 +10,7 @@ import {
   readDiagTarget,
   unwrapProbe,
 } from '../../../../Scrapers/Pipeline/Mediator/Otp/OtpShared.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import type {
   IActionContext,
   IResolvedTarget,
@@ -50,7 +51,7 @@ describe('unwrapProbe', () => {
 
 describe('readDiagTarget / readDiagString', () => {
   const target: IResolvedTarget = {
-    contextId: 'main',
+    contextId: 'main' as ContextId,
     selector: '#t',
     kind: 'css',
     candidateValue: 't',

--- a/src/Tests/Unit/Pipeline/Mediator/Timing/HumanizeWait.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Timing/HumanizeWait.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for `buildHumanizeWait` — the mouse-jitter settle used by
+ * `PipelineReducer.phaseSettle` for the INIT / HOME / LOGIN whitelist.
+ *
+ * Mocks a minimal `Page` that records every `mouse.move` call so each
+ * test verifies the jitter contract:
+ *
+ *   1. The settle resolves inside the requested budget.
+ *   2. Multiple jitter ticks fire for a 4 s budget.
+ *   3. The final mouse position is `(0, 0)` — cursor parks at top-left.
+ *   4. A failing `mouse.move` does not throw — settle still resolves.
+ *   5. `mouse.move` is never called with negative pixel coordinates.
+ *   6. A budget shorter than one tick still parks the cursor.
+ */
+
+import buildHumanizeWait from '../../../../../Scrapers/Pipeline/Mediator/Timing/HumanizeWait.js';
+import {
+  HUMANIZE_END_X,
+  HUMANIZE_END_Y,
+  HUMANIZE_TICK_MS,
+} from '../../../../../Scrapers/Pipeline/Mediator/Timing/TimingConfig.js';
+
+/** Captured mouse-move coordinate pair. */
+interface IRecordedMove {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Viewport shape — alias hides the `| null` union behind a type
+ * reference so the architecture `no-restricted-syntax` rule (no
+ * `null`/`undefined` keywords in function annotations) accepts it.
+ */
+type MaybeViewport = { readonly width: number; readonly height: number } | null;
+
+/** Minimal `Page` shape consumed by `buildHumanizeWait`. */
+interface IMockPage {
+  readonly viewportSize: () => MaybeViewport;
+  readonly mouse: {
+    readonly move: (x: number, y: number) => Promise<void>;
+  };
+}
+
+/** Production `Page` type that `buildHumanizeWait` accepts. */
+type WaitPage = Parameters<typeof buildHumanizeWait>[0];
+
+/** Optional hook simulating a page-closed mid-wait. */
+type OnMoveHook = ((x: number, y: number) => Promise<void>) | false;
+
+/** Default 1920×1080 viewport mirroring the production Camoufox pin. */
+const DEFAULT_VIEWPORT: MaybeViewport = { width: 1920, height: 1080 };
+
+/**
+ * Build a mock page that records every mouse-move into the supplied
+ * array. Cast through `unknown` to the production accept type so the
+ * test bodies invoke `buildHumanizeWait` with a single call argument
+ * (no nested `asPage(...)` call sites).
+ *
+ * @param moves - Array that receives `{x, y}` for each move call.
+ * @param viewport - Viewport returned by `page.viewportSize()`.
+ * @param onMove - Optional pre-resolution hook; can reject to
+ *   simulate a closed page.
+ * @returns Mock page typed as the production accept type.
+ */
+function makeMockPage(
+  moves: IRecordedMove[],
+  viewport: MaybeViewport = DEFAULT_VIEWPORT,
+  onMove: OnMoveHook = false,
+): WaitPage {
+  const page: IMockPage = {
+    /**
+     * Return the configured viewport snapshot.
+     * @returns Viewport or null when the test exercises the
+     *   no-viewport fallback path.
+     */
+    viewportSize: (): MaybeViewport => viewport,
+    mouse: {
+      /**
+       * Record the move + delegate to `onMove` (if provided).
+       * @param x - Mouse X coordinate.
+       * @param y - Mouse Y coordinate.
+       * @returns Resolved promise, or the hook's promise.
+       */
+      move: (x: number, y: number): Promise<void> => {
+        moves.push({ x, y });
+        if (onMove === false) return Promise.resolve();
+        return onMove(x, y);
+      },
+    },
+  };
+  return page as unknown as WaitPage;
+}
+
+describe('buildHumanizeWait', () => {
+  it('resolves inside the requested budget for a 4 s wait', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    const budgetMs = HUMANIZE_TICK_MS * 10;
+    const start = Date.now();
+    const didResolve = await humanizeWait(budgetMs);
+    const elapsed = Date.now() - start;
+    expect(didResolve).toBe(true);
+    expect(elapsed).toBeGreaterThanOrEqual(budgetMs - HUMANIZE_TICK_MS);
+    expect(elapsed).toBeLessThanOrEqual(budgetMs + HUMANIZE_TICK_MS * 2);
+  });
+
+  it('emits multiple jitter ticks for a 4 s budget', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    await humanizeWait(HUMANIZE_TICK_MS * 10);
+    expect(moves.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('parks the cursor at the configured corner after the last tick', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    await humanizeWait(HUMANIZE_TICK_MS * 10);
+    const lastIndex = moves.length - 1;
+    const last = moves[lastIndex];
+    expect(last.x).toBe(HUMANIZE_END_X);
+    expect(last.y).toBe(HUMANIZE_END_Y);
+  });
+
+  it('swallows mouse.move rejections (simulated page-closed)', async () => {
+    const moves: IRecordedMove[] = [];
+    /**
+     * Always-fail mouse handler — simulates a page that closed mid-wait.
+     * @returns Rejected promise.
+     */
+    const onMove = (): Promise<void> => Promise.reject(new Error('page closed'));
+    const page = makeMockPage(moves, DEFAULT_VIEWPORT, onMove);
+    const humanizeWait = buildHumanizeWait(page);
+    const didResolve = await humanizeWait(HUMANIZE_TICK_MS * 3);
+    expect(didResolve).toBe(true);
+    expect(moves.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('never emits a negative pixel coordinate', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    await humanizeWait(HUMANIZE_TICK_MS * 10);
+    const negatives = moves.filter((move): boolean => move.x < 0 || move.y < 0);
+    expect(negatives).toEqual([]);
+  });
+
+  it('handles a budget shorter than one tick: zero ticks, still parks', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    const shortBudget = Math.floor(HUMANIZE_TICK_MS / 4);
+    const didResolve = await humanizeWait(shortBudget);
+    expect(didResolve).toBe(true);
+    expect(moves.length).toBe(1);
+    expect(moves[0].x).toBe(HUMANIZE_END_X);
+    expect(moves[0].y).toBe(HUMANIZE_END_Y);
+  });
+
+  it('uses the viewport center as the starting cursor when viewport is available', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves);
+    const humanizeWait = buildHumanizeWait(page);
+    await humanizeWait(HUMANIZE_TICK_MS * 3);
+    expect(moves.length).toBeGreaterThanOrEqual(2);
+    const first = moves[0];
+    expect(first.x).toBeGreaterThan(0);
+    expect(first.y).toBeGreaterThan(0);
+  });
+
+  it('falls back to a default starting cursor when viewport returns null', async () => {
+    const moves: IRecordedMove[] = [];
+    const page = makeMockPage(moves, null);
+    const humanizeWait = buildHumanizeWait(page);
+    const didResolve = await humanizeWait(HUMANIZE_TICK_MS * 3);
+    expect(didResolve).toBe(true);
+    expect(moves.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Phases/Init/InitBrowserSetup.test.ts
+++ b/src/Tests/Unit/Pipeline/Phases/Init/InitBrowserSetup.test.ts
@@ -159,4 +159,12 @@ describe('closeBrowserSafe', () => {
     const didClose = await closeBrowserSafe(browser);
     expect(didClose).toBe(false);
   });
+
+  it('routes through the strip-aware composite cleanup when bank is supplied', async () => {
+    const closeFn = jest.fn().mockResolvedValue(undefined);
+    const browser = { close: closeFn } as unknown as Browser;
+    const didClose = await closeBrowserSafe(browser, 'amex');
+    expect(didClose).toBe(true);
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/Tests/Unit/Pipeline/Phases/Init/InitBrowserSetup.test.ts
+++ b/src/Tests/Unit/Pipeline/Phases/Init/InitBrowserSetup.test.ts
@@ -1,10 +1,132 @@
 /**
- * Unit tests for Phases/Init/InitBrowserSetup — safe close helper.
+ * Unit tests for Phases/Init/InitBrowserSetup — safe close helper,
+ * createContextAndPage union-narrowing, and buildBrowserState cleanup
+ * ordering for both ephemeral and persistent launch paths.
  */
 
-import type { Browser } from 'playwright-core';
+import { jest } from '@jest/globals';
+import type { Browser, BrowserContext, Page } from 'playwright-core';
 
-import { closeBrowserSafe } from '../../../../../Scrapers/Pipeline/Phases/Init/InitBrowserSetup.js';
+import {
+  buildBrowserState,
+  closeBrowserSafe,
+  createContextAndPage,
+} from '../../../../../Scrapers/Pipeline/Phases/Init/InitBrowserSetup.js';
+
+/**
+ * Build a fake ephemeral Browser whose `newContext` returns a context
+ * whose `newPage` behaves per the callback.
+ * @param newPage - Behaviour for `context.newPage()`.
+ * @returns Fake Browser + handles for assertion.
+ */
+function buildFakeEphemeralBrowser(newPage: () => Promise<Page>): {
+  browser: Browser;
+  contextClose: jest.Mock;
+} {
+  const contextClose = jest.fn().mockResolvedValue(undefined);
+  const fakeContext = { newPage, close: contextClose } as unknown as BrowserContext;
+  /**
+   * Resolve the fake context.
+   * @returns Fake browser context.
+   */
+  function newContext(): Promise<BrowserContext> {
+    return Promise.resolve(fakeContext);
+  }
+  const browser = { newContext } as unknown as Browser;
+  return { browser, contextClose };
+}
+
+/**
+ * Build a fake persistent BrowserContext with the given page list and
+ * an optional `newPage` factory. Lacks `newContext` so the production
+ * `'newContext' in result` narrow falls to the persistent branch.
+ * @param existingPages - Initial pages owned by the context.
+ * @param newPage - Behaviour for `context.newPage()`.
+ * @returns Fake context + close handle.
+ */
+function buildFakePersistentContext(
+  existingPages: readonly Page[],
+  newPage: () => Promise<Page>,
+): { context: BrowserContext; close: jest.Mock } {
+  const close = jest.fn().mockResolvedValue(undefined);
+  /**
+   * Return the prebuilt list of existing pages.
+   * @returns Page array (frozen).
+   */
+  function pages(): readonly Page[] {
+    return existingPages;
+  }
+  const ctx = { pages, newPage, close } as unknown as BrowserContext;
+  return { context: ctx, close };
+}
+
+describe('createContextAndPage — ephemeral path', () => {
+  it('returns context + page on the happy path', async () => {
+    const fakePage = { close: jest.fn() } as unknown as Page;
+    const { browser } = buildFakeEphemeralBrowser(() => Promise.resolve(fakePage));
+    const result = await createContextAndPage(browser);
+    expect(result.page).toBe(fakePage);
+  });
+
+  it('closes the freshly-created context and rethrows when newPage fails', async () => {
+    const newPageErr = new Error('newPage exploded');
+    const { browser, contextClose } = buildFakeEphemeralBrowser(() => Promise.reject(newPageErr));
+    let didThrow: unknown = null;
+    try {
+      await createContextAndPage(browser);
+    } catch (error_) {
+      didThrow = error_;
+    }
+    expect(didThrow).toBe(newPageErr);
+    expect(contextClose).toHaveBeenCalled();
+  });
+});
+
+describe('createContextAndPage — persistent path', () => {
+  it('reuses the first existing page when the context already has one', async () => {
+    const existingPage = { close: jest.fn() } as unknown as Page;
+    const newPage = jest.fn(() => Promise.resolve({ close: jest.fn() } as unknown as Page));
+    const { context } = buildFakePersistentContext([existingPage], newPage);
+    const result = await createContextAndPage(context);
+    expect(result.context).toBe(context);
+    expect(result.page).toBe(existingPage);
+    expect(newPage).not.toHaveBeenCalled();
+  });
+
+  it('opens a new page when the persistent context has none', async () => {
+    const fresh = { close: jest.fn() } as unknown as Page;
+    const newPage = jest.fn(() => Promise.resolve(fresh));
+    const { context } = buildFakePersistentContext([], newPage);
+    const result = await createContextAndPage(context);
+    expect(result.page).toBe(fresh);
+    expect(newPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildBrowserState cleanup ordering', () => {
+  it('produces a single composite cleanup when launchResult === context', async () => {
+    const close = jest.fn().mockResolvedValue(undefined);
+    /**
+     * Empty page list for the persistent-context fake.
+     * @returns Frozen empty array.
+     */
+    function pages(): readonly Page[] {
+      return [];
+    }
+    const sharedCtx = { pages, close } as unknown as BrowserContext;
+    const fakePage = { close: jest.fn() } as unknown as Page;
+    const state = buildBrowserState({
+      page: fakePage,
+      context: sharedCtx,
+      launchResult: sharedCtx,
+      bank: 'amex',
+    });
+    expect(state.cleanups).toHaveLength(1);
+    const didFinish = await state.cleanups[0]();
+    expect(didFinish.success).toBe(true);
+    expect(close).toHaveBeenCalled();
+  });
+});
 
 describe('closeBrowserSafe', () => {
   it('returns false when browser handle is false', async () => {

--- a/src/Tests/Unit/Pipeline/Strategy/Scrape/Account/BalanceExtractor.test.ts
+++ b/src/Tests/Unit/Pipeline/Strategy/Scrape/Account/BalanceExtractor.test.ts
@@ -7,6 +7,7 @@ import {
   resolveBalanceFromRecords,
   resolveRecordBalance,
 } from '../../../../../../Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.js';
+import type { JsonObject } from '../../../../../../Scrapers/Pipeline/Types/Json.js';
 import { isOk } from '../../../../../../Scrapers/Pipeline/Types/Procedure.js';
 
 describe('isRecord', () => {
@@ -52,7 +53,7 @@ describe('resolveRecordBalance', () => {
   });
 
   it('descends into top-level arrays for balance', () => {
-    const record = { items: [{ other: 'x' }, { balance: 500 }] };
+    const record = { items: [{ other: 'x' }, { balance: 500 }] } as JsonObject;
     const resolveRecordBalanceResult10 = resolveRecordBalance(record, ['balance']);
     expect(resolveRecordBalanceResult10).toBe(500);
   });
@@ -72,7 +73,7 @@ describe('resolveRecordBalance', () => {
 
 describe('resolveBalanceFromRecords', () => {
   it('finds balance in first matching record', () => {
-    const records = [{ other: 'x' }, { balance: 10 }];
+    const records = [{ other: 'x' }, { balance: 10 }] as JsonObject[];
     const result = resolveBalanceFromRecords(records, ['balance']);
     const isOkResult13 = isOk(result);
     expect(isOkResult13).toBe(true);
@@ -80,7 +81,7 @@ describe('resolveBalanceFromRecords', () => {
   });
 
   it('returns failure when no record has balance', () => {
-    const records = [{ a: 1 }, { b: 2 }];
+    const records = [{ a: 1 }, { b: 2 }] as JsonObject[];
     const result = resolveBalanceFromRecords(records, ['balance']);
     const isOkResult14 = isOk(result);
     expect(isOkResult14).toBe(false);

--- a/src/Tests/Unit/Pipeline/Strategy/Scrape/CrossBankBalanceResolution.test.ts
+++ b/src/Tests/Unit/Pipeline/Strategy/Scrape/CrossBankBalanceResolution.test.ts
@@ -21,6 +21,7 @@ import {
   resolveBalanceFromRecords,
   resolveRecordBalance,
 } from '../../../../../Scrapers/Pipeline/Strategy/Scrape/Account/BalanceExtractor.js';
+import type { JsonObject } from '../../../../../Scrapers/Pipeline/Types/Json.js';
 import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 
 /** Closed enum — pipeline browser banks that expose a balance field. */
@@ -35,7 +36,7 @@ interface IBankBalanceFixture {
    * FAKE response body. Records mirror real-bank captures' shapes with
    * PII-redacted FAKE values (account numbers, amounts, descriptions).
    */
-  readonly fakeBody: Readonly<Record<string, unknown>>;
+  readonly fakeBody: JsonObject;
   /**
    * The single alias DASHBOARD.FINAL would resolve onto
    * `ctx.txnEndpoint.fieldMap.balance` for this bank's TXN body.

--- a/src/Tests/Unit/Pipeline/Types/BasePhase.handoff.test.ts
+++ b/src/Tests/Unit/Pipeline/Types/BasePhase.handoff.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { BasePhase } from '../../../../Scrapers/Pipeline/Types/BasePhase.js';
+import type { ContextId } from '../../../../Scrapers/Pipeline/Types/Brand.js';
 import { none, some } from '../../../../Scrapers/Pipeline/Types/Option.js';
 import type { PhaseName } from '../../../../Scrapers/Pipeline/Types/Phase.js';
 import type {
@@ -105,7 +106,7 @@ describe('BasePhase HANDOFF log (phase-scoped)', () => {
         ...base.diagnostics,
         dashboardTarget: {
           selector: '#t',
-          contextId: 'main',
+          contextId: 'main' as ContextId,
           kind: 'css',
           candidateValue: '#t',
         },
@@ -138,7 +139,10 @@ describe('BasePhase HANDOFF log (phase-scoped)', () => {
     const phase = new LoginLikePhase();
     const disc = {
       targets: new Map([
-        ['password', { selector: '#p', contextId: 'main', kind: 'css', candidateValue: 'pwd' }],
+        [
+          'password',
+          { selector: '#p', contextId: 'main' as ContextId, kind: 'css', candidateValue: 'pwd' },
+        ],
       ]),
       formAnchor: none(),
       activeFrameId: 'main',

--- a/src/Tests/Unit/Scrapers/Pipeline/MockPipelineFactories.ts
+++ b/src/Tests/Unit/Scrapers/Pipeline/MockPipelineFactories.ts
@@ -475,6 +475,14 @@ export function makeMockMediator(overrides: Partial<IElementMediator> = {}): IEl
       return true as const;
     },
     /**
+     * No-op mock for humanizeWait. The Pipeline factory tests do
+     * not exercise the mouse-jitter side-effect; this stub satisfies
+     * the IElementMediator interface so the mediator can be passed
+     * through `phaseSettle` in tests that don't have a real Page.
+     * @returns Promise resolving to true.
+     */
+    humanizeWait: (): Promise<true> => Promise.resolve(true as const),
+    /**
      * Count by text mock — returns 0 (no elements).
      * @returns Zero.
      */

--- a/src/Tests/Unit/Scrapers/Pipeline/Phases/InitPhase.test.ts
+++ b/src/Tests/Unit/Scrapers/Pipeline/Phases/InitPhase.test.ts
@@ -7,14 +7,13 @@ import { jest } from '@jest/globals';
 
 import { assertHas, assertOk } from '../../../../Helpers/AssertProcedure.js';
 // Static imports of non-mocked factories — safe with jest.unstable_mockModule.
+import { createCamoufoxMock } from '../../../../MockModuleFactories.js';
 import { makeMockOptions } from '../../../Pipeline/Infrastructure/MockFactories.js';
 import { makeMockContext as MAKE_MOCK_CONTEXT } from '../MockPipelineFactories.js';
 
 jest.unstable_mockModule(
   '../../../../../Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.js',
-  () => ({
-    launchCamoufox: jest.fn(),
-  }),
+  createCamoufoxMock,
 );
 
 jest.unstable_mockModule(

--- a/src/Tests/Unit/Yahav.test.ts
+++ b/src/Tests/Unit/Yahav.test.ts
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', () => ({ launchCamoufox: jest.fn() }));
+import { createCamoufoxMock } from '../MockModuleFactories.js';
+
+jest.unstable_mockModule('../../Common/CamoufoxLauncher.js', createCamoufoxMock);
 
 jest.unstable_mockModule('../../Common/ElementsInteractions.js', () => ({
   clickButton: jest.fn().mockResolvedValue(undefined),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,18 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "ignoreDeprecations": "6.0",
+    /*
+     * `ignoreDeprecations` (added 2026-05-17 with the TS 5.9 -> 6.0 bump)
+     * silences `TS5101: Option 'baseUrl' is deprecated and will stop
+     * functioning in TypeScript 7.0`. `tsup` / `rollup-plugin-dts`
+     * auto-injects `baseUrl` during DTS bundling — we don't set it
+     * explicitly anywhere in this codebase, so it lands via the tool
+     * chain. To unblock the TS 7.0 upgrade later, remove this setting
+     * once the upstream `rollup-plugin-dts` build no longer relies on
+     * `baseUrl` (track at https://github.com/Swatinem/rollup-plugin-dts).
+     * No other deprecations apply: this repo uses `moduleResolution: NodeNext`,
+     * `module: NodeNext`, `target: es2022` — none of which are deprecated.
+     */
     "types": ["jest", "lodash", "node", "source-map-support"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary (WHY)

Two distinct lanes of work, kept as **atomic commits** so each can be reviewed (and reverted) independently:

1. **Cycles 1-2** — close every OPEN SonarCloud issue across the 6 active rule classes + lock the same patterns at `eslint --max-warnings 0` so they cannot regress.
2. **Cycle 3** (new — discovered while validating the SonarCloud branch in Docker) — seven atomic commits that make Cloudflare's managed challenge on `he.americanexpress.co.il` auto-pass, fix Hapoalim's hCaptcha trigger by humanising the silent 4 s phase-settle window, and add opt-in per-bank persistent profiles. Forensic provenance summarised under §"Cycle 3 — forensic provenance" below; raw artifacts are in CI job logs.

**Suggested split:** if you prefer one PR per lane, cycles 1-2 stop at `7f64b2a4` and cycle 3 starts at `4f1fd23e`. The lanes don't share files; splitting is a clean `git revert` of seven commits on this branch + new branch from `7f64b2a4`.

## Scope (WHAT) — single responsibility per commit

14 commits, two lanes:

### Cycle 1 — initial SonarCloud PR (6 commits)

| Commit | Scope |
|--------|-------|
| `d0d1a81c` `chore(tsconfig): explain ignoreDeprecations` | PR #234 CodeRabbit follow-up — document TS 6.0 `ignoreDeprecations` rationale. |
| `e7e747ec` `fix(quality): close 7 SonarCloud findings` | S2699 ×1 + S2933 ×2 + S7763 ×3 + S7772 ×1 = **7 issues**. |
| `a54a1064` `chore(lint): toolchain hardening + sonar gate` | `eslint-plugin-jest` + 4 new rules + pre-commit gate-13 (sonar-scanner). |
| `432e1f1a` `fix(hook): robust SONAR_TOKEN extract from .env` | Replace `. ./.env` arbitrary-exec path with targeted `grep + sed`. |
| `d4565377` `test(api-direct-call): drop FlowKind tautology` | S5914 ×3 — `expect(x).toBe(x)` deletions. |
| `b57da35b` `refactor(login): drop FormAnchorSelector alias` | S6564 ×1 — unnecessary free-function workaround alias. |

### Cycle 2 — close the remaining 7 S6564 in code (4 commits)

| Commit | Scope |
|--------|-------|
| `177bfdff` `fix(hook): address 3 CR findings on PR #235` | CRLF strip; `timeout` guard; `sonar-scan.mjs` cross-platform Node wrapper. |
| `036e2704` `refactor(types): close 6 S6564 + canary` | New shared `JsonValue` union + `redundant-type-alias.canary.ts`. 19/19 canaries pass. |
| `f61e2631` `refactor(types): brand ContextId (close S6564)` | `Brand<string, 'ContextId'>` + `mintContextId` helper; 5 ctors + 37 fixtures. |
| `7f64b2a4` `fix(types): canonical MAIN_CONTEXT_ID + mint` | 2 CR follow-up findings on cycle 2. |

### Cycle 3 — Amex Cloudflare + Hapoalim hCaptcha mitigation + persistent profiles (7 commits) — NEW

Pre-existing failure mode: Amex E2E real failed at `AUTH-DISCOVERY POST: AUTH_DISCOVERY_DASHBOARD_NOT_READY — reveal-missing` because Cloudflare's managed challenge on `he.americanexpress.co.il/personalarea/dashboard/` returned 403 + a `cf_chl_tk` Turnstile redirect after LOGIN, and our 172-locator reveal probe matched 0 candidates on the challenge page (Ray ID `9fdaebe9ee2d2674`).

| Commit | Scope |
|--------|-------|
| `4f1fd23e` `fix(docker): drop --env-file (quote-leak)` | Docker's `--env-file` parser bug-compatibly mirrors shell `source` and does NOT strip `"..."` wrapping quotes from values — unlike dotenv. Passwords wrapped to escape `#` (e.g. `MAX_PASSWORD="..."`) leaked literal quotes into the container env, where Max's `maxlength="14"` password input truncated the trailing quote and submitted an off-by-one password. Each test's `dotenv.config()` already strips quotes correctly. |
| `c578c407` `feat(camoufox): humanize + disable_coop + virtual` | Three documented Camoufox launcher knobs ([camoufox.com/python/usage](https://camoufox.com/python/usage/)): `humanize: true` (built-in cursor humanization), `disable_coop: true` (Cross-Origin-Opener-Policy relaxed so Turnstile iframe is reachable), `headless: 'virtual'` on Linux (Xvfb-backed display). All three toggleable via `CAMOUFOX_HUMANIZE`, `CAMOUFOX_DISABLE_COOP`, `CAMOUFOX_VIRTUAL_HEADLESS` env vars. Folded-in cleanup: consolidate the two duplicated `CamoufoxLauncher.ts` + `BrowserConfig.ts` pairs into one source of truth at `Common/`; Pipeline-side files become thin re-exports. Jest mock replicates camoufox-js's `virtual` mode (Xvfb spawn + safe boolean fallback). Docker CI-mirror + GH Actions install-camoufox both apt-install `xvfb`. `docker/run-banks.sh` now mounts a host-side directory for artifact inspection. **Validated: Amex E2E real PASSED in Docker CI mirror; 25 real txns scraped, Cloudflare auto-passed silently with no Turnstile checkbox.** |
| `bb488d65` `feat(camoufox): persistent profiles per bank` | Opt-in via `USE_PERSISTENT_PROFILES=true`. New `launchCamoufoxForBank` returns `Browser \| BrowserContext` (ephemeral vs persistent); helpers `getProfileDir`, `isPersistentProfilesEnabled`, `stripProfileCache`, `buildCloseAndStripCleanup`. Profile path is a per-bank subdirectory under the user's XDG cache root (configurable; see `getProfileDir` JSDoc) — never committed to git. CI restores + saves via `actions/cache` keyed `profile-<bank>-<runner.os>-v1` (new optional `bank` input to install-camoufox action). Strips `Cache/`, `OfflineCache/`, `cache2/`, `crashes/` post-run to keep profile small (~5-15 MB) and the GH Actions cache fast. 21 new unit tests cover all helpers + both context-narrow branches in `InitBrowserSetup`. 9 existing test files migrated from inline `jest.fn()` mocks to `createCamoufoxMock` factory so ESM imports resolve cleanly. |
| `ad03c545` `fix(tests): mkdtempSync for CodeQL temp-file rule` | CodeQL flagged 2 high-severity "insecure temporary file" alerts in the new `stripProfileCache` test (predictable temp-dir name based on `Date.now()`). Switched to `fs.mkdtempSync` for atomic crypto-random suffix + restrictive default perms. 16/16 unit tests pass. |
| `91455ada` `feat(reducer): humanize settle for init/home/login` | **Hapoalim hCaptcha mitigation.** Real A CI run on `ad03c545` (job `76672009659`) showed Hapoalim failing at HOME.PRE with a Hebrew "Additional security check is required — Please click the checkbox below" hCaptcha challenge on `www.bankhapoalim.co.il`. Root cause: the 4 s `phase-settle` is silent — banks profile the pre-auth window for "human input present?" and a silent settle reads as bot. New `Mediator/Timing/HumanizeWait.ts` emits ~1 mouse-move per `HUMANIZE_TICK_MS` (400 ms) within `HUMANIZE_JITTER_RADIUS_PX` (40 px) during the settle, then parks the cursor at top-left so `resolveVisible` runs against a deterministic position. Whitelist = `{init, home, login}` only; other phases stay silent. **Complementary to the Camoufox `humanize: true` knob** already shipped in `c578c407` — that one humanises existing mouse calls (curved paths + timing variance); this one generates new mouse calls during the otherwise-silent window. Forensic post-fix: standalone Hapoalim happy-path E2E `PASS in 331.145 s — ✓ scrapes transactions successfully (305947 ms)`. 8 new unit tests cover the cursor walk, budget bound, end-of-budget park, viewport fallback, under-tick budget, and swallow-on-mouse-error contract. |
| `3ea4d863` `chore(ci): clean Xvfb version probe via dpkg-query` | Cosmetic cleanup of the install-camoufox action: replaced `Xvfb -version` (which X.Org never supported — every CI matrix job logged a misleading "Unrecognized option: -version" stderr line) with `dpkg-query -W -f='${Package} ${Version}\n' xvfb`. Behaviour unchanged; CI logs now show the installed Xvfb version cleanly. |
| `fd4d7307` `fix(security): block Math.random, use crypto` | **SonarCloud quality-gate fix.** Two `typescript:S2245` (weak PRNG) hotspots in the new `HumanizeWait.nextJitterPosition` blocked `new_security_hotspots_reviewed`. Both call sites (`HumanizeWait.ts` jitter offsets + `CamoufoxJsMock.js` Xvfb display number) now use `node:crypto.randomInt`. **Locked at lint time** via a new `no-restricted-syntax` entry in both `RESTRICTED_SYNTAX_RULES` and `RESTRICTED_SYNTAX_RULES_NEW` that bans every `Math.random()` call site, with a new architectural canary `EslintCanaries/math-random.canary.ts` that fails the build if the rule is ever weakened (canary count 19 → **20/20 pass**). Approved CSPRNG alternatives: `randomBytes`, `randomInt`, `randomUUID` from `node:crypto`. |

## Scorecard

| Metric | Value |
|--------|-------|
| Commits (cycles 1-2) | 10 |
| Commits (cycle 3) | 7 |
| LoC (cycles 1-2) | +525 / -228 = **297 net** |
| LoC (cycle 3) | +1387 / -103 = **1284 net** |
| **SonarCloud issues closed in code** | **18 / 18** (S2699 + S2933 ×2 + S7763 ×3 + S7772 + S5914 ×3 + S6564 ×8) |
| SonarCloud "Won't Fix" dismissals | **0** |
| Architecture rules weakened | **0** |
| New ESLint rules wired | 6 (cycles 1-2: 5; cycle 3: 1 new — Math.random ban) |
| Architectural canaries | **20 / 20 pass** (added `math-random.canary.ts` in `fd4d7307`) |
| Cycle 3 — Amex E2E real (Docker mirror) | **PASS** in 437.8s with 25 real txns scraped |
| Cycle 3 — Hapoalim E2E real (Docker mirror) post-humanize | **PASS** in 331.1s with hCaptcha auto-cleared (no checkbox) |
| Cycle 3 — Persistent-profile tests + humanize tests | **29 / 29 pass** |
| Unit + mocked-E2E coverage | statements 97.05% / branches 95.08% / functions 97.06% / lines 98.28% — all above the 97 / 95 / 96 / 97 thresholds |
| **Real A CI run on `ad03c545`** (before humanize) | 6/7 PASS — Hapoalim only failure (hCaptcha trigger documented above) |

## Validation

- `npx tsc --noEmit` — clean
- `npx eslint src --max-warnings 0` — clean
- `npx prettier --check .` — clean
- `bash src/Scrapers/Pipeline/EslintCanaries/verify.sh` — 19/19 trigger
- Pre-commit full gate ladder ran on every commit. All green on every gate (prettier + tsc + eslint + biome + audit + architecture + build + canaries + test:pipeline + bank-tests + test:mock + test:e2e:mock + live-E2E slot).

## Cycle 3 — forensic provenance

- **Amex Cloudflare challenge HTML proof**: captured during the local Docker validation run on commit `c578c407`. The post-LOGIN navigation to `/personalarea/dashboard/` returned 403 with the Hebrew "ביצוע אימות אבטחה" Cloudflare challenge page (Ray ID `9fdaebe9ee2d2674` is in the screenshot). The screenshot lives in the run-local artifact tree on the developer host.
- **Hapoalim hCaptcha challenge HTML proof**: Real A CI job [`76672009659`](https://github.com/sergienko4/israeli-bank-scrapers/runs/76672009659) on commit `ad03c545` failed at HOME.PRE with the Hebrew "נדרש אימות נוסף — אנא לחצו על ריבוע ההזדהות שלמטה" + hCaptcha checkbox on `www.bankhapoalim.co.il`. Annotation visible in the job log.
- **Max password-leak smoking gun**: the Max login POST body on commit `ad03c545` (before the env-file fix) contained a leading literal `"` followed by the password, which Max's `maxlength="14"` password input truncated to drop the trailing `"` — submitting an off-by-one value. Reproducible only with Docker `--env-file` invocation; CI's per-secret `-e` flags never had the bug.
- **Camoufox docs**: https://camoufox.com/python/usage/
- **Camoufox Turnstile feature request**: https://github.com/daijro/camoufox/issues/584
- **Playwright Firefox cross-origin iframe issue**: https://github.com/microsoft/playwright/issues/21780 (closed not-planned)
- **Coordinate-click pattern**: https://github.com/MaestroOfAutomation/turnstile_bypass

## Self-review

- Atomic commits per concern (`commit-guidlines.md §1`); no mixed formatting/feature/fix.
- 50/72 commit-message rule respected on every subject + body.
- No `--no-verify`, no `--force-with-lease`, no `--amend`.
- Selective `git add` per file; no `git add .`.
- Cycle 3 — no `as any` / `as never` introductions; the union return type `Browser | BrowserContext` is type-narrowed via `'newContext' in result` in callers, not cast.
- Cycle 3 — no `void` return types in the new helpers (the `stripProfileCache` `: true` return matches the project's architecture rule).
- Cycle 3 — persistent profiles are **default off** (`USE_PERSISTENT_PROFILES=true` opt-in); the existing ephemeral path is byte-compatible for callers that don't opt in.
- 9 dependent test files were migrated to the shared `createCamoufoxMock` factory so the ESM module-mock surface includes every new export.

## Risk + rollback

- **Cycles 1-2** — toolchain commits block any future PR that reintroduces a flagged pattern. `SKIP_SONAR_GATE=1` escape hatch in place.
- **Cycle 3 — `feat(camoufox): humanize + disable_coop + virtual`** — proven safe via Docker CI mirror; defaults can be toggled off per-run via the three `CAMOUFOX_*` env vars without code change.
- **Cycle 3 — `feat(camoufox): persistent profiles per bank`** — opt-in only. Default `USE_PERSISTENT_PROFILES=false` means existing flows are byte-compatible. Enabling the feature only changes behaviour when the env var is set AND a Browser → BrowserContext narrow is observed by downstream consumers.
- **Cycle 3 — `fix(docker): drop --env-file (quote-leak)`** — local-only docker runner change. CI workflows already used `-e` per-secret (not `--env-file`), so no CI impact.

## Out of scope (tracked, not blocking)

- Cycles 1-2 — `jest/no-conditional-expect` (~680 sites); `sonar-scanner` CLI not auto-installed (axios CVE in npm wrapper).
- Cycle 3 — paid `@2captcha/captcha-solver` integration (NOT pursued — user pushed back on paid solvers; documented as a fallback only). Coordinate-click Turnstile solver port of [MaestroOfAutomation pattern](https://github.com/MaestroOfAutomation/turnstile_bypass) — not needed because P0 stack alone clears the challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional local Sonar scan on commit, per-bank persistent browser profiles, Linux virtual-display support, and humanized browser interactions.
  * New pre-push reviewer hook to gate pushes with a local review agent.

* **Bug Fixes**
  * Broad TypeScript typing and context-id safety improvements across pipeline code.

* **Testing**
  * Expanded unit tests and lint canaries to cover profile handling, Sonar parity, timing, and browser-launch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->