### PR TITLE
fix(onezero): route identity API via Camoufox TLS

### DIFF
--- a/src/Scrapers/Pipeline/Core/Executor/PipelineExecutor.ts
+++ b/src/Scrapers/Pipeline/Core/Executor/PipelineExecutor.ts
@@ -1,6 +1,7 @@
 /** Pipeline executor — reduces over phases; short-circuits on failure. */
 
 import type { IScraperScrapingResult, ScraperCredentials } from '../../../Base/Interface.js';
+import type { LifecyclePromise } from '../../../Base/Interfaces/CallbackTypes.js';
 import ScraperError from '../../../Base/ScraperError.js';
 import type { IPipelineContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
@@ -15,6 +16,32 @@ import {
   type IContextTracker,
 } from './PipelineMiddleware.js';
 import { reducePhases, wrapError } from './PipelineReducer.js';
+
+/**
+ * Awaits an optional dispose() callback, swallowing any thrown error so the
+ * already-failing scrape outcome is never masked.
+ * @param disposeFn - Optional dispose hook (undefined for mediators with no
+ * owned resources).
+ * @returns Resolves once dispose has been attempted (success or swallowed).
+ */
+async function tryDispose(disposeFn?: () => Promise<void>): LifecyclePromise {
+  try {
+    await disposeFn?.();
+  } catch {
+    /* silent: dispose must never mask the original scrape outcome */
+  }
+}
+
+/**
+ * Disposes an apiMediator that owns external resources (e.g. a Camoufox
+ * browser). Mediators without an own resource (dispose === undefined) are
+ * a no-op.
+ * @param ctx - The last-known pipeline context carrying the mediator slot.
+ * @returns Resolves once dispose has been attempted (success or swallowed).
+ */
+async function disposeApiMediatorSafe(ctx: IPipelineContext): LifecyclePromise {
+  if (ctx.apiMediator.has) await tryDispose(ctx.apiMediator.value.dispose);
+}
 
 /**
  * Run phase reduction with cleanup guarantee.
@@ -33,6 +60,7 @@ async function runWithCleanup(
   } finally {
     await runAfterPipeline(tracker.interceptors, tracker.lastCtx);
     await ensureBrowserCleanup(tracker, initialCtx.logger);
+    await disposeApiMediatorSafe(tracker.lastCtx);
   }
 }
 

--- a/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts
+++ b/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts
@@ -3,7 +3,10 @@
  */
 
 import type { ScraperCredentials } from '../../Base/Interface.js';
-import { createHeadlessApiMediator } from '../Mediator/Api/ApiMediator.js';
+import {
+  createBrowserBackedHeadlessApiMediator,
+  createHeadlessApiMediator,
+} from '../Mediator/Api/ApiMediator.js';
 import { resolvePipelineBankConfig } from '../Registry/Config/PipelineBankConfig.js';
 import { getDebug as createLogger } from '../Types/Debug.js';
 import { none, some } from '../Types/Option.js';
@@ -164,6 +167,7 @@ interface IHeadlessWiring {
   readonly identity: string;
   readonly graphql: string;
   readonly staticAuth?: string;
+  readonly requiresBrowserTls: boolean;
 }
 
 /**
@@ -180,7 +184,30 @@ function resolveHeadlessWiring(companyId: IPipelineContext['companyId']): IHeadl
     identity: headless.identityBase,
     graphql: headless.graphql,
     staticAuth: headless.staticAuth,
+    requiresBrowserTls: headless.requiresBrowserTls === true,
   };
+}
+
+/**
+ * Selects the mediator factory based on wiring.requiresBrowserTls and wires
+ * identityOriginUrl when the browser-backed branch is taken.
+ * @param companyId - Target bank company type.
+ * @param wiring - Resolved wiring entry (URLs + flags).
+ * @returns Wired IApiMediator instance (with dispose when browser-backed).
+ */
+function buildApiMediatorForWiring(
+  companyId: IPipelineContext['companyId'],
+  wiring: IHeadlessWiring,
+): ReturnType<typeof createHeadlessApiMediator> {
+  const base = {
+    bankHint: companyId,
+    identityBaseUrl: wiring.identity,
+    graphqlUrl: wiring.graphql,
+    staticAuth: wiring.staticAuth,
+  };
+  if (!wiring.requiresBrowserTls) return createHeadlessApiMediator(base);
+  const identityOriginUrl = new URL(wiring.identity).origin;
+  return createBrowserBackedHeadlessApiMediator({ ...base, identityOriginUrl });
 }
 
 /**
@@ -193,12 +220,7 @@ function wireHeadlessMediator(descriptor: IPipelineDescriptor, slots: IPhaseSlot
   if (descriptor.isHeadless !== true) return slots;
   const wiring = resolveHeadlessWiring(descriptor.options.companyId);
   if (wiring === false) return slots;
-  const apiMediator = createHeadlessApiMediator({
-    bankHint: descriptor.options.companyId,
-    identityBaseUrl: wiring.identity,
-    graphqlUrl: wiring.graphql,
-    staticAuth: wiring.staticAuth,
-  });
+  const apiMediator = buildApiMediatorForWiring(descriptor.options.companyId, wiring);
   return { ...slots, apiMediator: some(apiMediator) };
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ts
@@ -10,6 +10,7 @@ import type { WKQueryOperation } from '../../Registry/WK/QueriesWK.js';
 import { resolveWkQuery } from '../../Registry/WK/QueriesWK.js';
 import type { WKUrlGroup } from '../../Registry/WK/UrlsWK.js';
 import { resolveWkUrl } from '../../Registry/WK/UrlsWK.js';
+import { CamoufoxIdentityFetchStrategy } from '../../Strategy/Fetch/CamoufoxIdentityFetchStrategy.js';
 import type { IFetchStrategy, PostData } from '../../Strategy/Fetch/FetchStrategy.js';
 import { GraphQLFetchStrategy } from '../../Strategy/Fetch/GraphQLFetchStrategy.js';
 import { NativeFetchStrategy } from '../../Strategy/Fetch/NativeFetchStrategy.js';
@@ -65,6 +66,13 @@ export interface IApiMediator {
     variables: Record<string, unknown>,
     opts?: IApiQueryOpts,
   ) => Promise<Procedure<T>>;
+  /**
+   * Optional cleanup hook for mediators that own resources (e.g. a Camoufox
+   * browser). Idempotent. Called by PipelineExecutor at scrape finalize
+   * regardless of success/failure. Undefined for mediators with no owned
+   * resources (e.g. NativeFetchStrategy-backed banks).
+   */
+  readonly dispose?: () => Promise<void>;
 }
 
 /** Empty header map — shared singleton for callers with no extras. */
@@ -459,3 +467,43 @@ export function createHeadlessApiMediator(args: IHeadlessMediatorArgs): IApiMedi
   if (args.staticAuth) mediator.setRawAuth(args.staticAuth);
   return mediator;
 }
+
+/** Args bundle for the browser-backed headless-mediator factory. */
+interface IBrowserBackedHeadlessMediatorArgs {
+  readonly bankHint: CompanyTypes;
+  readonly identityBaseUrl: string;
+  /** Same-origin URL used for the Camoufox page navigation (e.g. 'https://identity.tfd-bank.com'). */
+  readonly identityOriginUrl: string;
+  readonly graphqlUrl: string;
+  readonly staticAuth?: string;
+}
+
+/**
+ * Builds an ApiMediator whose identity REST transport runs through a Camoufox
+ * browser session (TLS-bypass) while GraphQL keeps the native transport.
+ * The mediator exposes a dispose() hook that closes the Camoufox process.
+ * @param args - Bank hint + identity base URL + same-origin nav URL + graphql URL + optional staticAuth.
+ * @returns IApiMediator with dispose() plumbed through to the Camoufox strategy.
+ */
+export function createBrowserBackedHeadlessApiMediator(
+  args: IBrowserBackedHeadlessMediatorArgs,
+): IApiMediator {
+  const fetchStrategy: CamoufoxIdentityFetchStrategy = Reflect.construct(
+    CamoufoxIdentityFetchStrategy,
+    [args.identityOriginUrl],
+  );
+  const graphqlStrategy: GraphQLFetchStrategy = Reflect.construct(GraphQLFetchStrategy, [
+    args.graphqlUrl,
+  ]);
+  const mediator = createApiMediator(args.bankHint, fetchStrategy, graphqlStrategy);
+  if (args.staticAuth) mediator.setRawAuth(args.staticAuth);
+  /**
+   * Dispose hook delegating to the strategy's close. Idempotent via the
+   * strategy's own _disposed flag.
+   * @returns Resolves once the underlying Camoufox process is closed.
+   */
+  const dispose = (): Promise<void> => fetchStrategy.dispose();
+  return Object.assign(mediator, { dispose });
+}
+
+export type { IBrowserBackedHeadlessMediatorArgs };

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
@@ -62,6 +62,7 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
         'identity.getIdToken': 'https://identity.tfd-bank.com/v1/getIdToken',
         'identity.sessionToken': 'https://identity.tfd-bank.com/v1/sessions/token',
       },
+      requiresBrowserTls: true,
     },
   },
   [CompanyTypes.Pepper]: {

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
@@ -23,6 +23,12 @@ export interface IHeadlessUrlsConfig {
   readonly paths: Readonly<Partial<Record<AuthPathKey, string>>>;
   /** Static Authorization header installed before login (e.g. Transmit TSToken). */
   readonly staticAuth?: string;
+  /**
+   * When true, identity API calls (NOT graphql) are routed through a Camoufox
+   * browser session to bypass Cloudflare's Node-TLS bot rule. Default: undefined
+   * (treated as false). Only set for banks whose identity host gates Node TLS.
+   */
+  readonly requiresBrowserTls?: boolean;
 }
 
 /** Pipeline bank config — HOME phase URL + optional headless URLs. */

--- a/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
+++ b/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
@@ -1,0 +1,384 @@
+/**
+ * Camoufox-backed identity fetch strategy — routes REST calls through a
+ * Camoufox browser session so the underlying TLS ClientHello carries a
+ * Firefox JA3/JA4 fingerprint. Used by banks whose Cloudflare edge rejects
+ * Node undici's TLS handshake (currently: OneZero identity host).
+ *
+ * Lifecycle: lazy-launches Camoufox on first call, navigates the page to the
+ * constructor's originUrl so subsequent page.evaluate(fetch) calls are
+ * same-origin. Caller MUST invoke dispose() at scrape finalize.
+ */
+
+import type { Browser, Page } from 'playwright-core';
+
+import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
+import type { LifecyclePromise, Nullable } from '../../../Base/Interfaces/CallbackTypes.js';
+import { launchCamoufox } from '../../Mediator/Browser/CamoufoxLauncher.js';
+import type { Brand, SafeUrlForLog } from '../../Types/Brand.js';
+import { mintSafeUrlForLog } from '../../Types/Brand.js';
+import { getDebug } from '../../Types/Debug.js';
+import { toErrorMessage } from '../../Types/ErrorUtils.js';
+import type { Procedure } from '../../Types/Procedure.js';
+import { fail, isOk, succeed } from '../../Types/Procedure.js';
+import type { IFetchOpts, IFetchStrategy, PostData } from './FetchStrategy.js';
+
+const LOG = getDebug(import.meta.url);
+
+/** Maximum length of a response-body snippet embedded in an error message. */
+const ERROR_BODY_SNIPPET_LEN = 120;
+
+/**
+ * Cloudflare IE7-fallback HTML markers. A non-2xx response body containing
+ * any of these substrings is classified as WafBlocked — symmetry with
+ * WAF_BLOCK_PATTERNS observability without touching the shared list.
+ */
+const CF_HTML_MARKERS = ['oldie', 'cf-error'] as const;
+
+type LaunchDurationMs = Brand<number, 'LaunchDurationMs'>;
+type SetCookieEmitCount = Brand<number, 'SetCookieEmitCount'>;
+type HttpVerb = 'GET' | 'POST';
+
+/** Envelope returned by the in-page fetch wrapper. */
+interface IPageFetchEnvelope {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly bodyText: string;
+  readonly setCookies: readonly string[];
+}
+
+/** Args bundle for the in-page fetch invocation. */
+interface IInPageFetchArgs {
+  readonly url: string;
+  readonly method: HttpVerb;
+  readonly headers: Record<string, string>;
+  readonly body: string | null;
+}
+
+/** Args bundle for the dispatch helper (verb + url + body + opts). */
+interface IDispatchArgs {
+  readonly verb: HttpVerb;
+  readonly url: string;
+  readonly body: string | null;
+  readonly opts: IFetchOpts;
+}
+
+/**
+ * Strips query string and credentials from a URL for safe logging.
+ * @param url - Full URL to sanitize.
+ * @returns Origin + path only as a branded SafeUrlForLog.
+ */
+function safeUrlForLog(url: string): SafeUrlForLog {
+  try {
+    const parsed = new URL(url);
+    return mintSafeUrlForLog(`${parsed.origin}${parsed.pathname}`);
+  } catch {
+    return mintSafeUrlForLog('<unparseable>');
+  }
+}
+
+/**
+ * Merges the default JSON content-type with caller-supplied headers.
+ * Caller wins on collision.
+ * @param extraHeaders - Caller-supplied headers.
+ * @returns Merged headers record.
+ */
+function mergeHeaders(extraHeaders: Record<string, string>): Record<string, string> {
+  return { 'content-type': 'application/json', ...extraHeaders };
+}
+
+/**
+ * Runs the fetch wrapper inside the Camoufox page context.
+ * @param page - Active Camoufox page sharing origin with args.url.
+ * @param args - URL + method + headers + body (null for GET).
+ * @returns Serialized envelope from the in-page fetch().
+ */
+async function runFetchInPage(page: Page, args: IInPageFetchArgs): Promise<IPageFetchEnvelope> {
+  return page.evaluate(async (input: IInPageFetchArgs): Promise<IPageFetchEnvelope> => {
+    const init: RequestInit = { method: input.method, headers: input.headers };
+    if (input.body !== null) init.body = input.body;
+    const response = await fetch(input.url, init);
+    const bodyText = await response.text();
+    const setCookies = response.headers.getSetCookie();
+    return { ok: response.ok, status: response.status, bodyText, setCookies };
+  }, args);
+}
+
+/**
+ * Determines whether a body snippet matches a known Cloudflare interstitial.
+ * @param body - Raw response body text.
+ * @returns True when any CF_HTML_MARKERS substring is present.
+ */
+function isCloudflareHtml(body: string): boolean {
+  const lower = body.toLowerCase();
+  return CF_HTML_MARKERS.some((m): boolean => lower.includes(m));
+}
+
+/**
+ * Resolves the error category for a non-2xx body — Cloudflare HTML interstitials
+ * surface as WafBlocked, all other shapes stay Generic. Map-driven to satisfy
+ * the project's no-ternary rule.
+ * @param body - Raw response body text.
+ * @returns ScraperErrorTypes category.
+ */
+function classifyBody(body: string): ScraperErrorTypes {
+  if (isCloudflareHtml(body)) return ScraperErrorTypes.WafBlocked;
+  return ScraperErrorTypes.Generic;
+}
+
+/**
+ * Classifies a non-2xx envelope into a Procedure failure.
+ * @param env - In-page fetch envelope.
+ * @param verb - HTTP verb.
+ * @param url - Target URL.
+ * @returns Structured failure with status + body snippet.
+ */
+function classifyNon2xx<T>(env: IPageFetchEnvelope, verb: HttpVerb, url: string): Procedure<T> {
+  const snippet = env.bodyText.slice(0, ERROR_BODY_SNIPPET_LEN);
+  const message = `${verb} ${url} ${String(env.status)}: ${snippet}`;
+  const errorType = classifyBody(env.bodyText);
+  return fail(errorType, message);
+}
+
+/**
+ * Parses a 2xx envelope body as JSON.
+ * @param env - In-page fetch envelope.
+ * @param verb - HTTP verb.
+ * @param url - Target URL.
+ * @returns Succeed with parsed body, or Generic parse-error failure.
+ */
+function parseJsonEnvelope<T>(env: IPageFetchEnvelope, verb: HttpVerb, url: string): Procedure<T> {
+  try {
+    const parsed = JSON.parse(env.bodyText) as T;
+    return succeed(parsed);
+  } catch (error) {
+    const reason = toErrorMessage(error as Error);
+    return fail(ScraperErrorTypes.Generic, `${verb} ${url} parse error: ${reason}`);
+  }
+}
+
+/**
+ * Emits Set-Cookie lines through the caller's hook (empty array still fires
+ * once for contract symmetry with NativeFetchStrategy).
+ * @param setCookies - Set-Cookie lines extracted in the page context.
+ * @param hook - Optional caller-supplied callback.
+ * @returns Number of lines forwarded to the hook (0 when no hook).
+ */
+function emitSetCookies(
+  setCookies: readonly string[],
+  hook?: IFetchOpts['onSetCookie'],
+): SetCookieEmitCount {
+  if (!hook) return 0 as SetCookieEmitCount;
+  hook(setCookies);
+  return setCookies.length as SetCookieEmitCount;
+}
+
+/**
+ * Closes the captured browser handle, swallowing any close exception so the
+ * caller's original failure path is never masked. No-op when called twice or
+ * when the strategy was never launched.
+ * @param wasDisposed - Whether dispose was already invoked previously.
+ * @param browser - Captured browser handle (null when never launched).
+ * @returns Resolves once close has been attempted (or immediately when no-op).
+ */
+async function closeBrowserSafe(
+  wasDisposed: boolean,
+  browser: Nullable<Browser>,
+): LifecyclePromise {
+  const action = pickDisposeAction(wasDisposed, browser);
+  await action();
+}
+
+/**
+ * Resolves the dispose action to run given the current lifecycle state.
+ * @param wasDisposed - Whether dispose was already invoked previously.
+ * @param browser - Captured browser handle (null when never launched).
+ * @returns A zero-arg async action that emits the right log + close call.
+ */
+function pickDisposeAction(
+  wasDisposed: boolean,
+  browser: Nullable<Browser>,
+): () => LifecyclePromise {
+  if (wasDisposed) return logDisposeNoop;
+  if (!browser) return logDisposeNeverLaunched;
+  return (): LifecyclePromise => closeOrSwallow(browser);
+}
+
+/**
+ * Logs the idempotent no-op branch of dispose.
+ * @returns Always-resolved Promise.
+ */
+function logDisposeNoop(): LifecyclePromise {
+  LOG.debug({ message: '[camoufox-identity] dispose (already disposed)' });
+  return Promise.resolve();
+}
+
+/**
+ * Logs the never-launched branch of dispose.
+ * @returns Always-resolved Promise.
+ */
+function logDisposeNeverLaunched(): LifecyclePromise {
+  LOG.debug({ message: '[camoufox-identity] dispose (never launched)' });
+  return Promise.resolve();
+}
+
+/**
+ * Awaits browser.close() and logs the outcome; swallows any thrown error.
+ * @param browser - Live browser handle to close.
+ * @returns Resolves once close completes (success or swallowed failure).
+ */
+async function closeOrSwallow(browser: Browser): LifecyclePromise {
+  try {
+    await browser.close();
+    LOG.debug({ message: '[camoufox-identity] dispose' });
+  } catch (error) {
+    LOG.debug({
+      errorMessage: toErrorMessage(error as Error),
+      message: '[camoufox-identity] dispose IGNORED',
+    });
+  }
+}
+
+/**
+ * Fires the in-page fetch and routes the envelope through parse/classify.
+ * @param page - Active Camoufox page.
+ * @param args - Dispatch args bundle.
+ * @returns Procedure with parsed body, parse error, or structured failure.
+ */
+async function dispatch<T>(page: Page, args: IDispatchArgs): Promise<Procedure<T>> {
+  const safeUrl = safeUrlForLog(args.url);
+  LOG.debug({ verb: args.verb, url: safeUrl, message: '[camoufox-identity] fetch FIRE' });
+  const headers = mergeHeaders(args.opts.extraHeaders);
+  const fetchArgs: IInPageFetchArgs = {
+    url: args.url,
+    method: args.verb,
+    headers,
+    body: args.body,
+  };
+  let env: IPageFetchEnvelope;
+  try {
+    env = await runFetchInPage(page, fetchArgs);
+  } catch (error) {
+    const reason = toErrorMessage(error as Error);
+    return fail(ScraperErrorTypes.Generic, `${args.verb} ${args.url} network error: ${reason}`);
+  }
+  LOG.debug({
+    verb: args.verb,
+    url: safeUrl,
+    status: env.status,
+    message: '[camoufox-identity] fetch STATUS',
+  });
+  emitSetCookies(env.setCookies, args.opts.onSetCookie);
+  if (!env.ok) return classifyNon2xx<T>(env, args.verb, args.url);
+  return parseJsonEnvelope<T>(env, args.verb, args.url);
+}
+
+/** Camoufox-backed fetch strategy — lazy-launches a Firefox session for TLS. */
+class CamoufoxIdentityFetchStrategy implements IFetchStrategy {
+  private _browser: Browser | null = null;
+  private _page: Page | null = null;
+  private _disposed = false;
+  private readonly _originUrl: string;
+
+  /**
+   * Constructs a strategy bound to a same-origin page.
+   * @param originUrl - URL navigated to before fetching (origin used as-is).
+   */
+  constructor(originUrl: string) {
+    this._originUrl = originUrl;
+  }
+
+  /**
+   * POSTs a JSON body via a Camoufox page session.
+   * @param url - Target URL (must share origin with constructor originUrl).
+   * @param data - POST body, serialised as JSON.
+   * @param opts - Fetch options (extraHeaders + optional onSetCookie hook).
+   * @returns Procedure carrying parsed response or structured failure.
+   */
+  public async fetchPost<T>(url: string, data: PostData, opts: IFetchOpts): Promise<Procedure<T>> {
+    return this.runVerb<T>({ verb: 'POST', url, body: JSON.stringify(data), opts });
+  }
+
+  /**
+   * GETs via a Camoufox page session.
+   * @param url - Target URL (must share origin with constructor originUrl).
+   * @param opts - Fetch options.
+   * @returns Procedure carrying parsed response or structured failure.
+   */
+  public async fetchGet<T>(url: string, opts: IFetchOpts): Promise<Procedure<T>> {
+    return this.runVerb<T>({ verb: 'GET', url, body: null, opts });
+  }
+
+  /**
+   * Closes the Camoufox browser. Idempotent; safe on a never-launched strategy.
+   * @returns Resolves once close completes (or immediately when never launched).
+   */
+  public async dispose(): LifecyclePromise {
+    const wasDisposed = this._disposed;
+    this._disposed = true;
+    const browser = this._browser;
+    this._browser = null;
+    this._page = null;
+    await closeBrowserSafe(wasDisposed, browser);
+  }
+
+  /**
+   * Drives one verb end-to-end: ensure launch, fire fetch, classify outcome.
+   * @param args - Verb + URL + body + opts bundle.
+   * @returns Procedure with parsed body or structured failure.
+   */
+  private async runVerb<T>(args: IDispatchArgs): Promise<Procedure<T>> {
+    if (this._disposed) return fail(ScraperErrorTypes.Generic, 'strategy disposed');
+    const pageProc = await this.ensurePage();
+    if (!isOk(pageProc)) return pageProc;
+    return dispatch<T>(pageProc.value, args);
+  }
+
+  /**
+   * Ensures Camoufox is launched and a same-origin page is open.
+   * Idempotent: subsequent calls reuse the already-launched page.
+   * @returns Procedure carrying the active Page, or structured failure.
+   */
+  private async ensurePage(): Promise<Procedure<Page>> {
+    if (this._page) return succeed(this._page);
+    const safeOrigin = safeUrlForLog(this._originUrl);
+    LOG.debug({ origin: safeOrigin, message: '[camoufox-identity] launch START' });
+    const t0 = Date.now();
+    let browser: Browser;
+    try {
+      browser = await launchCamoufox(true);
+    } catch (error) {
+      const reason = toErrorMessage(error as Error);
+      LOG.debug({
+        origin: safeOrigin,
+        errorMessage: reason,
+        message: '[camoufox-identity] launch FAIL',
+      });
+      return fail(ScraperErrorTypes.Generic, `camoufox launch failed: ${reason}`);
+    }
+    this._browser = browser;
+    const durationMs = (Date.now() - t0) as LaunchDurationMs;
+    LOG.debug({ origin: safeOrigin, durationMs, message: '[camoufox-identity] launch END' });
+    return this.openPage(browser);
+  }
+
+  /**
+   * Opens a context + page in the launched browser and navigates to origin.
+   * @param browser - Launched Camoufox browser.
+   * @returns Procedure carrying the active Page, or Generic nav failure.
+   */
+  private async openPage(browser: Browser): Promise<Procedure<Page>> {
+    try {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await page.goto(this._originUrl);
+      this._page = page;
+      return succeed(page);
+    } catch (error) {
+      const reason = toErrorMessage(error as Error);
+      return fail(ScraperErrorTypes.Generic, `camoufox nav failed: ${reason}`);
+    }
+  }
+}
+
+export default CamoufoxIdentityFetchStrategy;
+export { CamoufoxIdentityFetchStrategy };

--- a/src/Tests/E2eMocked/OneZero/OneZeroFetchMock.ts
+++ b/src/Tests/E2eMocked/OneZero/OneZeroFetchMock.ts
@@ -10,7 +10,14 @@
  *   - POST <identityBase>.../getIdToken
  *   - POST <identityBase>.../sessions/token
  *   - POST <graphqlUrl>  (operation-name dispatch)
+ *
+ * Since fix/onezero-camoufox-identity-tls, identity calls route through the
+ * Camoufox-backed strategy. The CamoufoxJsMock fake-page-eval mode is toggled
+ * on so page.evaluate(fn, args) runs fn(args) in Node against this file's
+ * globalThis.fetch override.
  */
+
+import { setFakePageEvalMode } from '../../Mocks/CamoufoxJsMock.js';
 
 /** Tally values returned alongside dispose for wiring assertions. */
 export interface IMockCallCounts {
@@ -54,6 +61,25 @@ interface IResponseLike {
   readonly ok: boolean;
   readonly status: number;
   readonly text: () => Promise<string>;
+  readonly headers: { readonly getSetCookie: () => readonly string[] };
+}
+
+/** Empty Set-Cookie list reused across all synthetic responses. */
+const NO_SET_COOKIES: readonly string[] = Object.freeze([]);
+
+/**
+ * Build the synthetic Headers slice consumed by the in-page fetch wrapper.
+ * Returns an empty Set-Cookie list — the OneZero mock flow does not exercise
+ * cookie warming.
+ * @returns {object} Headers stub with a getSetCookie method returning [].
+ */
+function emptyHeaders(): IResponseLike['headers'] {
+  /**
+   * Returns the empty Set-Cookie list captured in NO_SET_COOKIES.
+   * @returns Frozen empty Set-Cookie array.
+   */
+  const getSetCookie = (): readonly string[] => NO_SET_COOKIES;
+  return { getSetCookie };
 }
 
 /** Accumulates call counts so tests can assert wiring. */
@@ -76,7 +102,7 @@ function buildResponse(status: number, bodyText: string): IResponseLike {
    * @returns Promise of body text.
    */
   const textFn = (): Promise<string> => Promise.resolve(bodyText);
-  return { ok: isOkStatus, status, text: textFn };
+  return { ok: isOkStatus, status, text: textFn, headers: emptyHeaders() };
 }
 
 /**
@@ -427,12 +453,14 @@ export function installOneZeroFetchMock(): IMockHandle {
   const tally: ICallTally = { identity: 0, graphql: 0 };
   const mockFetch = makeMockFetch(tally);
   (globalThis as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+  setFakePageEvalMode(true);
   /**
-   * Restore the original fetch implementation.
+   * Restore the original fetch implementation and reset the Camoufox mock.
    * @returns True once restoration completes.
    */
   const dispose = (): boolean => {
     globalThis.fetch = previousFetch;
+    setFakePageEvalMode(false);
     return true;
   };
   /**

--- a/src/Tests/Mocks/CamoufoxJsMock.d.ts
+++ b/src/Tests/Mocks/CamoufoxJsMock.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Toggle the Camoufox mock between real-Firefox-launch (default) and
+ * fake-page-eval mode used by E2eMocked tests that mock globalThis.fetch.
+ * @param enabled - True to enable fake mode; false to restore default.
+ * @returns The new mode (true if enabled, false otherwise).
+ */
+declare function setFakePageEvalMode(enabled: boolean): boolean;
+
+export { setFakePageEvalMode };
+export default setFakePageEvalMode;

--- a/src/Tests/Mocks/CamoufoxJsMock.js
+++ b/src/Tests/Mocks/CamoufoxJsMock.js
@@ -1,10 +1,46 @@
 // Jest ESM shim for @hieutran094/camoufox-js (ESM-only, uses import.meta).
-// Launches the real Camoufox binary via playwright-core firefox.launch().
+// Default: launches the real Camoufox binary via playwright-core firefox.launch().
+// Fake-page-eval mode: returns a fake Browser whose page.evaluate(fn, args)
+// invokes fn(args) directly in Node — used by E2eMocked tests that mock
+// globalThis.fetch and need the strategy's page.evaluate callback to run
+// against that mock instead of a real browser network stack.
 // Production code uses the ESM module directly via dynamic import().
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { firefox } from 'playwright-core';
+
+let FAKE_PAGE_EVAL_MODE = false;
+
+/**
+ * Toggle fake-page-eval mode. Default off so existing E2eMocked tests
+ * (non-headless banks) keep using real Firefox launches.
+ * @param {boolean} enabled - True to enable fake mode; false to restore default.
+ * @returns {boolean} The new mode.
+ */
+export function setFakePageEvalMode(enabled) {
+  FAKE_PAGE_EVAL_MODE = !!enabled;
+  return FAKE_PAGE_EVAL_MODE;
+}
+
+/**
+ * Build a fake Browser tree whose page.evaluate(fn, args) runs fn(args) in
+ * Node. The strategy is exercised end-to-end — only the network stack is
+ * simulated by the test's globalThis.fetch.
+ * @returns {object} Fake Browser exposing newContext + close.
+ */
+function buildFakeBrowser() {
+  const goto = () => Promise.resolve(null);
+  const evaluateFn = async (fn, args) => {
+    if (typeof fn !== 'function') return null;
+    return fn(args);
+  };
+  const page = { goto, evaluate: evaluateFn };
+  const newPage = () => Promise.resolve(page);
+  const newContext = () => Promise.resolve({ newPage });
+  const close = () => Promise.resolve();
+  return { newContext, close };
+}
 
 function findCamoufoxBinary() {
   const home = os.homedir();
@@ -25,6 +61,7 @@ function findCamoufoxBinary() {
 }
 
 export async function Camoufox(opts = {}) {
+  if (FAKE_PAGE_EVAL_MODE) return buildFakeBrowser();
   const executablePath = findCamoufoxBinary();
   if (!executablePath) {
     throw new Error('Camoufox binary not found — run: npx camoufox fetch');
@@ -35,4 +72,4 @@ export async function Camoufox(opts = {}) {
   });
 }
 
-export default { Camoufox };
+export default { Camoufox, setFakePageEvalMode };

--- a/src/Tests/Unit/Pipeline/Core/PipelineContextFactoryHeadless.test.ts
+++ b/src/Tests/Unit/Pipeline/Core/PipelineContextFactoryHeadless.test.ts
@@ -73,4 +73,37 @@ describe('PipelineContextFactory — wireHeadlessMediator', () => {
     expect(ctx.apiMediator.has).toBe(false);
     expect(ctx.loginAreaReady).toBe(false);
   });
+
+  it('OZ-PCF-01 — OneZero (requiresBrowserTls=true): mediator exposes dispose hook', () => {
+    const descriptor = makeDescriptor(true, CompanyTypes.OneZero);
+    const ctx = buildInitialContext(
+      descriptor,
+      {} as unknown as Parameters<typeof buildInitialContext>[1],
+    );
+    expect(ctx.apiMediator.has).toBe(true);
+    if (ctx.apiMediator.has) {
+      expect(typeof ctx.apiMediator.value.dispose).toBe('function');
+    }
+  });
+
+  it('OZ-PCF-02 — Pepper (no requiresBrowserTls): mediator dispose stays undefined', () => {
+    const descriptor = makeDescriptor(true, CompanyTypes.Pepper);
+    const ctx = buildInitialContext(
+      descriptor,
+      {} as unknown as Parameters<typeof buildInitialContext>[1],
+    );
+    expect(ctx.apiMediator.has).toBe(true);
+    if (ctx.apiMediator.has) {
+      expect(ctx.apiMediator.value.dispose).toBeUndefined();
+    }
+  });
+
+  it('OZ-PCF-03 — Hapoalim (non-headless): apiMediator slot stays none', () => {
+    const descriptor = makeDescriptor(false, CompanyTypes.Hapoalim);
+    const ctx = buildInitialContext(
+      descriptor,
+      {} as unknown as Parameters<typeof buildInitialContext>[1],
+    );
+    expect(ctx.apiMediator.has).toBe(false);
+  });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/Api/ApiMediator.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Api/ApiMediator.test.ts
@@ -11,6 +11,8 @@ import { fileURLToPath } from 'node:url';
 import { CompanyTypes } from '../../../../../Definitions.js';
 import {
   createApiMediator,
+  createBrowserBackedHeadlessApiMediator,
+  createHeadlessApiMediator,
   type IApiMediator,
 } from '../../../../../Scrapers/Pipeline/Mediator/Api/ApiMediator.js';
 import {
@@ -349,5 +351,40 @@ describe('ApiMediator/reuseContract', () => {
       /oneZero|amex|isracard|hapoalim|discount|visaCal|max|beinleumi|massad|mercantile|otsarHahayal|pagi/i;
     const hit = bannedNamesPattern.exec(source);
     expect(hit).toBeNull();
+  });
+});
+
+describe('ApiMediator/createBrowserBackedHeadlessApiMediator', () => {
+  it('OZ-AM-01 — factory returns a mediator carrying the standard surface and a dispose hook', () => {
+    const mediator = createBrowserBackedHeadlessApiMediator({
+      bankHint: HINT,
+      identityBaseUrl: 'https://id.example/v1/',
+      identityOriginUrl: 'https://id.example',
+      graphqlUrl: 'https://gql.example/graphql',
+    });
+    expect(typeof mediator.apiPost).toBe('function');
+    expect(typeof mediator.apiGet).toBe('function');
+    expect(typeof mediator.apiQuery).toBe('function');
+    expect(typeof mediator.dispose).toBe('function');
+  });
+
+  it('OZ-AM-02 — dispose() delegates to the strategy and is idempotent (no throw, no launch)', async () => {
+    const mediator = createBrowserBackedHeadlessApiMediator({
+      bankHint: HINT,
+      identityBaseUrl: 'https://id.example/v1/',
+      identityOriginUrl: 'https://id.example',
+      graphqlUrl: 'https://gql.example/graphql',
+    });
+    await expect(mediator.dispose?.()).resolves.toBeUndefined();
+    await expect(mediator.dispose?.()).resolves.toBeUndefined();
+  });
+
+  it('OZ-AM-03 — native createHeadlessApiMediator leaves dispose undefined', () => {
+    const mediator = createHeadlessApiMediator({
+      bankHint: HINT,
+      identityBaseUrl: 'https://id.example/v1/',
+      graphqlUrl: 'https://gql.example/graphql',
+    });
+    expect(mediator.dispose).toBeUndefined();
   });
 });

--- a/src/Tests/Unit/Scrapers/Pipeline/Strategy/CamoufoxIdentityFetchStrategy.test.ts
+++ b/src/Tests/Unit/Scrapers/Pipeline/Strategy/CamoufoxIdentityFetchStrategy.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Unit tests for CamoufoxIdentityFetchStrategy. Mocks @hieutran094/camoufox-js
+ * so launch returns a fake browser whose page.evaluate() is controlled
+ * per-test via a shared envelope fixture.
+ */
+
+import { jest } from '@jest/globals';
+
+import { ScraperErrorTypes } from '../../../../../Scrapers/Base/ErrorTypes.js';
+import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+
+/** Envelope returned by the in-page fetch wrapper. */
+interface IPageFetchEnvelope {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly bodyText: string;
+  readonly setCookies: readonly string[];
+}
+
+/** Per-test launch + fetch behaviour controlled by the shared state. */
+interface IMockState {
+  envelope: IPageFetchEnvelope;
+  launchThrows: boolean;
+  navThrows: boolean;
+  evaluateThrows: boolean;
+  evaluateRunsCallback: boolean;
+  closeThrows: boolean;
+  closeCalls: number;
+  pageGotos: string[];
+  launchCalls: number;
+}
+
+const ENV_OK_DEFAULT: IPageFetchEnvelope = {
+  ok: true,
+  status: 200,
+  bodyText: '{"ok":true}',
+  setCookies: [],
+};
+const STATE: IMockState = {
+  envelope: ENV_OK_DEFAULT,
+  launchThrows: false,
+  navThrows: false,
+  evaluateThrows: false,
+  evaluateRunsCallback: false,
+  closeThrows: false,
+  closeCalls: 0,
+  pageGotos: [],
+  launchCalls: 0,
+};
+
+/**
+ * Resets the shared mock state to default success behaviour.
+ * @returns True once reset.
+ */
+function resetState(): boolean {
+  Object.assign(STATE, {
+    envelope: ENV_OK_DEFAULT,
+    launchThrows: false,
+    navThrows: false,
+    evaluateThrows: false,
+    evaluateRunsCallback: false,
+    closeThrows: false,
+    closeCalls: 0,
+    pageGotos: [],
+    launchCalls: 0,
+  });
+  return true;
+}
+
+/**
+ * Builds the mock fake browser tree returned by the Camoufox factory.
+ * @returns Fake browser exposing newContext + close.
+ */
+function buildMockBrowser(): unknown {
+  /**
+   * Mock page.goto. Records URL or rejects on navThrows.
+   * @param url - Target URL.
+   * @returns Resolves null.
+   */
+  const goto = (url: string): Promise<unknown> => {
+    STATE.pageGotos.push(url);
+    if (STATE.navThrows) return Promise.reject(new Error('nav failed'));
+    return Promise.resolve(null);
+  };
+  /** Args bundle that mirrors the strategy's IInPageFetchArgs. */
+  type EvaluateCallback = (args: unknown) => Promise<IPageFetchEnvelope>;
+  /**
+   * Mock page.evaluate — returns STATE.envelope, rejects on evaluateThrows,
+   * or executes the supplied callback against the test's global fetch stub
+   * when evaluateRunsCallback is enabled (covers the in-page fetch wrapper).
+   * @param fn - Callback the production code passes to page.evaluate.
+   * @param args - Arguments forwarded to the callback.
+   * @returns Resolved envelope.
+   */
+  const evaluatePage = (fn?: EvaluateCallback, args?: unknown): Promise<IPageFetchEnvelope> => {
+    if (STATE.evaluateThrows) return Promise.reject(new Error('evaluate-boom'));
+    if (STATE.evaluateRunsCallback && typeof fn === 'function') return fn(args);
+    return Promise.resolve(STATE.envelope);
+  };
+  const page = { goto, evaluate: evaluatePage };
+  /**
+   * Mock newPage.
+   * @returns Resolved mock page.
+   */
+  const newPage = (): Promise<typeof page> => Promise.resolve(page);
+  /**
+   * Mock newContext.
+   * @returns Resolved mock context.
+   */
+  const newContext = (): Promise<{ newPage: typeof newPage }> => Promise.resolve({ newPage });
+  /**
+   * Mock browser.close. Increments STATE.closeCalls; rejects on closeThrows.
+   * @returns Resolved void.
+   */
+  const close = (): Promise<void> => {
+    STATE.closeCalls += 1;
+    if (STATE.closeThrows) return Promise.reject(new Error('close-boom'));
+    return Promise.resolve();
+  };
+  return { newContext, close };
+}
+
+/**
+ * Mock Camoufox launcher returning a fake Browser/Context/Page tree.
+ * @returns Fake browser whose page.evaluate replies from STATE.envelope.
+ */
+function camoufoxFactory(): Promise<unknown> {
+  STATE.launchCalls += 1;
+  if (STATE.launchThrows) {
+    const launchError = new Error('binary missing');
+    return Promise.reject(launchError);
+  }
+  const fakeBrowser = buildMockBrowser();
+  return Promise.resolve(fakeBrowser);
+}
+
+jest.unstable_mockModule('@hieutran094/camoufox-js', () => ({ Camoufox: camoufoxFactory }));
+
+const STRATEGY_MOD =
+  await import('../../../../../Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.js');
+const { CamoufoxIdentityFetchStrategy: STRATEGY } = STRATEGY_MOD;
+
+const ORIGIN = 'https://identity.tfd-bank.com';
+const URL_OK = 'https://identity.tfd-bank.com/v1/devices/token';
+const OPTS = { extraHeaders: {} };
+const ENV_OK: IPageFetchEnvelope = {
+  ok: true,
+  status: 200,
+  bodyText: '{"deviceToken":"jwt"}',
+  setCookies: ['sid=abc'],
+};
+const ENV_CF_OLDIE: IPageFetchEnvelope = {
+  ok: false,
+  status: 403,
+  bodyText: '<html class="ie6 oldie">',
+  setCookies: [],
+};
+const ENV_CF_ERROR: IPageFetchEnvelope = {
+  ok: false,
+  status: 403,
+  bodyText: '<html class="cf-error">',
+  setCookies: [],
+};
+const ENV_APP_400: IPageFetchEnvelope = {
+  ok: false,
+  status: 400,
+  bodyText: '{"error":"bad request"}',
+  setCookies: [],
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+describe('CamoufoxIdentityFetchStrategy/fetchPost', () => {
+  it('OZ-CIT-01 — first call launches Camoufox and navigates to origin', async () => {
+    STATE.envelope = ENV_OK;
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, { id: 'x' }, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(true);
+    expect(STATE.launchCalls).toBe(1);
+    expect(STATE.pageGotos).toEqual([ORIGIN]);
+  });
+
+  it('OZ-CIT-02 — second call reuses the existing page (no re-launch)', async () => {
+    STATE.envelope = ENV_OK;
+    const s = new STRATEGY(ORIGIN);
+    await s.fetchPost(URL_OK, {}, OPTS);
+    await s.fetchPost(URL_OK, {}, OPTS);
+    expect(STATE.launchCalls).toBe(1);
+    expect(STATE.pageGotos.length).toBe(1);
+  });
+
+  it('OZ-CIT-03 — 2xx JSON body parses to succeed(parsedJson)', async () => {
+    STATE.envelope = ENV_OK;
+    const r = await new STRATEGY(ORIGIN).fetchPost<{ deviceToken: string }>(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(true);
+    if (isOk(r)) expect(r.value.deviceToken).toBe('jwt');
+  });
+
+  /** Row for the it.each error-classification table. */
+  interface IClassifyCase {
+    readonly id: string;
+    readonly envelope: IPageFetchEnvelope;
+    readonly expectedType: typeof ScraperErrorTypes.WafBlocked | typeof ScraperErrorTypes.Generic;
+    readonly expectedSnippet: string;
+  }
+
+  const classifyCases: readonly IClassifyCase[] = [
+    {
+      id: 'OZ-CIT-04',
+      envelope: ENV_APP_400,
+      expectedType: ScraperErrorTypes.Generic,
+      expectedSnippet: 'bad request',
+    },
+    {
+      id: 'OZ-CIT-05a',
+      envelope: ENV_CF_OLDIE,
+      expectedType: ScraperErrorTypes.WafBlocked,
+      expectedSnippet: 'oldie',
+    },
+    {
+      id: 'OZ-CIT-05b',
+      envelope: ENV_CF_ERROR,
+      expectedType: ScraperErrorTypes.WafBlocked,
+      expectedSnippet: 'cf-error',
+    },
+  ] as const;
+
+  it.each(classifyCases)('$id — non-2xx classified', async (row: IClassifyCase) => {
+    STATE.envelope = row.envelope;
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) {
+      expect(r.errorType).toBe(row.expectedType);
+      expect(r.errorMessage).toContain(row.expectedSnippet);
+      expect(r.errorMessage).toMatch(/POST https:\/\/[^ ]+ \d+:/);
+    }
+  });
+
+  it('OZ-CIT-06 — page.evaluate throwing surfaces as network-error failure', async () => {
+    STATE.evaluateThrows = true;
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) expect(r.errorMessage).toContain('network error');
+  });
+
+  it('OZ-CIT-07 — malformed JSON 2xx returns parse-error failure', async () => {
+    STATE.envelope = { ok: true, status: 200, bodyText: 'not-json{', setCookies: [] };
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) expect(r.errorMessage).toContain('parse error');
+  });
+
+  it('OZ-CIT-08 — launch failure surfaces as Generic launch failure', async () => {
+    STATE.launchThrows = true;
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) expect(r.errorMessage).toContain('camoufox launch failed');
+  });
+
+  it('OZ-CIT-11 — disposed strategy returns deterministic Generic failure', async () => {
+    const s = new STRATEGY(ORIGIN);
+    await s.dispose();
+    const r = await s.fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) expect(r.errorMessage).toBe('strategy disposed');
+    expect(STATE.launchCalls).toBe(0);
+  });
+
+  it('OZ-CIT-12 — nav failure after launch returns Generic nav failure', async () => {
+    STATE.navThrows = true;
+    const r = await new STRATEGY(ORIGIN).fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) expect(r.errorMessage).toContain('camoufox nav failed');
+  });
+
+  it('OZ-CIT-15 — onSetCookie hook fires once per call with arrays and [] fallback', async () => {
+    STATE.envelope = ENV_OK;
+    const captured: (readonly string[])[] = [];
+    /**
+     * Capture hook — records each set-cookie array forwarded by the strategy.
+     * @param lines - Set-Cookie lines from the in-page fetch envelope.
+     * @returns The new captured length.
+     */
+    const hook = (lines: readonly string[]): number => captured.push(lines);
+    const s = new STRATEGY(ORIGIN);
+    await s.fetchPost(URL_OK, {}, { extraHeaders: {}, onSetCookie: hook });
+    STATE.envelope = { ok: true, status: 200, bodyText: '{}', setCookies: [] };
+    await s.fetchPost(URL_OK, {}, { extraHeaders: {}, onSetCookie: hook });
+    expect(captured).toEqual([['sid=abc'], []]);
+  });
+});
+
+describe('CamoufoxIdentityFetchStrategy/fetchGet', () => {
+  it('OZ-CIT-13 — GET 2xx succeeds via page.evaluate', async () => {
+    STATE.envelope = ENV_OK;
+    const r = await new STRATEGY(ORIGIN).fetchGet(URL_OK, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(true);
+  });
+
+  it('OZ-CIT-14 — GET non-2xx with app body returns Generic failure', async () => {
+    STATE.envelope = ENV_APP_400;
+    const r = await new STRATEGY(ORIGIN).fetchGet(URL_OK, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(false);
+    if (!isOk(r)) {
+      expect(r.errorType).toBe(ScraperErrorTypes.Generic);
+      expect(r.errorMessage).toMatch(/GET https:\/\/[^ ]+ 400:/);
+    }
+  });
+});
+
+describe('CamoufoxIdentityFetchStrategy/dispose', () => {
+  it('OZ-CIT-09 — dispose closes the browser', async () => {
+    STATE.envelope = ENV_OK;
+    const s = new STRATEGY(ORIGIN);
+    await s.fetchPost(URL_OK, {}, OPTS);
+    await s.dispose();
+    expect(STATE.closeCalls).toBe(1);
+  });
+
+  it('OZ-CIT-10 — dispose is idempotent (second call is no-op)', async () => {
+    STATE.envelope = ENV_OK;
+    const s = new STRATEGY(ORIGIN);
+    await s.fetchPost(URL_OK, {}, OPTS);
+    await s.dispose();
+    await s.dispose();
+    expect(STATE.closeCalls).toBe(1);
+  });
+
+  it('OZ-CIT-09b — dispose on never-launched strategy is a no-op', async () => {
+    await new STRATEGY(ORIGIN).dispose();
+    expect(STATE.closeCalls).toBe(0);
+    expect(STATE.launchCalls).toBe(0);
+  });
+
+  it('OZ-CIT-09c — dispose swallows browser.close() rejection', async () => {
+    STATE.envelope = ENV_OK;
+    STATE.closeThrows = true;
+    const s = new STRATEGY(ORIGIN);
+    await s.fetchPost(URL_OK, {}, OPTS);
+    const disposePromise = s.dispose();
+    await expect(disposePromise).resolves.toBeUndefined();
+    expect(STATE.closeCalls).toBe(1);
+  });
+});
+
+/** Shape of the synthetic in-browser Response used by OZ-CIT-17. */
+interface IStubResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly text: () => Promise<string>;
+  readonly headers: { readonly getSetCookie: () => readonly string[] };
+}
+
+/**
+ * Resolves a stub Response payload — kept module-scope so the nested-call
+ * lint rule does not fire when used inside stubFetch.
+ * @returns Resolved IStubResponse with success envelope shape.
+ */
+function resolveStubResponse(): Promise<IStubResponse> {
+  const captureCookies: readonly string[] = ['cf_clearance=abc'];
+  /**
+   * Resolves the synthetic response body text.
+   * @returns Resolved JSON string.
+   */
+  const text = (): Promise<string> => Promise.resolve('{"ok":true}');
+  /**
+   * Returns the captured Set-Cookie list.
+   * @returns The synthetic cookie array.
+   */
+  const getSetCookie = (): readonly string[] => captureCookies;
+  return Promise.resolve({ ok: true, status: 200, text, headers: { getSetCookie } });
+}
+
+describe('CamoufoxIdentityFetchStrategy/coverage edges', () => {
+  it('OZ-CIT-16 — unparseable origin URL falls through safeUrlForLog catch', async () => {
+    STATE.envelope = ENV_OK;
+    const r = await new STRATEGY('not a url').fetchPost(URL_OK, {}, OPTS);
+    const wasOk = isOk(r);
+    expect(wasOk).toBe(true);
+  });
+
+  it('OZ-CIT-17 — page.evaluate executes the in-page fetch wrapper for POST and GET', async () => {
+    STATE.evaluateRunsCallback = true;
+    const stubFetch = jest.fn(resolveStubResponse) as unknown as typeof fetch;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stubFetch;
+    try {
+      const s = new STRATEGY(ORIGIN);
+      const postProc = await s.fetchPost(URL_OK, {}, OPTS);
+      const getProc = await s.fetchGet(URL_OK, OPTS);
+      const wasPostOk = isOk(postProc);
+      const wasGetOk = isOk(getProc);
+      expect(wasPostOk).toBe(true);
+      expect(wasGetOk).toBe(true);
+      expect(stubFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `CamoufoxIdentityFetchStrategy` (new `IFetchStrategy` impl) that routes OneZero's 5 identity-API POSTs through a Camoufox browser via `page.evaluate(fetch)`, bypassing Cloudflare's Node-undici TLS fingerprint block on `identity.tfd-bank.com`.
- GraphQL transaction queries (`mobile.tfd-bank.com/mobile-graph/graphql`) keep using `NativeFetchStrategy` — that endpoint is permissive to Node TLS (empirically verified).
- Per-bank `requiresBrowserTls` opt-in flag on `IHeadlessUrlsConfig`; only OneZero opts in. Pepper, Hapoalim, all other banks unaffected.

## Why

OneZero E2E Real has been failing on developer residential IPs with `GENERIC POST https://identity.tfd-bank.com/v1/devices/token 403: <!DOCTYPE html> <!--[if lt IE 7]> <html class="no-js ie6 oldie">...`. Empirical investigation isolated the discriminator to TLS fingerprint:

| Client | TLS source | Result |
|---|---|---|
| `curl --http1.1 -A node` | Schannel | **200 + valid JWT** |
| Node 22.22 `fetch` (any UA) | undici/Node-TLS | **403 + CF interstitial** |
| Camoufox `page.evaluate(fetch)`, same-origin | Firefox | **200 + valid JWT** |

CI passes because GitHub Actions Azure egress IPs have neutral Cloudflare reputation for this tenant. The block is `JA3-fingerprint × IP-reputation` — both axes must combine. Routing through Camoufox shifts the JA3 axis to "real Firefox," sidestepping the rule entirely.

## Architecture

```
OneZero pipeline
  ├─ identity.* URLs ───→ CamoufoxIdentityFetchStrategy (NEW)
  │                       │ lazy-launch Camoufox
  │                       │ navigate to identity.tfd-bank.com/
  │                       │ page.evaluate(fetch)  ←— Firefox TLS
  │                       │ dispose() at scrape finalize
  │
  └─ mobile-graph URL ──→ NativeFetchStrategy (unchanged)
                          │ Node fetch  ←— Node TLS (CF allows)
```

- `IApiMediator` gets optional `dispose?: () => Promise<void>` (additive, non-breaking).
- `PipelineExecutor.runWithCleanup` calls `disposeApiMediatorSafe` in `finally` after `ensureBrowserCleanup` — fires on success, failure, and exception paths.
- `wireHeadlessMediator` branches on `requiresBrowserTls` flag; default-undefined keeps Pepper on its existing `createHeadlessApiMediator` path.

## OODA loop artifacts

Plan dir at `C:\tmp\plans\onezero-camoufox-identity-tls\`:

| Stage | File | Verdict |
|---|---|---|
| Observe | `observe.md` | 5 spec divergences caught; empirical 403 still reproduces |
| Orient | `orient.md` | REUSE/EXTEND/NEW-CODE matrix; identified `WAF_BLOCK_PATTERNS` duplicate-config drift bug (separate PR) |
| Decide | `decide.md` | All 12 questions locked with guideline citations; lifecycle = lazy-launch (P6 yields to `pr-guidlines.md` § 1) |
| Act | `act-report.md` | 9 files, tsc + lint pass |
| Final Review | `final-review.md` | READY-TO-COMMIT |
| RabbitAI | `rabbitai-review.md` | NO-BLOCKERS; 7 advisory-only findings deferred |

## Files changed (12 files)

| File | Kind | LoC |
|---|---|---|
| `src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts` | NEW | +384 |
| `src/Tests/Unit/Scrapers/Pipeline/Strategy/CamoufoxIdentityFetchStrategy.test.ts` | NEW | +405 |
| `src/Tests/Mocks/CamoufoxJsMock.d.ts` | NEW | +10 |
| `src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ts` | EXTEND | +48 |
| `src/Scrapers/Pipeline/Core/Executor/PipelineExecutor.ts` | EXTEND | +28 |
| `src/Scrapers/Pipeline/Core/PipelineContextFactory.ts` | EXTEND | +29 net |
| `src/Tests/Mocks/CamoufoxJsMock.js` | EXTEND | +45 |
| `src/Tests/Unit/Pipeline/Mediator/Api/ApiMediator.test.ts` | EXTEND | +37 |
| `src/Tests/Unit/Pipeline/Core/PipelineContextFactoryHeadless.test.ts` | EXTEND | +33 |
| `src/Tests/E2eMocked/OneZero/OneZeroFetchMock.ts` | EXTEND | +29 |
| `src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts` | EXTEND | +6 |
| `src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts` | EXTEND | +1 |

## Trade-offs (documented in OODA artifacts)

- **Lazy-launch deviation from P6 (strict construction-time DI):** chosen over async-cascade because async would have rewritten `buildInitialContext` + `executePipeline` + every test, with no determinism benefit since all 5 identity calls fire in a single `ApiDirectCallPhase`. Observability bridged by structured log keys `[camoufox-identity] launch START/END/FAIL`.

- **LoC budget OVER-BY-MANDATORY-RULES** (~870 vs guideline target 200–400): strategy file is 36.5% Javadoc (mandatory per `j-doc-guidlines.md`) + ESLint strict (`class-methods-use-this`, `no-restricted-syntax` no-else/no-ternary) forced ~14 helper extractions. Cuttable verbosity does not exist without violating either C11 (Javadoc) or weakening FR6 test coverage. Both Final Review + RabbitAI confirm.

- **`WAF_BLOCK_PATTERNS` not extended:** Cloudflare IE7-fallback markers (`oldie`, `cf-error`) are classified in-strategy via a private `CF_HTML_MARKERS` constant, NOT added to the shared `WAF_BLOCK_PATTERNS` (duplicated across `Mediator/Network/FetchConfig.ts` + `Common/Config/FetchConfig.ts` — drift bug noted for separate follow-up). Keeps this PR single-responsibility per `pr-guidlines.md` § 2.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` (full src/) — 0 errors, 0 warnings (eslint + lint:architecture + canaries + format:check)
- [x] `npm run test:pipeline` — 4630 tests pass; coverage gate (97% statements / 95% branches / 98% lines / 97% functions) clears with new strategy file at 100% on all 4 axes
- [x] `npm run test:e2e:mock` (OneZero) — 50 passed, 0 failed; CamoufoxJsMock fake-page-eval mode keeps it fully synthetic
- [x] Local pre-commit hook all 5 phases — ✅ ALL GATES PASSED
- [x] RabbitAI defensive review — NO-BLOCKERS, 0 PII leaks, 0 internal paths
- [ ] CI: 18 E2E Smoke banks
- [ ] CI: 7 E2E Real A banks (Beinleumi, Discount, Hapoalim, Isracard, Max, **OneZero**, VisaCal)
- [ ] CI: 1 E2E Real B bank (Amex)

## Out of scope (follow-up PRs)

- Reclassify `NativeFetchStrategy` 403+Cloudflare-HTML as `WafBlocked` instead of `Generic` (observability symmetry).
- De-duplicate `WAF_BLOCK_PATTERNS` across the two `FetchConfig.ts` copies.
- Apply same Camoufox-backed pattern to other headless banks if Cloudflare expands the rule.
- Documentation pass on the TLS-bypass architecture in dev guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OneZero pipeline now routes identity API calls through a browser session.
  * API mediators now support resource cleanup via dispose lifecycle hooks.

* **Tests**
  * Added test coverage for browser-backed API mediator configuration and behavior.
  * Added comprehensive testing for browser-based identity fetch strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergienko4/israeli-bank-scrapers/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->