### PR TITLE
chore(deps): npm refresh — audit fix, playwright pin, flatted remove, dependabot widen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,19 @@ updates:
           - patch
           - minor
           - major
+      # Playwright is the other critical browser-automation surface.
+      # Auto-bump on patch + minor so upstream regression fixes flow
+      # in as their own PR; CI (E2e.test.ts invalid-creds regression
+      # guard) gates whether the bump lands. The ~range in
+      # package.json is the install-time safety gate; this group
+      # is the discovery gate.
+      playwright:
+        patterns:
+          - 'playwright-core'
+          - 'playwright'
+        update-types:
+          - patch
+          - minor
       dev-dependencies:
         dependency-type: development
         update-types:
@@ -29,12 +42,16 @@ updates:
           - patch
         exclude-patterns:
           - '@hieutran094/camoufox-js'
+          - 'playwright-core'
+          - 'playwright'
       production-dependencies:
         dependency-type: production
         update-types:
           - patch
         exclude-patterns:
           - '@hieutran094/camoufox-js'
+          - 'playwright-core'
+          - 'playwright'
 
   - package-ecosystem: github-actions
     directory: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "eslint-plugin-unicorn": "^64.0.0",
         "eslint-plugin-unused-imports": "^4.4.1",
         "fast-check": "^4.8.0",
-        "flatted": "^3.4.2",
         "fs-extra": "^11.3.5",
         "globals": "^17.6.0",
         "husky": "^9.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
         "pino": "^10.3.1",
-        "playwright-core": "^1.58.2",
+        "playwright-core": "~1.59.1",
         "utility-types": "^3.11.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10769,9 +10769,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "eslint-plugin-unicorn": "^64.0.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "fast-check": "^4.8.0",
-    "flatted": "^3.4.2",
     "fs-extra": "^11.3.5",
     "globals": "^17.6.0",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "pino": "^10.3.1",
-    "playwright-core": "^1.58.2",
+    "playwright-core": "~1.59.1",
     "utility-types": "^3.11.0"
   },
   "files": [


### PR DESCRIPTION
## Description

Refresh the npm dependency surface against `main`: patch two moderate CVE transitives (brace-expansion + ws), pin `playwright-core` below the confirmed 1.60.0 Firefox PageError regression, drop one unused direct dev-dep, and widen the dependabot config so future `playwright-core` minor releases surface as their own PRs (CI gates whether they land). **4 atomic commits, 27 lines net** across `package.json` + `package-lock.json` + `.github/dependabot.yml`. **Zero `src/**` changes.**

## Why

**Supply-chain hygiene.** Two transitive moderate CVEs (GHSA-jxxr-4gwj-5jf2 brace-expansion DoS via numeric range, GHSA-58qx-3vcg-4xpx ws uninitialized-memory disclosure) had fixes available as patch-only bumps via `npm audit fix`. Both ship now. `npm audit` returns 0 vulnerabilities after the chain lands.

**Playwright Firefox regression.** `playwright-core` 1.60.0 introduced a new `pageerror` event payload with a `location: { url, line, column }` field. Firefox can emit uncaught errors WITHOUT location info (very common for non-JS errors), and the new dispatcher at `coreBundle.js:49619-49628` dereferences `pageError.location.url` without optional chaining. Result: `src/Tests/E2e.test.ts` "scraper rejects with invalid credentials" crashes with `TypeError: Cannot read properties of undefined (reading 'url')`. Verified 1.61.0-alpha as of 2026-05-21 still has the bug. Range tightened to `~1.59.1` so semver excludes the buggy 1.60+ minor while still admitting 1.59.x patches. The existing E2e test is the regression guard — it fails on 1.60.0 and passes on 1.59.1.

**Direct-dep surface reduction.** `flatted` was declared as a direct devDep but has zero source-level imports; it is supplied transitively by `eslint → file-entry-cache → flat-cache → flatted@3.4.2`. Removing the direct entry shrinks the supply-chain footprint without changing runtime behaviour. `npm run lint` still passes after removal.

**Dependabot auto-discovery for playwright.** The prior `production-dependencies` group was patch-only, which meant any future 1.60.x or 1.61.x release (including the eventual upstream fix for the regression above) would NOT surface as a PR. New dedicated `playwright` group allows patch + minor; CI runs on every dependabot PR so the E2e regression guard gates whether bumps land. The `~1.59.1` package.json range is the install-time safety gate; this dependabot group is the discovery gate.

## Scope

**Closed:**
- 2 moderate CVE patches (transitive: brace-expansion, ws)
- 1 upstream-regression block (playwright-core pinned `~1.59.1`)
- 1 unused direct dep removal (flatted)
- 1 dependabot config widening (playwright group)

**Held for follow-up PRs:**
- `@hieutran094/camoufox-js` 0.6.8 → 0.6.9 (registry per-version metadata phantom; dist-tag flipped back during OODA cycle — re-check next cycle)
- `lint-staged` 16 → 17 (requires Node engine bump `>=22.14.0` → `>=22.22.1`)
- `fs-extra` + `minimist` removal (referenced only by orphan `utils/pre-publish.js`; separate PR to drop the orphan + these deps)
- `test-exclude` + `ua-parser-js` overrides (parents still require)
- Upstream playwright fix (file at github.com/microsoft/playwright when bandwidth allows)

**Out of scope:**
- ESLint flat-config rewrite for v11+ (not yet released)
- New dependencies of any kind
- Source-code changes (NFR1: 0 LoC of `src/**` modified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing framework dependencies to latest compatible version
  * Removed unused development dependency
  * Enhanced automated dependency management configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergienko4/israeli-bank-scrapers/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->