### PR TITLE
chore(canary): Phase 1 follow-up - add re-export-types-pipeline canary (36 -> 37)

### DIFF
--- a/src/Scrapers/Pipeline/EslintCanaries/re-export-types-pipeline.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/re-export-types-pipeline.canary.ts
@@ -1,0 +1,48 @@
+/**
+ * Canary — closes Phase 1 acceptance criterion §12e Pipeline/Types
+ * scope extension (PR #274, master plan
+ * `pipeline-decoupling-master-2026-05-28`).
+ *
+ * <p>Verifies the {@code unicorn/prefer-export-from} rule fires on
+ * the {@code import type {...}; export type {...}} barrel anti-pattern
+ * (SonarCloud {@code typescript:S7763}). Without the §12e extension,
+ * the global {@code ignoreUsedVariables: true} default treats the
+ * re-export reference as "used" and the rule silently passes — which
+ * is exactly the gap PR #274 surfaced (11 findings in
+ * {@code PipelineContext.ts}).
+ *
+ * <p>The §12e extension at {@code eslint.config.mjs} L1393-1399 scopes
+ * {@code ignoreUsedVariables: false} to:
+ * <ul>
+ *   <li>{@code src/Scrapers/Base/**} (original Phase 0 scope)</li>
+ *   <li>{@code src/Scrapers/Pipeline/Types/**} (PR #274 addition)</li>
+ * </ul>
+ *
+ * <p>Companion to {@code re-export-shorthand.canary.ts} which documents
+ * the Base/** half. This file documents the Pipeline/Types half.
+ *
+ * <p>Applicable guidelines:
+ * <ul>
+ *   <li>{@code design-patterns-guidlines.md} — "Avoid duplication."</li>
+ *   <li>{@code coding-principle-guidlines.md} §5 — SOLID Open/Closed.</li>
+ *   <li>{@code before-commit-guidlines.md} — canary is a permanent guard.</li>
+ * </ul>
+ */
+
+import type { Option } from '../Types/Option.js';
+
+/**
+ * Anchor — keeps the file non-empty when the linter skips bare
+ * re-export statements.
+ * @param value - Value to wrap.
+ * @returns Wrapped option.
+ */
+function wrap(value: string): Option<string> {
+  return { ok: true, value } as Option<string>;
+}
+
+// Deliberate violation — manual barrel re-export of an imported type
+// instead of `export type { Option } from '../Types/Option.js';`.
+// With §12e `ignoreUsedVariables: false` this fires `unicorn/prefer-export-from`.
+export type { Option };
+export { wrap };


### PR DESCRIPTION
## Why

Closes the Phase 1 acceptance criterion gap from PR #274 (master plan `pipeline-decoupling-master-2026-05-28`).

PR #274 added the ESLint rule extension at `eslint.config.mjs` §12e (`unicorn/prefer-export-from` `{ignoreUsedVariables: false}` scope extended from `Base/**` to also cover `Pipeline/Types/**`) but did not add a matching canary fixture. The master plan metric explicitly says **canary count: 36 baseline -> 37 after Phase 1**. This PR closes that gap.

## What

Adds `src/Scrapers/Pipeline/EslintCanaries/re-export-types-pipeline.canary.ts` — documents the Pipeline/Types half of §12e. Paired with the existing `re-export-shorthand.canary.ts` (which documents the Base/** half).

## Why a canary even though the rule is already in §12e

- The rule extension protects **production code in scope** (Base + Pipeline/Types).
- The canary is the **permanent guard contract** — if anyone deletes §12e in a future refactor, the canary stays as the documented intent + verify.sh count tripwire.
- Follows project convention from `before-commit-guidlines.md`: "each ESLint rule MUST have a paired canary fixture".

## Validation

| Gate | Result |
|---|---|
| `npx prettier --check` | ✅ |
| `npx tsc --noEmit` | ✅ |
| `npx eslint src --max-warnings 0` | ✅ |
| `npm run lint:architecture` | ✅ |
| `npm run lint:dead-code` | ✅ 282 Pipeline files, all reachable |
| `npm run lint:phases:strict` | ✅ |
| Canary harness (`verify.sh`) | ✅ 37/37 fire ≥1 error |
| Full husky pre-commit (15 gates) | ✅ including E2E mock + live |

## Master plan sync

After merge, master `status.txt` "After P1" column updates to:
- Canary fixtures: **37** (was target, was sitting at 36 after PR #274)

## Risk

**None.** No production code touched. No tests changed. New file lives in `src/Scrapers/Pipeline/EslintCanaries/` which is in the global ESLint ignore list and excluded from tsconfig — same shape as the other 36 canaries.

---

🤖 Generated with [Copilot CLI](https://github.com/cli/cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated verification for ESLint configuration to ensure consistent type export patterns across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sergienko4/israeli-bank-scrapers/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->