### PR TITLE
fix(ci): grant contents:write to dependabot auto-merge job

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - name: Approve PR


### PR DESCRIPTION
## Description

Restore dependabot auto-merge by granting the job the `contents: write` permission required by GitHub's `enablePullRequestAutoMerge` GraphQL mutation. 1 line added to `.github/workflows/dependabot-auto-merge.yml`.

## Why

Dependabot PR #254 (`build(deps-dev): bump ts-jest from 29.4.10 to 29.4.11`) failed the `auto-merge` job with:

```
GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)
```

The `gh pr merge --auto --squash` command — which calls the `enablePullRequestAutoMerge` GraphQL mutation under the hood — requires **both** `pull-requests: write` AND `contents: write` per GitHub's API contract. PR #248 (Security Hardening — CodeQL #32, #33) restricted the default `GITHUB_TOKEN` to least-privilege and the `dependabot-auto-merge.yml` workflow declared only `pull-requests: write`. The missing `contents: write` is the regression.

The guard at line 11 (`if: github.actor == 'dependabot[bot]'`) keeps the elevated permission scoped strictly to dependabot PRs — non-dependabot triggers cannot reach this job, so the principle of least privilege is preserved.

## Scope

**Fixed:**
- `dependabot-auto-merge.yml` job permissions: `pull-requests: write` → `contents: write` + `pull-requests: write`

**Verification path post-merge:**
- Next dependabot PR exercises the same workflow; success is visible as the job exiting 0 instead of 1.

**Out of scope:**
- Other workflows' permissions (audited — `qodo-failover.yml`, `pr.yml`, `release.yml`, `pr-docs.yml`, `pr-title.yml`, `docs.yml`, `codeql.yml` all have correct least-privilege grants for their respective jobs).
- Manually merging the existing PR #254 (the user can `gh pr merge 254 --squash` to land the ts-jest patch once this fix is on main).
