### PR TITLE
chore(deps): bump Camoufox v135.0.1-beta.24 -> v150.0.2-beta.25

### DIFF
--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -13,9 +13,7 @@ runs:
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ~/.cache/camoufox
-        key: camoufox-v135.0.1-beta.24
-        restore-keys: |
-          camoufox-
+        key: camoufox-v150.0.2-beta.25
     - name: Install Camoufox browser
       shell: bash
       env:
@@ -31,7 +29,7 @@ runs:
           else
             echo "camoufox-js fetch failed (likely rate-limited) — falling back to gh release download"
             ASSET_DIR=$(mktemp -d)
-            gh release download v135.0.1-beta.24 --repo daijro/camoufox --pattern 'camoufox-*-lin.x86_64.zip' --dir "$ASSET_DIR" --clobber
+            gh release download v150.0.2-beta.25 --repo daijro/camoufox --pattern 'camoufox-*-lin.x86_64.zip' --dir "$ASSET_DIR" --clobber
             mkdir -p ~/.cache/camoufox
             unzip -o "$ASSET_DIR"/*.zip -d ~/.cache/camoufox/
             rm -rf "$ASSET_DIR"

--- a/docker/Dockerfile.ci-mirror
+++ b/docker/Dockerfile.ci-mirror
@@ -1,4 +1,4 @@
-# CI mirror — Ubuntu 24.04 + Node 22.14.0 + Camoufox v135.0.1-beta.24.
+# CI mirror — Ubuntu 24.04 + Node 22.14.0 + Camoufox v150.0.2-beta.25.
 # Built to match GitHub's `ubuntu-latest` (= 24.04) runner image so local
 # repro of the E2E Real A jobs matches the CI environment byte-for-byte
 # above the OS level. Used for two purposes:
@@ -19,7 +19,7 @@ FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION=22.14.0
-ARG CAMOUFOX_VERSION=v135.0.1-beta.24
+ARG CAMOUFOX_VERSION=v150.0.2-beta.25
 
 # Mirror the apt set that the GitHub `ubuntu-24.04` runner image carries
 # that Camoufox / Firefox needs at runtime. Source list cross-checked


### PR DESCRIPTION
## Why

CI was pinned to Camoufox v135 by the **GHA cache key**, not by the npm package. `@hieutran094/camoufox-js@0.6.8` resolves the Camoufox release dynamically at runtime by walking `daijro/camoufox` GitHub releases newest-first ([pkgman.js `CamoufoxFetcher.getAsset`](https://github.com/apify/camoufox-js/blob/main/src/pkgman.ts)) and picking the newest release whose assets match the platform + support range (`>=beta.19, <1`). The cache key was the only thing holding CI back.

Upstream `daijro/camoufox` published `v150.0.2-beta.25` on 2026-05-11. With the cache key released, `0.6.8` will pick it up automatically on the next cold fetch — no `package.json` bump needed (0.6.8 is already latest on npm).

## What

Two files, 4 edits, ~6 line diff.

**`.github/actions/install-camoufox/action.yml`**
- cache key: `camoufox-v135.0.1-beta.24` → `camoufox-v150.0.2-beta.25`
- **dropped `restore-keys: camoufox-`** — a v150 cache miss with that prefix restore-key would silently restore the v135 binary under the new key. The install step's `if [ -f camoufox-bin ]` check then sees the binary, skips the fetch, and leaves the v150 cache entry holding v135 bytes. Permanent regression until manual cache clear.
- gh-release fallback tag: `v135.0.1-beta.24` → `v150.0.2-beta.25`

**`docker/Dockerfile.ci-mirror`**
- header comment + `CAMOUFOX_VERSION` ARG → `v150.0.2-beta.25` (ARG is unused at runtime; bumped for grep hygiene).

## Why NOT bump `package.json`

- `@hieutran094/camoufox-js@0.6.8` is the **current latest** on npm (no newer version exists).
- It does **not** hardcode v135 — it resolves the upstream release dynamically per [pkgman.js:88-129](../../../../sergienko4/israeli-bank-scrapers/blob/main/node_modules/%40hieutran094/camoufox-js/dist/pkgman.js).
- Bumping would churn the lockfile for no behavioral change.

## Risks

1. **15-version Camoufox jump** (v135 → v150). Fingerprint surface, Playwright API compat, WAF-detection signal mix all change. E2E Real gate is the verdict.
2. **v150.0.2-beta.25 is 9 days old** (published 2026-05-11) — less battle-tested than v135.0.1-beta.24 (March 2025).
3. **First CI run cold-fetches ~700 MB** from upstream GitHub Releases. Subsequent runs hit the new cache.
4. **No Windows assets** on v150 per upstream release notes — irrelevant for CI (Ubuntu) but Windows devs running host-Camoufox will need to wait for the upstream Windows release or use the Docker mirror.

## Test plan

- [ ] E2E Smoke (all 18 banks) green
- [ ] E2E Real A (Beinleumi, Discount, Hapoalim, Isracard, Max, OneZero, VisaCal) green
- [ ] E2E Real B (Amex) green
- [ ] Cache-key change forces a cold-fetch on first run (no v135 carry-over)
- [ ] No regressions on the 1M-context test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Camoufox to version 150.0.2-beta.25 across CI infrastructure and Docker configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergienko4/israeli-bank-scrapers/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->