### PR TITLE
docs(repo): add PR template with doc + CI checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+<!--
+Pull Request — Israeli Bank Scrapers (Pipeline architecture)
+
+Keep the PR small and focused. One PR == one logical change
+(see C:/tmp/guidelines/pr-guidlines.md). Target 200–400 lines of
+changed code; split larger work before review.
+
+Commit messages follow the 50/72 rule
+(C:/tmp/guidelines/commit-guidlines.md).
+-->
+
+## Summary
+
+<!--
+1–3 bullets. WHAT changes + WHY. Link issues / prior PRs if relevant.
+-->
+
+-
+-
+-
+
+## Test plan
+
+<!-- Tick what applies before requesting review. -->
+
+- [ ] unit tests added / updated
+- [ ] integration tests added / updated where the surface warrants
+- [ ] `npm run lint` passes
+- [ ] `npm run test:pipeline` passes (coverage gates respected)
+- [ ] `npm run test:e2e:mock` passes (or N/A documented below)
+
+## Docs
+
+<!--
+Every user-visible behaviour change MUST update the user guide.
+TypeDoc (/api/) auto-flows from JSDoc on src/**. mkdocs (docs/**)
+is hand-authored — please add or update the relevant page.
+-->
+
+- [ ] page added or updated under `docs/` for any user-visible change (new option, new error, new phase behaviour, new bank, new observability surface)
+- [ ] `mkdocs.yml` nav updated when adding a new page
+- [ ] JSDoc comments updated on every changed exported symbol (TypeDoc consumes these)
+- [ ] N/A — explain why: <!-- e.g. "internal refactor; no user-visible surface" -->
+
+## CI / security
+
+- [ ] no secrets committed
+- [ ] no PII or customer identifiers in code, tests, or commit messages
+- [ ] new third-party action pinned by SHA (not by tag)
+- [ ] new shell scripts include `set -euo pipefail`
+
+## Notes for reviewer
+
+<!-- Anything that helps reading the diff. Optional. -->


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` (GitHub auto-loads for new PRs)
- Bake in the docs-update checklist that PR #269 surfaced as the missing process gate
- Cover summary / test plan / docs / CI-security / reviewer-notes sections

## Why

The mkdocs user guide (`docs/**/*.md`) is hand-authored. TypeDoc auto-flows from JSDoc on `src/**`, but there's no automation today that forces an author to update `docs/` when a user-visible behavior changes. PR #269 caught this gap explicitly — the envelope-sniff feature and the screenshot-allowlist feature both needed manual `docs/observability/*.md` pages.

This template is the lightest of three queued mechanisms:
1. **This PR** — PR template doc checklist (author discipline)
2. (next) — CodeRabbit instruction asking the reviewer to flag undocumented new public symbols
3. (next) — CI canary that fails on new public Pipeline exports without docs mention

## Test plan

- [ ] CI: nothing to run (docs-only)
- [ ] Verify GitHub picks up the template by opening the next PR and seeing it pre-filled

## Docs

- [x] N/A — explain why: this PR IS the documentation surface (the PR template itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)