### PR TITLE
fix(ci): drop deprecated --exclude-mail from Lychee args

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -65,7 +65,6 @@ jobs:
             --cache
             --max-cache-age 1d
             --no-progress
-            --exclude-mail
             --exclude 'sergienko4.github.io/israeli-bank-scrapers/'
             --exclude 'npmjs.com/package/'
             'README.md' 'docs/**/*.md'


### PR DESCRIPTION
## Summary

Lychee v0.23.0 (pulled by Dependabot PR #268's bump of `lycheeverse/lychee-action` to the v0.23 series) **removed `--exclude-mail` entirely**. The flag was deprecated in earlier v0.x releases (PR #264 CI showed the warning) and is now a hard parse error:

```
error: unexpected argument '--exclude-mail' found
  tip: a similar argument exists: '--include-mail'
```

**1-line removal** in `link-check.yml`. Email checking has been default-off in Lychee since v0.20; the new `--include-mail` flag is the opt-in. We never want to check email links, so removing the flag preserves the desired behaviour with no further change.

## Impact

Currently blocks:
- PR #263 (release-please for 8.4.0) — Lychee job [78294383181](https://github.com/sergienko4/israeli-bank-scrapers/actions/runs/26575726422/job/78294383181) failing
- Every future PR that touches `docs/` or `README.md`

After this lands, Lychee re-runs cleanly on all open PRs.

## Test plan

- [ ] CI: Lychee step passes on this PR's own check (it runs against this branch's `link-check.yml`)
- [ ] After merge: PR #263 (release-please) Lychee step passes on next CI re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)