### PR TITLE
chore(security): close deferred S2/S9 + ban suppression comments

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1141,4 +1141,39 @@ export default tseslint.config(
       'no-restricted-syntax': ['error', ...RESTRICTED_SYNTAX_RULES, NO_DIRECT_SCREENSHOT_RULE],
     },
   },
+
+  // 15. NO SUPPRESSION COMMENTS — Phase 2 of Security Hardening 2026-05.
+  //     Bans every suppression-comment family on src/** so future
+  //     contributors cannot silence a Sonar / TypeScript / Biome /
+  //     ESLint / coverage rule instead of fixing the underlying
+  //     issue. Routed through ESLint's built-in `no-warning-comments`
+  //     rule (terms-array form) because Line/Block AST selectors
+  //     (`Line:matches([value*='...'])`) are non-functional in
+  //     ESLint 9 + typescript-eslint flat-config — verified
+  //     empirically. The terms-array form fires on both Line and
+  //     Block comments. Canary fixtures in EslintCanaries/ are
+  //     intentionally malformed; excluded via `ignores`.
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    ignores: ['src/Scrapers/Pipeline/EslintCanaries/**'],
+    rules: {
+      'no-warning-comments': [
+        'error',
+        {
+          terms: [
+            'NOSONAR',
+            '@ts-ignore',
+            '@ts-expect-error',
+            '@ts-nocheck',
+            'biome-ignore',
+            'eslint-disable',
+            'istanbul ignore',
+            'c8 ignore',
+            'v8 ignore',
+          ],
+          location: 'anywhere',
+        },
+      ],
+    },
+  },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1017,31 +1017,6 @@ export default tseslint.config(
     },
   },
 
-  // 12. ARCHITECTURE-RULE EXCEPTION — narrowed by Security Hardening
-  //     2026-05 (RC-5).
-  //
-  //     Previously this block disabled `sonarjs/redundant-type-aliases`
-  //     for 8 files. The 6 `type X = unknown` aliases (S3..S8) were
-  //     migrated to the shared {@link JsonValue} structural union;
-  //     their entries were removed.
-  //
-  //     The 2 string-typed aliases (S2 `FormAnchorSelector`, S9
-  //     `ContextId`) remain as bare `type X = string` because the
-  //     brand-pattern migration cascaded into >15 consumer sites
-  //     across production + test code (Decide §6 NEW-R10 5-file
-  //     ceiling). Tracked as a Decide-time deviation; the migration
-  //     is deferred to a follow-up PR scoped to the consumer-site
-  //     cleanup. NOSONAR comments stay on the alias lines.
-  {
-    files: [
-      'src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts',
-      'src/Scrapers/Pipeline/Types/PipelineContext.ts',
-    ],
-    rules: {
-      'sonarjs/redundant-type-aliases': 'off',
-    },
-  },
-
   // 12c. QUALITY RULES (Security Hardening 2026-05) — `readonly`
   //      private fields, `node:` protocol prefix for built-in imports.
   //      Both rules close Sonar findings (S2933 + S7772) AND prevent

--- a/src/Common/FormAnchor.ts
+++ b/src/Common/FormAnchor.ts
@@ -90,34 +90,39 @@ async function evaluateFormWalk(ctx: Page | Frame, resolvedSelector: string): Pr
 
 /**
  * Self-contained browser-context form walk. ALL logic inline — no external refs.
+ * Must be self-contained: Playwright evaluate() serializes only this function;
+ * inner helpers are defined inside the body to stay within the serialised source.
  * Uses only anonymous function expressions to avoid __name injection by build tools.
  * @param input - DOM input element (injected by Playwright).
  * @param skipTypes - Non-fillable input types (passed as arg).
  * @returns CSS selector for the nearest form-like ancestor.
  */
-/**
- * Self-contained browser-context form walk. ALL logic inline — no external refs.
- * Must be self-contained: Playwright evaluate() serializes only this function.
- * @param input - DOM input element (injected by Playwright).
- * @param skipTypes - Non-fillable input types (passed as arg).
- * @returns CSS selector for the nearest form-like ancestor.
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: browser evaluate() requires self-contained function
 function formWalkBrowserFn(input: Element, skipTypes: string[]): string {
   const skip = new Set(skipTypes);
+  /**
+   * Decide whether `el` qualifies as a form-anchor ancestor.
+   * @param el - candidate ancestor.
+   * @returns true when `el` is a FORM or holds 2+ fillable inputs.
+   */
+  const isFormAnchor = (el: Element): boolean =>
+    el.tagName === 'FORM' ||
+    [...el.querySelectorAll('input')].filter(i => !skip.has(i.type)).length >= 2;
+  /**
+   * Build a stable CSS selector for the matched ancestor.
+   * @param el - matched ancestor.
+   * @returns CSS selector targeting `el` uniquely within its parent.
+   */
+  const buildSelectorForElement = (el: Element): string => {
+    if (el.id) return '#' + el.id;
+    const tag = el.tagName.toLowerCase();
+    const p = el.parentElement;
+    if (!p) return tag;
+    const sib = [...p.children].filter(c => c.tagName === el.tagName);
+    return sib.length <= 1 ? tag : tag + ':nth-of-type(' + String(sib.indexOf(el) + 1) + ')';
+  };
   let el = input.parentElement;
   while (el && el !== document.body) {
-    const isForm = el.tagName === 'FORM';
-    const fills = isForm ? [] : [...el.querySelectorAll('input')].filter(i => !skip.has(i.type));
-    if (isForm || fills.length >= 2) {
-      if (el.id) return '#' + el.id;
-      const tag = el.tagName.toLowerCase();
-      const p = el.parentElement;
-      if (!p) return tag;
-      const target = el;
-      const sib = [...p.children].filter(c => c.tagName === target.tagName);
-      return sib.length <= 1 ? tag : tag + ':nth-of-type(' + String(sib.indexOf(target) + 1) + ')';
-    }
+    if (isFormAnchor(el)) return buildSelectorForElement(el);
     el = el.parentElement;
   }
   return '';

--- a/src/Scrapers/Pipeline/EslintCanaries/bare-return.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/bare-return.canary.ts
@@ -1,7 +1,6 @@
 // Canary: ReturnStatement[argument=null] — bare return; must be caught
-function earlyExit(): boolean {
-  // @ts-expect-error Intentional: canary tests bare return
+const earlyExit = () => {
   return;
-}
+};
 
 export { earlyExit };

--- a/src/Scrapers/Pipeline/EslintCanaries/no-suppression-comments.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/no-suppression-comments.canary.ts
@@ -1,0 +1,6 @@
+// Canary fixture for the no-suppression-comments rule (eslint.config.mjs
+// block #15). MUST contain at least one line matching the rule's `terms`
+// array so the canary harness reports a non-zero error count.
+// NOSONAR intentional fixture: must trigger the no-warning-comments rule
+// biome-ignore lint: intentional fixture: must trigger no-warning-comments
+export const noSuppressionCommentsCanary = true;

--- a/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
@@ -7,7 +7,7 @@ import type { Frame, Locator, Page } from 'playwright-core';
 
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
 import { getDebug } from '../../Types/Debug.js';
-import type { ContextId, IResolvedTarget } from '../../Types/PipelineContext.js';
+import type { IResolvedTarget } from '../../Types/PipelineContext.js';
 import {
   ELEMENTS_CLICK_TIMEOUT_MS,
   ELEMENTS_EVALUATE_TIMEOUT_MS,
@@ -485,7 +485,7 @@ function raceResultToTarget(result: IRaceResult, page: Page): IResolvedTarget | 
   if (!result.found) return false;
   if (!result.context) return false;
   if (!result.candidate) return false;
-  const contextId: ContextId = computeContextId(result.context, page);
+  const contextId: string = computeContextId(result.context, page);
   const fromIdentity = result.identity && buildIdentitySelector(result.identity);
   const selector = fromIdentity || candidateToSelector(result.candidate);
   return {

--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
@@ -17,7 +17,6 @@ import type { Frame, Locator, Page } from 'playwright-core';
 
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
 import type { Option } from '../../Types/Option.js';
-import type { ContextId } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import type { IFormAnchor } from '../Form/FormAnchor.js';
 import type { IFormErrorScanResult } from '../Form/FormErrorDiscovery.js';
@@ -361,7 +360,7 @@ interface ICookieInjection {
 /** Bundled args for `IActionMediator.clickElement` — fits the 3-param ceiling. */
 interface IClickElementArgs {
   /** Opaque frame identifier. */
-  readonly contextId: ContextId;
+  readonly contextId: string;
   /** CSS/XPath selector. */
   readonly selector: string;
   /** Force click bypassing actionability checks (for hidden toggles). */
@@ -390,7 +389,7 @@ interface IActionMediator {
    * @param value - Value to fill.
    * @returns True after filling.
    */
-  fillInput(contextId: ContextId, selector: string, value: string): Promise<true>;
+  fillInput(contextId: string, selector: string, value: string): Promise<true>;
 
   /**
    * Click an element by contextId + selector.
@@ -404,7 +403,7 @@ interface IActionMediator {
    * @param contextId - Opaque frame identifier.
    * @returns True after pressing.
    */
-  pressEnter(contextId: ContextId): Promise<true>;
+  pressEnter(contextId: string): Promise<true>;
 
   // ── Navigation (no raw Frame needed) ──
 

--- a/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/FrameRegistry.ts
@@ -8,13 +8,12 @@
 import type { Frame, Page } from 'playwright-core';
 
 import ScraperError from '../../../Base/ScraperError.js';
-import type { ContextId } from '../../Types/PipelineContext.js';
 
 /** Main page context identifier constant. */
-const MAIN_CONTEXT_ID: ContextId = 'main';
+const MAIN_CONTEXT_ID = 'main';
 
 /** Iframe context identifier prefix. */
-const IFRAME_PREFIX: ContextId = 'iframe:';
+const IFRAME_PREFIX = 'iframe:';
 
 /**
  * Compute a stable opaque contextId for a Page or Frame.
@@ -30,7 +29,7 @@ const IFRAME_PREFIX: ContextId = 'iframe:';
  * @param rawUrl - Full URL with potential query params.
  * @returns Origin + pathname only.
  */
-function stableUrl(rawUrl: ContextId): ContextId {
+function stableUrl(rawUrl: string): string {
   try {
     const parsed = new URL(rawUrl);
     return `${parsed.origin}${parsed.pathname}`;
@@ -45,7 +44,7 @@ function stableUrl(rawUrl: ContextId): ContextId {
  * @param page - The main page (for main-frame detection).
  * @returns Stable opaque contextId string.
  */
-function computeContextId(context: Page | Frame, page: Page): ContextId {
+function computeContextId(context: Page | Frame, page: Page): string {
   const isMain: boolean = context === page;
   if (isMain) return MAIN_CONTEXT_ID;
   const isMainFrame: boolean = 'mainFrame' in page && context === page.mainFrame();
@@ -54,13 +53,13 @@ function computeContextId(context: Page | Frame, page: Page): ContextId {
   const url = frame.url();
   const name = frame.name();
   const hasRealUrl = url !== 'about:blank' && url.length > 0;
-  const stableIdMap: Record<string, ContextId> = { true: stableUrl(url), false: name };
+  const stableIdMap: Record<string, string> = { true: stableUrl(url), false: name };
   const stableId = stableIdMap[String(hasRealUrl)];
   return `${IFRAME_PREFIX}${stableId}`;
 }
 
 /** Immutable frame registry — maps contextId → actual Frame. */
-type FrameRegistryMap = ReadonlyMap<ContextId, Page | Frame>;
+type FrameRegistryMap = ReadonlyMap<string, Page | Frame>;
 
 /**
  * Check if a frame is the main frame — used to filter in registry build.
@@ -79,7 +78,7 @@ function isMainFrame(frame: Frame, page: Page): boolean {
  * @returns Immutable map of contextId → Frame.
  */
 function buildFrameRegistry(page: Page): FrameRegistryMap {
-  const registry = new Map<ContextId, Page | Frame>();
+  const registry = new Map<string, Page | Frame>();
   registry.set(MAIN_CONTEXT_ID, page);
   const childFrames = page.frames().filter((f): boolean => !isMainFrame(f, page));
   for (const frame of childFrames) {
@@ -95,7 +94,7 @@ function buildFrameRegistry(page: Page): FrameRegistryMap {
  * @param contextId - The opaque contextId.
  * @returns The actual Page or Frame.
  */
-function resolveFrame(registry: FrameRegistryMap, contextId: ContextId): Page | Frame {
+function resolveFrame(registry: FrameRegistryMap, contextId: string): Page | Frame {
   const frame = registry.get(contextId);
   if (!frame) throw new ScraperError(`Unknown contextId: ${contextId}`);
   return frame;

--- a/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts
@@ -231,20 +231,6 @@ function normalizeSubmitConfig(submit: ILoginConfig['submit']): readonly Selecto
 }
 
 /**
- * Trustworthy form-anchor selector (id/name/class) or empty string
- * sentinel.
- *
- * <p>Deferred from the Security Hardening 2026-05 RC-5 brand
- * migration per Decide §6 NEW-R10: branding cascaded into the
- * LoginPhaseActionsHelpers test file, which is outside the
- * Act-stage allow-list. Recorded as a Decide-time deviation; will
- * be migrated in a follow-up PR. Sonar S6564 silence retained via
- * the `eslint.config.mjs` §12 override entry.
- */
-// NOSONAR — Rule #15 (no-primitive-returns) requires a named alias here.
-type FormAnchorSelector = string;
-
-/**
  * Extract form-anchor selector ONLY when the anchor is trustworthy:
  *   - `#id`             (e.g. Amex/Isracard `#otpLobbyFormPassword`)
  *   - `tag[name="X"]`   (form name attribute when id is empty)
@@ -256,7 +242,7 @@ type FormAnchorSelector = string;
  * @param formAnchor - Optional form anchor option.
  * @returns Trustworthy CSS selector or empty string.
  */
-function extractFormAnchorSelector(formAnchor: Option<IFormAnchor>): FormAnchorSelector {
+function extractFormAnchorSelector(formAnchor: Option<IFormAnchor>): string {
   if (!formAnchor.has) return '';
   const selector = formAnchor.value.selector;
   if (selector.length === 0) return '';

--- a/src/Scrapers/Pipeline/Types/JsonValue.ts
+++ b/src/Scrapers/Pipeline/Types/JsonValue.ts
@@ -3,7 +3,7 @@
  * JSON tree" across the pipeline.
  *
  * <p>Spec.txt §1 RC-5: replaces the per-file `type JsonValue = unknown`
- * pattern (and its `NOSONAR` companion) that previously dodged
+ * pattern (and its Sonar-suppression companion) that previously dodged
  * SonarJS rule `typescript:S6564` (redundant type alias) while
  * still honouring the project's architecture-rule ban on bare
  * `unknown` in function parameter/return positions
@@ -57,7 +57,7 @@ type JsonArray = readonly JsonValue[];
  * narrower contract via type guards.
  *
  * <p>Spec.txt §1 RC-5: replaces per-file `type X = unknown`
- * aliases (eight files, each with a `NOSONAR` comment) with
+ * aliases (eight files, each with a Sonar-suppression comment) with
  * one shared definition. Honours the project's
  * `no-restricted-syntax` ban on bare `unknown` in
  * function signatures while closing S6564 at the same time.

--- a/src/Scrapers/Pipeline/Types/PipelineContext.ts
+++ b/src/Scrapers/Pipeline/Types/PipelineContext.ts
@@ -167,27 +167,12 @@ export interface IPreLoginDiscovery {
 
 // ── Phase-Specific Discovery Types (PRE → ACTION handoff) ───────────
 
-/**
- * Opaque frame identifier — `'main'` or `'iframe:<url>'`;
- * never a raw Playwright object.
- *
- * <p>Deferred from the Security Hardening 2026-05 RC-5 brand
- * migration per Decide §6 NEW-R10 (5-file consumer-cascade ceiling):
- * the brand pattern caused tsc errors in 15+ consumer sites across
- * production + test code. Recorded as a Decide-time deviation; will
- * be migrated in a follow-up PR scoped to the cascade cleanup.
- * Sonar S6564 silence is retained via the `eslint.config.mjs`
- * §12 override entry. NOSONAR.
- */
-// NOSONAR — Rule #15 (no-primitive-returns) requires a named alias here.
-export type ContextId = string;
-
 /** Resolved element target — PRE discovered, ACTION executes via contextId. */
 export interface IResolvedTarget {
   /** CSS/XPath selector for the element. */
   readonly selector: string;
-  /** Opaque frame identifier — resolved by private registry inside executor. */
-  readonly contextId: ContextId;
+  /** Opaque frame identifier — `'main'` or `'iframe:<url>'`. */
+  readonly contextId: string;
   /** Strategy that matched (xpath, placeholder, labelText, etc.). */
   readonly kind: string;
   /** Candidate value that was searched for. */
@@ -213,7 +198,7 @@ export interface ILoginFieldDiscovery {
   /** Form anchor discovered from password field. */
   readonly formAnchor: Option<IFormAnchor>;
   /** Opaque identifier of the frame where fields were found. */
-  readonly activeFrameId: ContextId;
+  readonly activeFrameId: string;
   /** Pre-resolved submit button target (contextId + selector). */
   readonly submitTarget: Option<IResolvedTarget>;
 }

--- a/src/Tests/Tools/LintValidator.ts
+++ b/src/Tests/Tools/LintValidator.ts
@@ -27,7 +27,6 @@ export type RuleKey =
   | 'Rule #10'
   | '[Async]'
   | 'PII-Log'
-  | 'NOSONAR-Discipline'
   | 'S6564-Canary'
   | 'S3735-Canary'
   | 'S1607-Canary';
@@ -165,7 +164,6 @@ export function loadAllowlist(
         v === 'Rule #10' ||
         v === '[Async]' ||
         v === 'PII-Log' ||
-        v === 'NOSONAR-Discipline' ||
         v === 'S6564-Canary' ||
         v === 'S3735-Canary' ||
         v === 'S1607-Canary',
@@ -202,12 +200,6 @@ const S6564_CANARY_RE = /^type\s+[A-Z]\w*\s*=\s*(?:boolean|string|number|void|un
  * Catches the discard-promise antipattern. Defence-in-depth.
  */
 const S3735_CANARY_RE = /^\s*void\s+\w/gm;
-/**
- * Regex: NOSONAR comment lacking rationale text (NOSONAR-Discipline).
- * Every `// NOSONAR` must carry an explanation after `—` or `:` of at
- * least 20 chars. Drive-by silencing is rejected.
- */
-const NOSONAR_DISCIPLINE_RE = /\/\/\s*NOSONAR(?!.*[—:].{20})/g;
 /**
  * Regex: `it.skip(`/`describe.skip(` (S1607 canary).
  * Matches the call site; the issue-ref rationale check runs on the
@@ -293,10 +285,7 @@ const PII_PAYLOAD_RE = new RegExp(
 
 /**
  * Emit S6564-Canary issues for a file. Catches bare-primitive aliases
- * even when ESLint is bypassed. Skips matches whose immediately
- * preceding line carries a `// NOSONAR` justification (mirrors
- * SonarCloud's server-side suppression so the local canary stays
- * consistent with the cloud gate).
+ * even when ESLint is bypassed.
  * @param code - Source text.
  * @returns S6564-Canary issues (may be empty).
  */
@@ -306,8 +295,6 @@ function s6564CanaryIssues(code: string): IIssue[] {
   for (const [idx, line] of lines.entries()) {
     S6564_CANARY_RE.lastIndex = 0;
     if (!S6564_CANARY_RE.test(line)) continue;
-    const prev = idx > 0 ? lines[idx - 1] : '';
-    if (prev.includes('NOSONAR')) continue;
     out.push({
       rule: 'S6564-Canary',
       message: `[S6564-Canary] Bare-primitive type alias at line ${String(idx + 1)}: ${line.trim()}`,
@@ -333,26 +320,6 @@ function s3735CanaryIssues(code: string): IIssue[] {
     });
   }
   S3735_CANARY_RE.lastIndex = 0;
-  return out;
-}
-
-/**
- * Emit NOSONAR-Discipline issues for a file. Forces every NOSONAR
- * marker to carry rationale text after `—` or `:` of at least 20
- * chars so drive-by silencing is rejected.
- * @param code - Source text.
- * @returns NOSONAR-Discipline issues (may be empty).
- */
-function nosonarDisciplineIssues(code: string): IIssue[] {
-  const out: IIssue[] = [];
-  const matches = code.match(NOSONAR_DISCIPLINE_RE) ?? [];
-  for (const m of matches) {
-    out.push({
-      rule: 'NOSONAR-Discipline',
-      message: `[NOSONAR-Discipline] NOSONAR without rationale: ${m.trim()}`,
-    });
-  }
-  NOSONAR_DISCIPLINE_RE.lastIndex = 0;
   return out;
 }
 
@@ -506,12 +473,7 @@ function issuesFromCodeRaw(filePath: string, code: string): IIssue[] {
   issues.push(...piiLogIssues(code));
   // Defence-in-depth canaries: re-affirm the SonarJS rules via regex
   // so a `--no-verify` ESLint bypass still trips the architecture gate.
-  issues.push(
-    ...s6564CanaryIssues(code),
-    ...s3735CanaryIssues(code),
-    ...nosonarDisciplineIssues(code),
-    ...s1607CanaryIssues(code),
-  );
+  issues.push(...s6564CanaryIssues(code), ...s3735CanaryIssues(code), ...s1607CanaryIssues(code));
   return issues;
 }
 


### PR DESCRIPTION
## Description

Close the 2 SonarCloud findings deferred by PR #248 (S2 + S9 `typescript:S6564` redundant type aliases) by inlining the aliases through their consumer cascade, remove every suppression comment from `src/`, and install a working ESLint canary that BLOCKS any future suppression comment. **6 atomic commits, ~-77 net LoC, zero `lib/index.d.ts` md5 change**.

## Why

**Closing the deferred SonarCloud findings.** PR #248 deferred S2 + S9 because the brand-pattern migration was estimated at >15 consumer files. Phase 2 Observe re-measured: the actual cascade is **4 files** (not 15+), so the migration ships in this PR. `FormAnchorSelector` and `ContextId` are inlined to `string` at every consumer; neither type was exported through `lib/index.d.ts`, so the public API surface is unchanged.

**Eliminating suppression debt.** PR #248 also documented the deferrals with `// NOSONAR` comments that were placed on the wrong line — SonarCloud's `NOSONAR` only works inline (same line as the issue), not on the line above. The result: 2 documented suppressions that weren't actually suppressing anything. This PR removes them, plus the 1 working `// biome-ignore` in `FormAnchor.ts` and the 1 `// @ts-expect-error` in `bare-return.canary.ts`, by refactoring the underlying code so the rules no longer fire.

**Recurrence guard that actually fires.** A new file-scoped block in `eslint.config.mjs` enables ESLint's built-in `no-warning-comments` rule with a `terms` array covering 9 suppression families: `NOSONAR`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`, `biome-ignore`, `eslint-disable`, `istanbul ignore`, `c8 ignore`, `v8 ignore`. Empirically verified that dropping `// NOSONAR` into a real source file fails lint with the expected error. The original draft used `Line:matches([value*='NOSONAR'])` AST selectors which were found (via empirical testing) to be non-functional in ESLint 9 + typescript-eslint flat-config — the rule was rewritten before commit to use the working `no-warning-comments` mechanism.

## Scope

**Closed:**
- Sonar S2 (FormAnchorSelector S6564 — 1 file inlined)
- Sonar S9 (ContextId S6564 — 4-file cascade)
- Suppression debt: 2 NOSONAR + 1 biome-ignore + 1 @ts-expect-error all removed
- Obsolete tooling: `NOSONAR-Discipline` rule + scanner deleted from `LintValidator.ts`; `eslint.config.mjs §12` override removed
- Recurrence guard: `no-warning-comments` enabled with 9-term ban list, scoped to `src/**` excluding `EslintCanaries/`

**Out of scope (deferred to follow-up):**
- Canary harness systemic issue: `tsconfig.json:exclude` for `EslintCanaries/` makes all canary fixtures fire on parse errors rather than the rules they claim to test. Pre-existing, not introduced by this PR. Reported as RabbitAI F2.
- The 4 CodeQL alerts (#32-#35) currently showing "open" are stale snapshots pointing at pre-fix SHA `0dc08028`. Latest 3 analyses on main report 0 results. They should auto-close after this PR's merge triggers a fresh CodeQL run on the new main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Simplified internal type system for improved consistency across the codebase
* Reorganized form-handling logic for better code clarity

## Chores
* Strengthened linting configuration to enforce stricter coding standards
* Updated validation tools to reduce excessive code suppressions and improve development practices
* Removed legacy validation discipline checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergienko4/israeli-bank-scrapers/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->