### PR TITLE
ci(coderabbit): flag undocumented new Pipeline exports

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,23 @@ reviews:
       instructions: >
         CI/CD workflows. Check for: missing timeout-minutes, unpinned actions,
         overly broad permissions, missing set -euo pipefail in shell scripts.
+    - path: "src/Scrapers/Pipeline/**"
+      instructions: >
+        Pipeline code. When this PR adds a new exported symbol
+        (function, class, interface, type, const) in this tree,
+        verify there is a corresponding mention in docs/**/*.md
+        (a new file under docs/observability/, docs/architecture/,
+        docs/phases/, docs/banks/, etc., or an edit to an existing
+        page). TypeDoc auto-flows from JSDoc on /api/, but the
+        mkdocs user guide (docs/) is hand-authored — flag the PR
+        when a user-visible behaviour change ships without a
+        docs/ update.
+    - path: "docs/**"
+      instructions: >
+        mkdocs user guide. Check for: links that 404 (Lychee runs
+        on CI), undefined cross-references (mkdocs build --strict
+        rejects), and pages added without a corresponding nav entry
+        in mkdocs.yml.
 
   # Don't review these paths
   path_filters:


### PR DESCRIPTION
## Summary

- Extend `.coderabbit.yaml` `path_instructions` with two new entries
- `src/Scrapers/Pipeline/**` — reviewer flags new public exports that lack a `docs/**/*.md` mention
- `docs/**` — reviewer checks 404 links, undefined cross-refs, and missing `mkdocs.yml` nav entries

## Why

PR #269 surfaced that nothing today flags a user-visible Pipeline behavior change shipping without a `docs/` page. TypeDoc auto-flows from JSDoc on `src/**` to the `/api/` subsite, but the mkdocs user guide (`docs/**`) is hand-authored. The PR template doc-checklist landed in PR #271 catches the author side; this CodeRabbit rule catches the reviewer side when an author forgets to tick the box.

Sequence:
1. PR #271 — PR template author checklist (lightweight, depends on discipline)
2. **This PR** — CodeRabbit reviewer-side rule (zero CI cost, AI-driven)
3. Next — CI canary that fails the build on undocumented new Pipeline exports (deterministic gate)

## Test plan

- [ ] CI: nothing to run (yaml-only)
- [ ] After merge: CodeRabbit will pick up the change on the next PR review cycle — verify by watching the comments on whatever lands next

## Docs

- [x] N/A — explain why: meta-config; no user-visible runtime behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)