### PR TITLE
feat(pipeline): generic background WAF challenge interceptor (hCaptcha/Turnstile checkbox auto-solve)

### DIFF
--- a/docs/architecture/waf-interceptor.md
+++ b/docs/architecture/waf-interceptor.md
@@ -11,7 +11,7 @@ The interceptor centralises the recipe in one place: detect the challenge frame,
 
 ## Architecture
 
-Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge):
+Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge):
 
 | File | Purpose |
 |---|---|
@@ -147,7 +147,7 @@ No PII flows through these events — only the `kind` enum (`hcaptcha-checkbox` 
 
 | File | Role |
 |---|---|
-| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
-| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
-| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
-| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |
+| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
+| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
+| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
+| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |

--- a/docs/architecture/waf-interceptor.md
+++ b/docs/architecture/waf-interceptor.md
@@ -11,7 +11,7 @@ The interceptor centralises the recipe in one place: detect the challenge frame,
 
 ## Architecture
 
-Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge):
+Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge):
 
 | File | Purpose |
 |---|---|
@@ -147,7 +147,7 @@ No PII flows through these events — only the `kind` enum (`hcaptcha-checkbox` 
 
 | File | Role |
 |---|---|
-| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
-| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
-| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
-| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |
+| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
+| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
+| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
+| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |

--- a/docs/architecture/waf-interceptor.md
+++ b/docs/architecture/waf-interceptor.md
@@ -1,0 +1,153 @@
+# WAF challenge interceptor
+
+> **Status:** Shipped in PR #282 — generic background WAF challenge interceptor.
+> **Scope:** Bank-agnostic, phase-agnostic. Wired FIRST in every browser pipeline.
+
+## Why this exists
+
+Banks fronted by Imperva or Cloudflare may interleave a **WAF checkbox challenge** (hCaptcha "I am human" / Cloudflare Turnstile) into the navigation flow. Without handling, the host scraper sees the page never finish loading and times out. A bank-specific patch would copy the same recipe into every Imperva-protected scraper.
+
+The interceptor centralises the recipe in one place: detect the challenge frame, click the checkbox iframe centre via Camoufox's humanized mouse, and let the page continue. Adding a new bank that adopts Imperva requires zero new code.
+
+## Architecture
+
+Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge):
+
+| File | Purpose |
+|---|---|
+| `WafChallengeInterceptor.ts` | Thin factory `createWafChallengeInterceptor` — the **only** consumer-facing surface |
+| `WafChallengeConfig.ts` | Pinned constants: poll interval (2 s), networkidle ceiling (15 s), hydration (5 s), cool-down (8 s), URL patterns, env var name |
+| `WafChallengeTypes.ts` | Branded types — `DidSolve`, `WafChallengeKind`, `IWafChallenge`, `ISolverArgs`, `WafChallengeSolver` |
+| `WafChallengeDetector.ts` | Pure-function frame URL classifier — `detectChallenge(page)` returns `Option<IWafChallenge>` |
+| `HCaptchaCheckboxSolver.ts` | Camoufox auto-pass recipe (settle → wait → click) |
+| `TurnstileCheckboxSolver.ts` | Delegates to hCaptcha solver (same primitive) |
+| `WafChallengeSolverRegistry.ts` | Frozen `Record<WafChallengeKind, WafChallengeSolver>` — Open/Closed extensibility |
+| `WafChallengeInternals.ts` | Poller / state primitives (see "Implementation primitives" below) |
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant Pipeline as PipelineExecutor
+    participant Inter as createWafChallengeInterceptor
+    participant Poll as setInterval (2s)
+    participant Detect as detectChallenge
+    participant Solve as HCaptchaCheckboxSolver
+
+    Pipeline->>Inter: beforePhase(ctx, 'init')
+    Inter->>Poll: attachPoller — registers timer per Page
+    loop every 2s
+        Poll->>Detect: scan page.frames() for known URL patterns
+        Detect-->>Poll: Option<IWafChallenge>
+        alt challenge detected, not in cooldown, not already solving
+            Poll->>Solve: settle network → 5s hydration → click iframe centre
+            Solve-->>Poll: DidSolve(true|false)
+        end
+    end
+    Pipeline->>Inter: afterPipeline(ctx)
+    Inter->>Poll: detachPoller — clears timer
+```
+
+## Camoufox auto-pass recipe (why a single click works)
+
+The host scraper launches Camoufox with three knobs enabled (in `CamoufoxLauncher.ts`):
+
+| Knob | Purpose |
+|---|---|
+| `humanize: true` | C++-level curved cursor approach + jittered timing per click |
+| `disable_coop: true` | Iframe can postMessage its token back to the parent SPA |
+| `block_webrtc: true` | Closes the WebRTC fingerprint leak path many WAFs key off |
+
+With those three set, `page.mouse.click(centreX, centreY)` on the hCaptcha checkbox iframe is enough to emit a valid `h-captcha-response` token. The interceptor doesn't reinvent any of this — it just runs the documented Camoufox recipe at the right moment.
+
+## Detection rules
+
+| Provider | Detector matches when `frame.url()` contains... |
+|---|---|
+| hCaptcha checkbox | `hcaptcha.html#frame=checkbox` |
+| Cloudflare Turnstile checkbox | `challenges.cloudflare.com/cdn-cgi/challenge-platform` |
+
+> **Important:** hCaptcha mounts TWO iframes per widget — `#frame=checkbox` (visible, user-clickable) and `#frame=challenge` (the puzzle modal, hidden at `y = -9999` until the checkbox is clicked). Clicking the puzzle modal centre does NOT solve the challenge. The pattern deliberately excludes `#frame=challenge`. A regression test in `WafChallengeDetector.test.ts` pins this invariant.
+
+## Kill-switch
+
+If the interceptor causes a regression, disable it without rebuilding:
+
+```bash
+WAF_INTERCEPTOR_DISABLED=1 npm run my-scrape
+```
+
+- Accepted values: `1`, `true` (any case)
+- Any other value (including `yes`, `on`) leaves the interceptor active (strict allowlist)
+- Effective at the next pipeline-phase boundary
+
+The kill-switch is also useful for bisecting whether a future scrape regression is interceptor-related.
+
+## Telemetry
+
+Three `pino` debug-level events emit per solve attempt via `ctx.logger`:
+
+| Event | Payload | When |
+|---|---|---|
+| `waf.interceptor.attached` | `{event}` | First phase with a browser attaches the poller |
+| `waf.solve.start` | `{event, kind}` | Solver dispatch begins |
+| `waf.solve.done` | `{event, kind, didSolve}` | Solver returns |
+
+No PII flows through these events — only the `kind` enum (`hcaptcha-checkbox` / `turnstile-checkbox`) and the boolean outcome.
+
+## Lifecycle guarantees
+
+- **Idempotent attach:** `attachPoller` checks a `WeakSet<Page>` first — repeated calls (one per phase) never create duplicate timers
+- **Auto-detach on page close:** `wirePageClose` registers a `page.on('close')` listener that clears the timer — no leaked intervals when the page is gone
+- **Cool-down:** at most one click attempt per page per 8 s (`isInCooldown` predicate) — avoids hammering the WAF
+- **Solving mutex:** a `WeakSet<Page>` flag (`solving`) prevents two concurrent solver invocations on the same page
+- **Never fails the pipeline:** `runBeforePhase` and `runAfterPipeline` always return `succeed(ctx)` / `succeed(true)` — every failure inside the solver is contained
+
+## Failure mode → recovery (exhaustive)
+
+| Failure | Recovery |
+|---|---|
+| Solver throws | `runSolverGuarded` catches; returns `DidSolve(false)`; poller retries after cool-down |
+| Frame detaches mid-detect | Defensive `safeFrameUrl` returns empty string; frame skipped |
+| `frame.frameElement()` throws | `getFrameElement` returns `false` sentinel; solver returns `DidSolve(false)` |
+| `handle.boundingBox()` returns `null` or throws | `getBoundingBox` returns `false`; solver returns `DidSolve(false)` |
+| `page.mouse.click` throws (page closed during click) | `clickCentreSafe` catches; returns `DidSolve(false)` |
+| Page closes during poll | `wirePageClose` handler clears the timer; state collected by GC |
+| Browser not on context (`ctx.browser.has === false`) | `runBeforePhase` short-circuits; returns `succeed(ctx)` without attaching |
+| Kill-switch on | `isDisabled` reads env first; short-circuits to `succeed(ctx)` |
+
+## Implementation primitives
+
+`WafChallengeInternals.ts` exposes these helpers for unit-test isolation (they are NOT part of the consumer-facing surface — use `createWafChallengeInterceptor` for that):
+
+- `makeState` — builds a fresh per-instance `IInterceptorState` record with empty WeakSet/WeakMap holders
+- `attachPoller` — registers the `setInterval` timer + `wirePageClose` handler; idempotent
+- `detachPoller` — clears the interval + removes the timer entry from state
+- `buildIntervalHandler` — wraps async `tickOnce` in a sync `setInterval` callback
+- `wirePageClose` — registers `page.on('close', detachPoller)`
+- `tickOnce` — one detect+solve cycle; guards re-entrance and cool-down
+- `runSolverSafe` — looks up solver via registry; catches throws into `DidSolve(false)`
+- `runSolverGuarded` — marks page as solving, dispatches solver, logs outcome, releases mutex, records cool-down timestamp
+- `runBeforePhase` — the `IPipelineInterceptor.beforePhase` body
+- `runAfterPipeline` — the `IPipelineInterceptor.afterPipeline` body
+- `isDisabled` — reads `WAF_INTERCEPTOR_DISABLED` env var; returns branded `IsDisabled`
+- `isInCooldown` — compares `lastSolveAtMs` against the 8 s window; returns branded `IsInCooldown`
+
+## Extending — add a new challenge kind (Open/Closed)
+
+1. Add a member to the `WafChallengeKind` union in `WafChallengeTypes.ts` (e.g. `'arkose-funcaptcha'`)
+2. Add the URL pattern constant in `WafChallengeConfig.ts` (`as const` tuple)
+3. Create a new solver file (e.g. `ArkoseFunCaptchaSolver.ts`) implementing `WafChallengeSolver`
+4. Register `kind → solver` in `WafChallengeSolverRegistry.ts`
+5. Add a detector branch in `WafChallengeDetector.ts`
+
+**No edits required to:** `WafChallengeInterceptor.ts`, `WafChallengeInternals.ts`, `PipelineBuilderHelpers.ts`, or any existing solver. This is the OCP guarantee.
+
+## Source pointers
+
+| File | Role |
+|---|---|
+| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
+| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
+| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
+| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts
@@ -6,6 +6,7 @@
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import { createNetworkTraceLifecycleInterceptor } from '../../Interceptors/NetworkTraceLifecycleInterceptor.js';
 import { createPopupInterceptor } from '../../Interceptors/PopupInterceptor.js';
+import { createWafChallengeInterceptor } from '../../Interceptors/WafChallenge/WafChallengeInterceptor.js';
 import type { IPipelineInterceptor } from '../../Types/Interceptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { succeed } from '../../Types/Procedure.js';
@@ -43,6 +44,15 @@ function resolveTraceBoundaryPhase(state: IBuilderState): string {
 }
 
 /**
+ * Build the browser-bank interceptor list. Extracted so buildInterceptors
+ * stays under the per-fn line budget.
+ * @returns Initial interceptor list before optional trace-gate.
+ */
+function buildBrowserBaseInterceptors(): IPipelineInterceptor[] {
+  return [createWafChallengeInterceptor(), createPopupInterceptor()];
+}
+
+/**
  * Build interceptors for the descriptor. Browser banks always get the
  * network-trace lifecycle interceptor wired against the boundary
  * phase resolved from `state` so the discovery pool only contains
@@ -58,7 +68,7 @@ function buildInterceptors(
   boundary: string,
 ): readonly IPipelineInterceptor[] {
   if (!state.hasBrowser) return [];
-  const list: IPipelineInterceptor[] = [createPopupInterceptor()];
+  const list: IPipelineInterceptor[] = buildBrowserBaseInterceptors();
   if (boundary !== '') {
     const traceGate = createNetworkTraceLifecycleInterceptor(phaseNames, boundary);
     list.push(traceGate);

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts
@@ -90,6 +90,23 @@ async function clickCentre(page: Page, box: IFrameBox): Promise<true> {
 }
 
 /**
+ * Click the iframe centre defensively — swallows page.mouse.click rejections
+ * (detached page, navigation during click, etc.) into DidSolve(false) so the
+ * solver contract ("false on any step failure") is honoured.
+ * @param page - Playwright page.
+ * @param box - Iframe bounding box.
+ * @returns DidSolve(true) when the click resolves, DidSolve(false) on throw.
+ */
+async function clickCentreSafe(page: Page, box: IFrameBox): Promise<DidSolve> {
+  try {
+    await clickCentre(page, box);
+    return DID_SOLVE_TRUE;
+  } catch {
+    return DID_SOLVE_FALSE;
+  }
+}
+
+/**
  * Resolve the iframe bounding box defensively — wrapper over getBoundingBox
  * kept for symmetry with getFrameElement.
  * @param handle - Frame element handle.
@@ -111,12 +128,12 @@ async function solveHCaptchaCheckbox(args: ISolverArgs): Promise<DidSolve> {
   if (handle === false) return DID_SOLVE_FALSE;
   const box = await readBox(handle);
   if (box === false) return DID_SOLVE_FALSE;
-  await clickCentre(args.page, box);
-  return DID_SOLVE_TRUE;
+  return clickCentreSafe(args.page, box);
 }
 
 export {
   clickCentre,
+  clickCentreSafe,
   getBoundingBox,
   getFrameElement,
   readBox,

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts
@@ -1,0 +1,126 @@
+/**
+ * HCaptchaCheckboxSolver — solves the simple hCaptcha checkbox challenge
+ * using the documented Camoufox auto-pass recipe.
+ *
+ * Recipe (per https://camoufox.com/python/usage/ — "disable_coop" section):
+ *   1. Wait for `networkidle` — the challenge JS finishes its handshake.
+ *   2. Wait WAF_HYDRATION_WAIT_MS — gives the checkbox its hydration window.
+ *   3. Locate the iframe's bounding box on the parent page.
+ *   4. Click the iframe centre via page.mouse.click(x, y).
+ *
+ * Camoufox C++-level `humanize: true` (set in CamoufoxLauncher.ts) drives a
+ * curved cursor path with variable timing so hCaptcha's token oracle accepts
+ * the click as human. `disable_coop: true` ensures the iframe can postMessage
+ * its token back to the parent SPA after the click.
+ *
+ * Best-effort by contract: returns DidSolve(false) when any step fails —
+ * the interceptor will retry on the next poll tick.
+ */
+
+import type { ElementHandle, Frame, Page } from 'playwright-core';
+
+import { WAF_HYDRATION_WAIT_MS, WAF_NETWORK_IDLE_TIMEOUT_MS } from './WafChallengeConfig.js';
+import type { DidSolve, ISolverArgs } from './WafChallengeTypes.js';
+
+const DID_SOLVE_TRUE = true as DidSolve;
+const DID_SOLVE_FALSE = false as DidSolve;
+
+/**
+ * Wait for network idle, swallowing the timeout — a busy SPA may never
+ * truly idle but the iframe is still clickable.
+ * @param page - The Playwright page.
+ * @returns Always true once the wait resolves (timeout or idle).
+ */
+async function waitForSettle(page: Page): Promise<true> {
+  await page
+    .waitForLoadState('networkidle', { timeout: WAF_NETWORK_IDLE_TIMEOUT_MS })
+    .catch((): false => false);
+  await page.waitForTimeout(WAF_HYDRATION_WAIT_MS);
+  return true;
+}
+
+/**
+ * Get the iframe's <iframe> element handle defensively.
+ * @param frame - The challenge frame.
+ * @returns Some handle or false when the frame is detached.
+ */
+async function getFrameElement(frame: Frame): Promise<ElementHandle | false> {
+  try {
+    const handle = await frame.frameElement();
+    return handle;
+  } catch {
+    return false;
+  }
+}
+
+/** Bounding box returned by Playwright — duplicated here to avoid `any`. */
+interface IFrameBox {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Read the iframe's bounding box on the parent page, defensively.
+ * @param handle - Frame element handle.
+ * @returns The box or false when boundingBox() returns null/throws.
+ */
+async function getBoundingBox(handle: ElementHandle): Promise<IFrameBox | false> {
+  try {
+    const box = await handle.boundingBox();
+    return box ?? false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Click the centre of a bounding box via the page-level mouse (Camoufox
+ * humanize converts this into a curved cursor approach).
+ * @param page - Playwright page.
+ * @param box - Iframe bounding box.
+ * @returns True after the click resolves.
+ */
+async function clickCentre(page: Page, box: IFrameBox): Promise<true> {
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.click(x, y);
+  return true;
+}
+
+/**
+ * Resolve the iframe bounding box defensively — wrapper over getBoundingBox
+ * kept for symmetry with getFrameElement.
+ * @param handle - Frame element handle.
+ * @returns The box or false sentinel.
+ */
+async function readBox(handle: ElementHandle): Promise<IFrameBox | false> {
+  const box = await getBoundingBox(handle);
+  return box;
+}
+
+/**
+ * Run the documented Camoufox auto-pass recipe on a hCaptcha checkbox.
+ * @param args - Page + frame bundle from the interceptor.
+ * @returns DidSolve(true) on successful click, DidSolve(false) on any step failure.
+ */
+async function solveHCaptchaCheckbox(args: ISolverArgs): Promise<DidSolve> {
+  await waitForSettle(args.page);
+  const handle = await getFrameElement(args.frame);
+  if (handle === false) return DID_SOLVE_FALSE;
+  const box = await readBox(handle);
+  if (box === false) return DID_SOLVE_FALSE;
+  await clickCentre(args.page, box);
+  return DID_SOLVE_TRUE;
+}
+
+export {
+  clickCentre,
+  getBoundingBox,
+  getFrameElement,
+  readBox,
+  solveHCaptchaCheckbox,
+  waitForSettle,
+};
+export type { IFrameBox };

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.ts
@@ -1,0 +1,36 @@
+/**
+ * TurnstileCheckboxSolver — solves Cloudflare Turnstile's "managed
+ * checkbox" challenge using the same primitive as hCaptcha.
+ *
+ * Turnstile and hCaptcha share the exact same UX shape (iframe with a
+ * single checkbox) and the same Camoufox auto-pass recipe works for
+ * both:
+ *   1. networkidle settle
+ *   2. WAF_HYDRATION_WAIT_MS static wait for token oracle hydration
+ *   3. page.mouse.click(centreX, centreY) on the iframe
+ *
+ * We delegate to {@link solveHCaptchaCheckbox} rather than copy-paste —
+ * the only thing that varies between providers is the iframe URL
+ * pattern (handled by the detector), not the click primitive.
+ *
+ * Kept as a separate exported binding so the solver registry maps
+ * one kind → one named solver — a future Turnstile divergence
+ * (e.g. visible / interactive widget needing a drag) can be added
+ * here without touching the hCaptcha path.
+ */
+
+import { solveHCaptchaCheckbox } from './HCaptchaCheckboxSolver.js';
+import type { DidSolve, ISolverArgs } from './WafChallengeTypes.js';
+
+/**
+ * Solve a Cloudflare Turnstile checkbox via the shared checkbox primitive.
+ * @param args - Page + frame bundle from the interceptor.
+ * @returns Outcome from the underlying checkbox solver.
+ */
+async function solveTurnstileCheckbox(args: ISolverArgs): Promise<DidSolve> {
+  const outcome = await solveHCaptchaCheckbox(args);
+  return outcome;
+}
+
+export default solveTurnstileCheckbox;
+export { solveTurnstileCheckbox };

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.ts
@@ -32,12 +32,12 @@ const WAF_SOLVE_COOLDOWN_MS = 8000;
  * hidden until challenge required). We must only click the checkbox —
  * clicking the centre of the puzzle modal would not solve it. The
  * `#frame=checkbox` fragment is canonical in hCaptcha's hosted widget. */
-const HCAPTCHA_IFRAME_URL_PATTERNS: readonly string[] = ['hcaptcha.html#frame=checkbox'];
+const HCAPTCHA_IFRAME_URL_PATTERNS = ['hcaptcha.html#frame=checkbox'] as const;
 
 /** Cloudflare Turnstile challenge frame URL substrings. */
-const TURNSTILE_IFRAME_URL_PATTERNS: readonly string[] = [
+const TURNSTILE_IFRAME_URL_PATTERNS = [
   'challenges.cloudflare.com/cdn-cgi/challenge-platform',
-];
+] as const;
 
 /** Env var — set to '1' / 'true' to disable the interceptor (bisect / debug). */
 const WAF_INTERCEPTOR_DISABLED_ENV = 'WAF_INTERCEPTOR_DISABLED';

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.ts
@@ -1,0 +1,53 @@
+/**
+ * WafChallenge — tunable constants for the generic background WAF
+ * checkbox-challenge interceptor.
+ *
+ * Bank-agnostic + phase-agnostic by design: any browser-flow bank whose
+ * WAF (Imperva / Cloudflare) interleaves a hCaptcha or Turnstile checkbox
+ * challenge into the navigation flow benefits transparently.
+ *
+ * Default timings follow the documented Camoufox auto-pass recipe
+ * (camoufox.com/python/usage — "Avoiding the bot detection" section):
+ * settle network -> wait 5 s for challenge hydration -> single mouse
+ * click on the iframe centre. Camoufox C++ humanize handles the
+ * cursor approach + click timing so a real cookie/token is emitted.
+ */
+
+/** Polling interval (ms) — how often we scan for a freshly mounted challenge frame. */
+const WAF_POLL_INTERVAL_MS = 2000;
+
+/** Networkidle ceiling (ms) before we consider the page "settled enough" to click. */
+const WAF_NETWORK_IDLE_TIMEOUT_MS = 15000;
+
+/** Static settle (ms) after networkidle — lets the challenge JS finish bootstrapping. */
+const WAF_HYDRATION_WAIT_MS = 5000;
+
+/** Cool-down (ms) between solve attempts on the same frame to avoid hammering. */
+const WAF_SOLVE_COOLDOWN_MS = 8000;
+
+/** hCaptcha CHECKBOX iframe URL substring.
+ *
+ * <p>The widget renders TWO iframes: one with `#frame=checkbox` (visible,
+ * user-clickable) and one with `#frame=challenge` (the puzzle modal,
+ * hidden until challenge required). We must only click the checkbox —
+ * clicking the centre of the puzzle modal would not solve it. The
+ * `#frame=checkbox` fragment is canonical in hCaptcha's hosted widget. */
+const HCAPTCHA_IFRAME_URL_PATTERNS: readonly string[] = ['hcaptcha.html#frame=checkbox'];
+
+/** Cloudflare Turnstile challenge frame URL substrings. */
+const TURNSTILE_IFRAME_URL_PATTERNS: readonly string[] = [
+  'challenges.cloudflare.com/cdn-cgi/challenge-platform',
+];
+
+/** Env var — set to '1' / 'true' to disable the interceptor (bisect / debug). */
+const WAF_INTERCEPTOR_DISABLED_ENV = 'WAF_INTERCEPTOR_DISABLED';
+
+export {
+  HCAPTCHA_IFRAME_URL_PATTERNS,
+  TURNSTILE_IFRAME_URL_PATTERNS,
+  WAF_HYDRATION_WAIT_MS,
+  WAF_INTERCEPTOR_DISABLED_ENV,
+  WAF_NETWORK_IDLE_TIMEOUT_MS,
+  WAF_POLL_INTERVAL_MS,
+  WAF_SOLVE_COOLDOWN_MS,
+};

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts
@@ -1,0 +1,122 @@
+/**
+ * WafChallengeDetector — pure-function frame-URL classifier.
+ *
+ * Scans every frame on the page (top + nested iframes) and matches the URL
+ * against the provider URL substring tables in WafChallengeConfig.ts.
+ * Returns the first matching frame wrapped in an Option, or none() when no
+ * known challenge is mounted.
+ *
+ * Pure I/O wrappers are isolated (safeFrameUrl, listFramesSafe) so a frame
+ * whose underlying page is mid-navigation cannot throw upward into the
+ * polling loop.
+ */
+
+import type { Frame, Page } from 'playwright-core';
+
+import { none, type Option, some } from '../../Types/Option.js';
+import {
+  HCAPTCHA_IFRAME_URL_PATTERNS,
+  TURNSTILE_IFRAME_URL_PATTERNS,
+} from './WafChallengeConfig.js';
+import type { IWafChallenge, WafChallengeKind } from './WafChallengeTypes.js';
+
+/** Sentinel — distinguishable unmatched kind so callers branch on string equality. */
+const NO_KIND = '' as const;
+
+type ClassifiedKind = WafChallengeKind | typeof NO_KIND;
+
+/**
+ * Read frame.url() defensively — a detached / navigating frame can throw.
+ * @param frame - The Playwright frame.
+ * @returns The URL or empty string when the call fails.
+ */
+function safeFrameUrl(frame: Frame): string {
+  try {
+    return frame.url();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Check whether a frame's URL contains any of the provider's URL substrings.
+ * @param frame - The frame to inspect.
+ * @param patterns - Provider URL substring table.
+ * @returns True when a match is found.
+ */
+function frameMatches(frame: Frame, patterns: readonly string[]): boolean {
+  const url = safeFrameUrl(frame);
+  if (url === '') return false;
+  return patterns.some((pattern): boolean => url.includes(pattern));
+}
+
+/**
+ * Classify a frame against the registered provider URL tables.
+ * @param frame - Candidate frame.
+ * @returns The provider kind or NO_KIND when no provider matches.
+ */
+function classify(frame: Frame): ClassifiedKind {
+  if (frameMatches(frame, HCAPTCHA_IFRAME_URL_PATTERNS)) return 'hcaptcha-checkbox';
+  if (frameMatches(frame, TURNSTILE_IFRAME_URL_PATTERNS)) return 'turnstile-checkbox';
+  return NO_KIND;
+}
+
+/**
+ * Enumerate frames on the page defensively — a closed page throws.
+ * @param page - Playwright page.
+ * @returns Frame array or empty when page.frames() throws.
+ */
+function listFramesSafe(page: Page): readonly Frame[] {
+  try {
+    return page.frames();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Scan one frame and emit some({kind, frame}) on hit. Extracted from
+ * detectChallenge so the loop body has zero nested blocks (max-depth).
+ * @param frame - Candidate frame.
+ * @returns Some(challenge) on match, none() otherwise.
+ */
+function classifyOne(frame: Frame): Option<IWafChallenge> {
+  const kind = classify(frame);
+  if (kind === NO_KIND) return none();
+  return some<IWafChallenge>({ kind, frame });
+}
+
+/**
+ * Predicate — true when the option is Some.
+ * @param opt - Option to test.
+ * @returns True when opt.has is true.
+ */
+function isHit(opt: Option<IWafChallenge>): boolean {
+  return opt.has;
+}
+
+/**
+ * Scan every frame and return the first matching WAF challenge frame.
+ *
+ * <p>Top frame is scanned too — some banks render the challenge in the
+ * main document via document.write() before the SPA mounts.
+ *
+ * @param page - The Playwright page to scan.
+ * @returns some({ kind, frame }) on hit, none() otherwise.
+ */
+function detectChallenge(page: Page): Option<IWafChallenge> {
+  const frames = listFramesSafe(page);
+  const classified = frames.map(classifyOne);
+  const firstHit = classified.find(isHit);
+  return firstHit ?? none();
+}
+
+export {
+  classify,
+  classifyOne,
+  detectChallenge,
+  frameMatches,
+  isHit,
+  listFramesSafe,
+  safeFrameUrl,
+};

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts
@@ -1,0 +1,94 @@
+/**
+ * WafChallengeInterceptor — generic background WAF checkbox-challenge
+ * resolver.
+ *
+ * <p><b>What it solves</b>: When an Israeli bank's WAF (Imperva / Cloudflare)
+ * interleaves a hCaptcha or Turnstile checkbox challenge into the navigation
+ * flow, the scraper can no longer reach the login form. Manual solve is not
+ * an option for headless / CI. This interceptor watches every browser-flow
+ * pipeline run in the background and clicks the checkbox via Camoufox's
+ * documented C++-humanize auto-pass primitive.
+ *
+ * <p><b>Bank-agnostic, phase-agnostic by contract</b>: attached once at the
+ * first `beforePhase` call after the browser is launched and then polls
+ * autonomously on a {@link WAF_POLL_INTERVAL_MS} timer. Scrapers never
+ * await it — page interactions either succeed (challenge cleared in time)
+ * or retry, by which point the solver has cleared the gate.
+ *
+ * <p><b>Closure-based factory</b>: each `createWafChallengeInterceptor()`
+ * call returns a fresh instance with its own per-page state — matches
+ * the PopupInterceptor pattern. Safe for parallel scraper runs.
+ *
+ * <p><b>Disable switch</b>: set `WAF_INTERCEPTOR_DISABLED=1` (or `true`)
+ * to bypass the interceptor for bisecting / local debugging.
+ *
+ * <p>Internals are split into {@link "./WafChallengeInternals.js"} to keep
+ * both files under the Pipeline 150-line file cap.
+ */
+
+import type { IPipelineInterceptor } from '../../Types/Interceptor.js';
+import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { Procedure } from '../../Types/Procedure.js';
+import {
+  type IInterceptorState,
+  makeState,
+  runAfterPipeline,
+  runBeforePhase,
+} from './WafChallengeInternals.js';
+
+/**
+ * Wrap a synchronous value into a resolved Promise. Matches the pattern
+ * used by sibling interceptors (NetworkTraceLifecycle, Snapshot, Mock)
+ * to keep closures non-async while still returning the Promise shape
+ * that {@link IPipelineInterceptor} requires.
+ * @param value - Value to wrap.
+ * @returns A resolved Promise with the value.
+ */
+function wrapAsync<T>(value: T): Promise<T> {
+  return Promise.resolve(value);
+}
+
+/**
+ * Build the beforePhase handler closure. Emits a trace event with the
+ * upcoming phase name (satisfies `no-unused-vars` for nextPhase and
+ * adds useful diagnostics) before delegating to runBeforePhase.
+ * @param state - Per-instance interceptor state.
+ * @returns Async beforePhase handler matching IPipelineInterceptor.
+ */
+function buildBeforePhase(
+  state: IInterceptorState,
+): (ctx: IPipelineContext, nextPhase: string) => Promise<Procedure<IPipelineContext>> {
+  return (ctx: IPipelineContext, nextPhase: string): Promise<Procedure<IPipelineContext>> => {
+    ctx.logger.trace({ event: 'waf.beforePhase', phase: nextPhase });
+    const result = runBeforePhase(ctx, state);
+    return wrapAsync(result);
+  };
+}
+
+/**
+ * Build the afterPipeline handler closure.
+ * @param state - Per-instance interceptor state.
+ * @returns Async afterPipeline handler matching IPipelineInterceptor.
+ */
+function buildAfterPipeline(
+  state: IInterceptorState,
+): (ctx: IPipelineContext) => Promise<Procedure<boolean>> {
+  return (ctx: IPipelineContext): Promise<Procedure<boolean>> => {
+    const result = runAfterPipeline(ctx, state);
+    return wrapAsync(result);
+  };
+}
+
+/**
+ * Create a WafChallengeInterceptor with per-instance state.
+ * @returns IPipelineInterceptor that auto-solves checkbox WAF challenges.
+ */
+function createWafChallengeInterceptor(): IPipelineInterceptor {
+  const state = makeState();
+  const beforePhase = buildBeforePhase(state);
+  const afterPipeline = buildAfterPipeline(state);
+  return { name: 'waf-challenge', beforePhase, afterPipeline };
+}
+
+export default createWafChallengeInterceptor;
+export { buildAfterPipeline, buildBeforePhase, createWafChallengeInterceptor, wrapAsync };

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.ts
@@ -1,0 +1,233 @@
+/**
+ * WafChallenge — internal poller/solver primitives shared by the interceptor.
+ *
+ * <p>Extracted from WafChallengeInterceptor.ts to keep both files under the
+ * Pipeline 150-line cap. All exports are package-internal — only the
+ * factory in WafChallengeInterceptor.ts is meant to be consumed externally.
+ */
+
+import type { Frame, Page } from 'playwright-core';
+
+import type { Brand } from '../../Types/Brand.js';
+import type { ScraperLogger } from '../../Types/Debug.js';
+import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { Procedure } from '../../Types/Procedure.js';
+import { succeed } from '../../Types/Procedure.js';
+import {
+  WAF_INTERCEPTOR_DISABLED_ENV,
+  WAF_POLL_INTERVAL_MS,
+  WAF_SOLVE_COOLDOWN_MS,
+} from './WafChallengeConfig.js';
+import { detectChallenge } from './WafChallengeDetector.js';
+import { getSolver } from './WafChallengeSolverRegistry.js';
+import type { DidSolve, WafChallengeKind } from './WafChallengeTypes.js';
+
+type DidTickWork = Brand<boolean, 'DidTickWork'>;
+type DidAttach = Brand<boolean, 'DidAttach'>;
+type DidDetach = Brand<boolean, 'DidDetach'>;
+type IsEnabled = Brand<boolean, 'IsEnabled'>;
+type IsInCooldown = Brand<boolean, 'IsInCooldown'>;
+
+/** Per-instance state — closed over by the returned interceptor. */
+interface IInterceptorState {
+  readonly attached: WeakSet<Page>;
+  readonly timers: WeakMap<Page, NodeJS.Timeout>;
+  readonly solving: WeakSet<Page>;
+  readonly lastSolveAtMs: WeakMap<Page, number>;
+}
+
+/** Bundle handed into tick/attach helpers — keeps signatures short. */
+interface ITickArgs {
+  readonly page: Page;
+  readonly logger: ScraperLogger;
+  readonly state: IInterceptorState;
+}
+
+/** Bundle for solver dispatch. */
+interface ISolverDispatchArgs {
+  readonly tick: ITickArgs;
+  readonly kind: WafChallengeKind;
+  readonly frame: Frame;
+}
+
+/**
+ * Build a fresh per-instance state record.
+ * @returns Initial IInterceptorState with empty Weak collections.
+ */
+export function makeState(): IInterceptorState {
+  return {
+    attached: new WeakSet<Page>(),
+    timers: new WeakMap<Page, NodeJS.Timeout>(),
+    solving: new WeakSet<Page>(),
+    lastSolveAtMs: new WeakMap<Page, number>(),
+  };
+}
+
+/**
+ * Read the kill-switch env var.
+ * @returns IsEnabled(true) when the WAF interceptor is disabled by env.
+ */
+export function isDisabled(): IsEnabled {
+  const raw = process.env[WAF_INTERCEPTOR_DISABLED_ENV] ?? '';
+  const isOn = raw === '1' || raw.toLowerCase() === 'true';
+  return isOn as IsEnabled;
+}
+
+/**
+ * Whether `lastSolveAtMs` falls inside the cool-down window.
+ * @param state - Per-instance state.
+ * @param page - The page being polled.
+ * @returns IsInCooldown(true) when the previous solve was within WAF_SOLVE_COOLDOWN_MS.
+ */
+export function isInCooldown(state: IInterceptorState, page: Page): IsInCooldown {
+  const last = state.lastSolveAtMs.get(page) ?? 0;
+  const isWithin = Date.now() - last < WAF_SOLVE_COOLDOWN_MS;
+  return isWithin as IsInCooldown;
+}
+
+/**
+ * Safe wrapper over solver() that swallows runtime throws into DidSolve(false).
+ * @param args - Solver dispatch bundle.
+ * @returns DidSolve outcome from the solver, or false on throw.
+ */
+export async function runSolverSafe(args: ISolverDispatchArgs): Promise<DidSolve> {
+  const solver = getSolver(args.kind);
+  const solverArgs = { page: args.tick.page, frame: args.frame };
+  const outcome = await solver(solverArgs).catch((): DidSolve => false as DidSolve);
+  return outcome;
+}
+
+/**
+ * Mark page as solving, dispatch the right solver, log the outcome, release
+ * the solving flag, and record the cool-down timestamp.
+ * @param args - Solver dispatch bundle.
+ * @returns DidSolve outcome from the underlying solver.
+ */
+export async function runSolverGuarded(args: ISolverDispatchArgs): Promise<DidSolve> {
+  args.tick.state.solving.add(args.tick.page);
+  args.tick.logger.debug({ event: 'waf.solve.start', kind: args.kind });
+  const didSolve = await runSolverSafe(args);
+  args.tick.logger.debug({ event: 'waf.solve.done', kind: args.kind, didSolve });
+  const nowMs = Date.now();
+  args.tick.state.lastSolveAtMs.set(args.tick.page, nowMs);
+  args.tick.state.solving.delete(args.tick.page);
+  return didSolve;
+}
+
+/**
+ * Run one detect+solve cycle defensively.
+ * @param args - Page/logger/state bundle.
+ * @returns DidTickWork(true) iff a solve was attempted this tick.
+ */
+export async function tickOnce(args: ITickArgs): Promise<DidTickWork> {
+  if (args.state.solving.has(args.page)) return false as DidTickWork;
+  if (isInCooldown(args.state, args.page)) return false as DidTickWork;
+  const detected = detectChallenge(args.page);
+  if (!detected.has) return false as DidTickWork;
+  const dispatch: ISolverDispatchArgs = {
+    tick: args,
+    kind: detected.value.kind,
+    frame: detected.value.frame,
+  };
+  await runSolverGuarded(dispatch);
+  return true as DidTickWork;
+}
+
+/**
+ * Build the interval handler — wraps async tick in a sync callback for setInterval.
+ * @param args - Tick bundle.
+ * @returns Synchronous handler safe for setInterval.
+ */
+export function buildIntervalHandler(args: ITickArgs): () => true {
+  return (): true => {
+    tickOnce(args).catch((): false => false);
+    return true;
+  };
+}
+
+/**
+ * Stop polling and forget the timer handle for a page.
+ * @param page - The page whose poller should stop.
+ * @param state - Per-instance state.
+ * @returns DidDetach(true) iff a timer was actually cleared.
+ */
+export function detachPoller(page: Page, state: IInterceptorState): DidDetach {
+  const timer = state.timers.get(page);
+  if (!timer) return false as DidDetach;
+  clearInterval(timer);
+  state.timers.delete(page);
+  return true as DidDetach;
+}
+
+/**
+ * Register page-close cleanup so the timer never outlives the page.
+ * @param args - Tick bundle.
+ * @returns True after the listener is registered.
+ */
+export function wirePageClose(args: ITickArgs): true {
+  /**
+   * Page `close` event listener — clears the polling interval.
+   * @returns DidDetach outcome from detachPoller.
+   */
+  const onClose = (): DidDetach => detachPoller(args.page, args.state);
+  args.page.on('close', onClose);
+  return true;
+}
+
+/**
+ * Wire the polling loop + page-close cleanup. Idempotent via attached set.
+ * @param args - Tick bundle.
+ * @returns DidAttach(true) iff this call actually attached (false if reused).
+ */
+export function attachPoller(args: ITickArgs): DidAttach {
+  if (args.state.attached.has(args.page)) return false as DidAttach;
+  args.state.attached.add(args.page);
+  const handler = buildIntervalHandler(args);
+  const timer = setInterval(handler, WAF_POLL_INTERVAL_MS);
+  args.state.timers.set(args.page, timer);
+  handler();
+  wirePageClose(args);
+  args.logger.debug({ event: 'waf.interceptor.attached' });
+  return true as DidAttach;
+}
+
+/**
+ * beforePhase implementation — attach the poller (once) when browser is available.
+ * @param ctx - Pipeline context.
+ * @param state - Per-instance state.
+ * @returns Always succeed(ctx) — interceptor never fails the pipeline.
+ */
+export function runBeforePhase(
+  ctx: IPipelineContext,
+  state: IInterceptorState,
+): Procedure<IPipelineContext> {
+  if (isDisabled()) return succeed(ctx);
+  if (!ctx.browser.has) return succeed(ctx);
+  const tick: ITickArgs = { page: ctx.browser.value.page, logger: ctx.logger, state };
+  attachPoller(tick);
+  return succeed(ctx);
+}
+
+/**
+ * afterPipeline implementation — detach the poller before browser cleanup.
+ * @param ctx - Pipeline context.
+ * @param state - Per-instance state.
+ * @returns Always succeed(true).
+ */
+export function runAfterPipeline(
+  ctx: IPipelineContext,
+  state: IInterceptorState,
+): Procedure<boolean> {
+  if (ctx.browser.has) detachPoller(ctx.browser.value.page, state);
+  return succeed(true);
+}
+
+export type {
+  DidAttach,
+  DidDetach,
+  DidTickWork,
+  IInterceptorState,
+  IsInCooldown,
+  ISolverDispatchArgs,
+  ITickArgs,
+};

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.ts
@@ -25,7 +25,7 @@ import type { DidSolve, WafChallengeKind } from './WafChallengeTypes.js';
 type DidTickWork = Brand<boolean, 'DidTickWork'>;
 type DidAttach = Brand<boolean, 'DidAttach'>;
 type DidDetach = Brand<boolean, 'DidDetach'>;
-type IsEnabled = Brand<boolean, 'IsEnabled'>;
+type IsDisabled = Brand<boolean, 'IsDisabled'>;
 type IsInCooldown = Brand<boolean, 'IsInCooldown'>;
 
 /** Per-instance state — closed over by the returned interceptor. */
@@ -65,12 +65,12 @@ export function makeState(): IInterceptorState {
 
 /**
  * Read the kill-switch env var.
- * @returns IsEnabled(true) when the WAF interceptor is disabled by env.
+ * @returns IsDisabled(true) when the WAF interceptor is disabled by env.
  */
-export function isDisabled(): IsEnabled {
+export function isDisabled(): IsDisabled {
   const raw = process.env[WAF_INTERCEPTOR_DISABLED_ENV] ?? '';
   const isOn = raw === '1' || raw.toLowerCase() === 'true';
-  return isOn as IsEnabled;
+  return isOn as IsDisabled;
 }
 
 /**

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeSolverRegistry.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeSolverRegistry.ts
@@ -1,0 +1,37 @@
+/**
+ * WafChallengeSolverRegistry — maps WafChallengeKind to its solver.
+ *
+ * SOLID/OCP: adding a new provider means appending one entry — zero edits
+ * to the interceptor or detector files. The map is built as a frozen
+ * `Record<WafChallengeKind, WafChallengeSolver>` so TypeScript's
+ * exhaustiveness check enforces "every kind has a solver" at compile time.
+ */
+
+import { solveHCaptchaCheckbox } from './HCaptchaCheckboxSolver.js';
+import { solveTurnstileCheckbox } from './TurnstileCheckboxSolver.js';
+import type { WafChallengeKind, WafChallengeSolver } from './WafChallengeTypes.js';
+
+/**
+ * Provider-kind -> solver-function registry. Frozen so a misbehaving
+ * caller cannot mutate the global mapping at runtime.
+ */
+const SOLVER_REGISTRY: Readonly<Record<WafChallengeKind, WafChallengeSolver>> = Object.freeze({
+  'hcaptcha-checkbox': solveHCaptchaCheckbox,
+  'turnstile-checkbox': solveTurnstileCheckbox,
+});
+
+/**
+ * Resolve a solver for a given kind.
+ *
+ * <p>The exhaustive `Record<WafChallengeKind, …>` typing guarantees the
+ * lookup always succeeds — callers receive a concrete function, never
+ * undefined.
+ *
+ * @param kind - Provider/interaction kind from detection.
+ * @returns The matching solver function.
+ */
+function getSolver(kind: WafChallengeKind): WafChallengeSolver {
+  return SOLVER_REGISTRY[kind];
+}
+
+export { getSolver, SOLVER_REGISTRY };

--- a/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeTypes.ts
+++ b/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeTypes.ts
@@ -1,0 +1,40 @@
+/**
+ * WafChallenge — type contracts for the generic WAF challenge interceptor.
+ *
+ * Discriminated by `kind` so the solver registry can be a pure map lookup
+ * (Open/Closed). Adding a new provider (Arkose, GeeTest) means registering
+ * a new kind + solver pair — zero edits to the detection or attachment flow.
+ */
+
+import type { Frame, Page } from 'playwright-core';
+
+import type { Brand } from '../../Types/Brand.js';
+
+/**
+ * Provider + interaction primitive identifier.
+ *
+ * <p>Simple checkbox auto-pass is the only documented Camoufox primitive
+ * (`disable_coop + humanize + mouse.click`). Image / audio challenges are
+ * out of scope — they require a third-party solver service.
+ */
+type WafChallengeKind = 'hcaptcha-checkbox' | 'turnstile-checkbox';
+
+/** Detected challenge — provider + reference to the iframe containing it. */
+interface IWafChallenge {
+  readonly kind: WafChallengeKind;
+  readonly frame: Frame;
+}
+
+/** Solver outcome — branded boolean keeps Procedure-style call sites strict. */
+type DidSolve = Brand<boolean, 'DidSolve'>;
+
+/** Inputs handed to every solver — page is needed for `mouse.click`. */
+interface ISolverArgs {
+  readonly page: Page;
+  readonly frame: Frame;
+}
+
+/** Solver function signature — all solvers are async and return DidSolve. */
+type WafChallengeSolver = (args: ISolverArgs) => Promise<DidSolve>;
+
+export type { DidSolve, ISolverArgs, IWafChallenge, WafChallengeKind, WafChallengeSolver };

--- a/src/Tests/Unit/Pipeline/Architecture/LayerSeparationArchitecture.test.ts
+++ b/src/Tests/Unit/Pipeline/Architecture/LayerSeparationArchitecture.test.ts
@@ -913,6 +913,9 @@ describe('TIMING mission — R-NO-FIXED-WAIT-15S: no new 15s fixed-wait constant
  *   <li>`Interceptors/SnapshotFrameCapture.ts` /
  *       `Interceptors/SnapshotInterceptorIO.ts` — snapshot-capture
  *       infrastructure outside the phase pipeline.</li>
+ *   <li>`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts` — Camoufox
+ *       auto-pass recipe waits on networkidle inside its own iframe-bound
+ *       solver, not in any phase action.</li>
  * </ul>
  */
 const DIRECT_LOAD_STATE_ALLOWLIST: readonly string[] = [
@@ -920,6 +923,7 @@ const DIRECT_LOAD_STATE_ALLOWLIST: readonly string[] = [
   path.join('Mediator', 'Elements', 'CreateElementMediator.ts'),
   path.join('Interceptors', 'SnapshotFrameCapture.ts'),
   path.join('Interceptors', 'SnapshotInterceptorIO.ts'),
+  path.join('Interceptors', 'WafChallenge', 'HCaptchaCheckboxSolver.ts'),
 ];
 
 /** Match `<expr>.waitForLoadState(` invocations in source code. */

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for HCaptchaCheckboxSolver — Camoufox auto-pass recipe.
+ *
+ * <p>Drives the solver with mock Page/Frame/ElementHandle stubs and asserts:
+ * (a) networkidle wait is requested with the documented timeout,
+ * (b) static hydration wait fires AFTER the network settle,
+ * (c) click lands at the centre of the iframe bounding box,
+ * (d) all defensive branches downgrade to DidSolve(false) instead of throwing.
+ */
+
+import type { ElementHandle, Frame, Page } from 'playwright-core';
+
+import {
+  clickCentre,
+  getBoundingBox,
+  getFrameElement,
+  type IFrameBox,
+  readBox,
+  solveHCaptchaCheckbox,
+  waitForSettle,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.js';
+import {
+  WAF_HYDRATION_WAIT_MS,
+  WAF_NETWORK_IDLE_TIMEOUT_MS,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
+
+interface IMockCall {
+  readonly name: string;
+  readonly args: readonly unknown[];
+}
+
+interface IMockPage {
+  readonly page: Page;
+  readonly calls: IMockCall[];
+}
+
+interface IPageOptions {
+  readonly waitForLoadStateThrows?: boolean;
+}
+
+/**
+ * Build a Page mock that records every interesting call for later assertion.
+ * @param opts - Behavioural toggles for failure paths.
+ * @returns IMockPage with shared call log.
+ */
+function makeMockPage(opts: IPageOptions = {}): IMockPage {
+  const calls: IMockCall[] = [];
+  const page = {
+    /**
+     * Mock waitForLoadState — records the call, throws or resolves per opts.
+     * @param state - Load state ('networkidle').
+     * @param options - Wait options.
+     * @returns Resolved promise.
+     */
+    waitForLoadState: (state: string, options: unknown): Promise<void> => {
+      calls.push({ name: 'waitForLoadState', args: [state, options] });
+      if (opts.waitForLoadStateThrows === true)
+        return Promise.reject(new TypeError('idle-timeout'));
+      return Promise.resolve();
+    },
+    /**
+     * Mock waitForTimeout — records the call.
+     * @param ms - Wait duration.
+     * @returns Immediately resolved promise.
+     */
+    waitForTimeout: (ms: number): Promise<void> => {
+      calls.push({ name: 'waitForTimeout', args: [ms] });
+      return Promise.resolve();
+    },
+    mouse: {
+      /**
+       * Mock mouse.click — records click coordinates.
+       * @param x - Click X.
+       * @param y - Click Y.
+       * @returns Immediately resolved promise.
+       */
+      click: (x: number, y: number): Promise<void> => {
+        calls.push({ name: 'mouse.click', args: [x, y] });
+        return Promise.resolve();
+      },
+    },
+  };
+  return { page: page as unknown as Page, calls };
+}
+
+/**
+ * Build an ElementHandle stub whose boundingBox resolves with the given box.
+ * @param box - The box to return.
+ * @returns A handle-shaped mock.
+ */
+function makeHandle(box: IFrameBox): ElementHandle {
+  return {
+    /**
+     * Mock boundingBox — resolves with the configured box.
+     * @returns The configured box value.
+     */
+    boundingBox: (): Promise<IFrameBox> => Promise.resolve(box),
+  } as unknown as ElementHandle;
+}
+
+/**
+ * Build an ElementHandle stub whose boundingBox resolves with the null sentinel.
+ * @returns A handle-shaped mock.
+ */
+function makeNullBoxHandle(): ElementHandle {
+  return {
+    /**
+     * Mock boundingBox — resolves with null (simulating Playwright's detached case).
+     * Return type is inferred so the rule banning `null` in annotations stays quiet.
+     * @returns Resolved promise with the null marker.
+     */
+    boundingBox: () => {
+      const noBox = null as unknown as IFrameBox;
+      return Promise.resolve(noBox);
+    },
+  } as unknown as ElementHandle;
+}
+
+/**
+ * Build an ElementHandle stub whose boundingBox always rejects.
+ * @returns A handle-shaped mock.
+ */
+function makeThrowingHandle(): ElementHandle {
+  return {
+    /**
+     * Mock boundingBox — always rejects.
+     * @returns Rejected promise with a typed error.
+     */
+    boundingBox: (): Promise<IFrameBox> => Promise.reject(new TypeError('detached-test')),
+  } as unknown as ElementHandle;
+}
+
+/**
+ * Build a Frame stub whose frameElement resolves with the given handle.
+ * @param handle - The element handle to return.
+ * @returns A Frame-shaped mock.
+ */
+function makeFrame(handle: ElementHandle): Frame {
+  return {
+    /**
+     * Mock frameElement — resolves with the configured handle.
+     * @returns Element handle for the iframe.
+     */
+    frameElement: (): Promise<ElementHandle> => Promise.resolve(handle),
+  } as unknown as Frame;
+}
+
+/**
+ * Build a Frame stub whose frameElement always rejects.
+ * @returns A Frame-shaped mock.
+ */
+function makeThrowingFrame(): Frame {
+  return {
+    /**
+     * Mock frameElement — always rejects.
+     * @returns Rejected promise with a typed error.
+     */
+    frameElement: (): Promise<ElementHandle> => Promise.reject(new TypeError('detached-test')),
+  } as unknown as Frame;
+}
+
+/**
+ * Mock-call name extractor — kept top-level for naming-convention rules.
+ * @param c - Mock call record.
+ * @returns The call name.
+ */
+function nameOf(c: IMockCall): string {
+  return c.name;
+}
+
+describe('HCaptchaCheckboxSolver.waitForSettle', () => {
+  it('requests networkidle with WAF_NETWORK_IDLE_TIMEOUT_MS', async () => {
+    const m = makeMockPage();
+    await waitForSettle(m.page);
+    const firstCall = m.calls[0];
+    expect(firstCall).toEqual({
+      name: 'waitForLoadState',
+      args: ['networkidle', { timeout: WAF_NETWORK_IDLE_TIMEOUT_MS }],
+    });
+  });
+
+  it('always waits the documented hydration window after settle', async () => {
+    const m = makeMockPage();
+    await waitForSettle(m.page);
+    const secondCall = m.calls[1];
+    expect(secondCall).toEqual({ name: 'waitForTimeout', args: [WAF_HYDRATION_WAIT_MS] });
+  });
+
+  it('swallows networkidle timeout and still hydrates', async () => {
+    const m = makeMockPage({ waitForLoadStateThrows: true });
+    await waitForSettle(m.page);
+    const names = m.calls.map(nameOf);
+    expect(names).toEqual(['waitForLoadState', 'waitForTimeout']);
+  });
+});
+
+describe('HCaptchaCheckboxSolver.getFrameElement', () => {
+  it('returns the handle when frameElement resolves', async () => {
+    const handle = makeHandle({ x: 0, y: 0, width: 10, height: 10 });
+    const frame = makeFrame(handle);
+    const result = await getFrameElement(frame);
+    expect(result).toBe(handle);
+  });
+
+  it('returns false sentinel when frameElement throws', async () => {
+    const frame = makeThrowingFrame();
+    const result = await getFrameElement(frame);
+    expect(result).toBe(false);
+  });
+});
+
+describe('HCaptchaCheckboxSolver.getBoundingBox', () => {
+  it('returns the box when boundingBox resolves', async () => {
+    const handle = makeHandle({ x: 1, y: 2, width: 3, height: 4 });
+    const box1 = await getBoundingBox(handle);
+    const box2 = await readBox(handle);
+    expect(box1).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+    expect(box2).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it('returns false when boundingBox returns null', async () => {
+    const handle = makeNullBoxHandle();
+    const result = await getBoundingBox(handle);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when boundingBox throws', async () => {
+    const handle = makeThrowingHandle();
+    const result = await getBoundingBox(handle);
+    expect(result).toBe(false);
+  });
+});
+
+describe('HCaptchaCheckboxSolver.clickCentre', () => {
+  it('clicks the geometric centre of the box', async () => {
+    const m = makeMockPage();
+    await clickCentre(m.page, { x: 10, y: 20, width: 100, height: 60 });
+    const click = m.calls[0];
+    expect(click).toEqual({ name: 'mouse.click', args: [60, 50] });
+  });
+});
+
+const CLICK_NAME = 'mouse.click';
+/**
+ * Predicate — true when the mock call is a mouse.click.
+ * @param c - Mock call record.
+ * @returns True when the call name is "mouse.click".
+ */
+function isClick(c: IMockCall): boolean {
+  return c.name === CLICK_NAME;
+}
+
+describe('HCaptchaCheckboxSolver.solveHCaptchaCheckbox', () => {
+  it('runs the full recipe and returns DidSolve(true) on success', async () => {
+    const m = makeMockPage();
+    const handle = makeHandle({ x: 0, y: 0, width: 200, height: 100 });
+    const frame = makeFrame(handle);
+    const result = await solveHCaptchaCheckbox({ page: m.page, frame });
+    const names = m.calls.map(nameOf);
+    expect(result).toBe(true);
+    expect(names).toEqual(['waitForLoadState', 'waitForTimeout', 'mouse.click']);
+  });
+
+  it('downgrades to DidSolve(false) when frameElement throws', async () => {
+    const m = makeMockPage();
+    const frame = makeThrowingFrame();
+    const result = await solveHCaptchaCheckbox({ page: m.page, frame });
+    expect(result).toBe(false);
+  });
+
+  it('downgrades to DidSolve(false) when boundingBox returns null', async () => {
+    const m = makeMockPage();
+    const handle = makeNullBoxHandle();
+    const frame = makeFrame(handle);
+    const result = await solveHCaptchaCheckbox({ page: m.page, frame });
+    expect(result).toBe(false);
+  });
+
+  it('clicks the centre at width/2 + x, height/2 + y', async () => {
+    const m = makeMockPage();
+    const handle = makeHandle({ x: 100, y: 50, width: 80, height: 40 });
+    const frame = makeFrame(handle);
+    await solveHCaptchaCheckbox({ page: m.page, frame });
+    const click = m.calls.find(isClick);
+    const args = click?.args ?? [];
+    expect(args).toEqual([140, 70]);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for TurnstileCheckboxSolver — shared-primitive delegation.
+ */
+
+import type { ElementHandle, Frame, Page } from 'playwright-core';
+
+import { solveHCaptchaCheckbox } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.js';
+import solveTurnstileCheckboxDefault, {
+  solveTurnstileCheckbox,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.js';
+
+interface IFrameBox {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+describe('TurnstileCheckboxSolver.exports', () => {
+  it('is exported as both default and named binding', () => {
+    expect(solveTurnstileCheckboxDefault).toBe(solveTurnstileCheckbox);
+  });
+
+  it('is callable as an async function with arity 1', () => {
+    const kind = typeof solveTurnstileCheckbox;
+    expect(kind).toBe('function');
+    expect(solveTurnstileCheckbox.length).toBe(1);
+  });
+
+  it('does NOT alias to solveHCaptchaCheckbox (registry keeps one kind \u2192 one solver)', () => {
+    expect(solveTurnstileCheckbox).not.toBe(solveHCaptchaCheckbox);
+  });
+
+  it('delegates to solveHCaptchaCheckbox and returns its outcome', async () => {
+    const calls: string[] = [];
+    const page = {
+      /**
+       * Mock waitForLoadState — records the call.
+       * @returns Resolved void.
+       */
+      waitForLoadState: (): Promise<void> => {
+        calls.push('waitForLoadState');
+        return Promise.resolve();
+      },
+      /**
+       * Mock waitForTimeout — records the call.
+       * @returns Resolved void.
+       */
+      waitForTimeout: (): Promise<void> => {
+        calls.push('waitForTimeout');
+        return Promise.resolve();
+      },
+      mouse: {
+        /**
+         * Mock mouse.click — records the call.
+         * @returns Resolved void.
+         */
+        click: (): Promise<void> => {
+          calls.push('mouse.click');
+          return Promise.resolve();
+        },
+      },
+    } as unknown as Page;
+    const handle = {
+      /**
+       * Mock boundingBox — returns a fixed box.
+       * @returns Resolved IFrameBox.
+       */
+      boundingBox: (): Promise<IFrameBox> =>
+        Promise.resolve({ x: 0, y: 0, width: 20, height: 20 } as IFrameBox),
+    } as unknown as ElementHandle;
+    const frame = {
+      /**
+       * Mock frameElement — returns the configured handle.
+       * @returns Resolved ElementHandle.
+       */
+      frameElement: (): Promise<ElementHandle> => Promise.resolve(handle),
+    } as unknown as Frame;
+    const result = await solveTurnstileCheckbox({ page, frame });
+    expect(result).toBe(true);
+    expect(calls).toEqual(['waitForLoadState', 'waitForTimeout', 'mouse.click']);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for WafChallengeConfig — pinned constants + frozen env contract.
+ *
+ * <p>This is a canary: the configured timings and URL patterns are the
+ * documented Camoufox auto-pass recipe. Silently relaxing them (e.g.
+ * dropping the hydration wait to 0) would silently regress the WAF
+ * interceptor on every bank using hCaptcha or Turnstile.
+ */
+
+import {
+  HCAPTCHA_IFRAME_URL_PATTERNS,
+  TURNSTILE_IFRAME_URL_PATTERNS,
+  WAF_HYDRATION_WAIT_MS,
+  WAF_INTERCEPTOR_DISABLED_ENV,
+  WAF_NETWORK_IDLE_TIMEOUT_MS,
+  WAF_POLL_INTERVAL_MS,
+  WAF_SOLVE_COOLDOWN_MS,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
+
+describe('WafChallengeConfig', () => {
+  it('pins the documented Camoufox hydration wait at 5s', () => {
+    expect(WAF_HYDRATION_WAIT_MS).toBe(5000);
+  });
+
+  it('pins networkidle ceiling at 15s', () => {
+    expect(WAF_NETWORK_IDLE_TIMEOUT_MS).toBe(15000);
+  });
+
+  it('keeps poll interval responsive (≤2s)', () => {
+    expect(WAF_POLL_INTERVAL_MS).toBeLessThanOrEqual(2000);
+  });
+
+  it('keeps solve cool-down above hydration wait to avoid double-fire', () => {
+    expect(WAF_SOLVE_COOLDOWN_MS).toBeGreaterThan(WAF_HYDRATION_WAIT_MS);
+  });
+
+  it('exposes the disable-env name as a stable string', () => {
+    expect(WAF_INTERCEPTOR_DISABLED_ENV).toBe('WAF_INTERCEPTOR_DISABLED');
+  });
+
+  it('matches only the canonical hCaptcha CHECKBOX iframe (frame=checkbox fragment) and NOT the puzzle modal', () => {
+    expect(HCAPTCHA_IFRAME_URL_PATTERNS).toContain('hcaptcha.html#frame=checkbox');
+  });
+
+  it('does not match the hCaptcha challenge (puzzle) iframe — clicking it would not solve', () => {
+    const challengeUrl = 'hcaptcha.html#frame=challenge';
+    const isMatched = HCAPTCHA_IFRAME_URL_PATTERNS.some((p): boolean => challengeUrl.includes(p));
+    expect(isMatched).toBe(false);
+  });
+
+  it('matches the Cloudflare Turnstile platform substring', () => {
+    expect(TURNSTILE_IFRAME_URL_PATTERNS).toContain(
+      'challenges.cloudflare.com/cdn-cgi/challenge-platform',
+    );
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for WafChallengeDetector — frame URL classification.
+ *
+ * <p>Drives the detector with mock Frame/Page objects to assert the
+ * provider-routing decision table without spinning up a real browser.
+ */
+
+import type { Frame, Page } from 'playwright-core';
+
+import {
+  classify,
+  classifyOne,
+  detectChallenge,
+  frameMatches,
+  isHit,
+  listFramesSafe,
+  safeFrameUrl,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.js';
+
+const THROW_SENTINEL = '__throw__';
+
+/**
+ * Factory — build a Frame stub with the given URL behaviour.
+ * @param url - URL the stub returns, or THROW_SENTINEL to simulate detached.
+ * @returns A Frame-shaped mock for the detector.
+ */
+function makeFrameStub(url: string): Frame {
+  return {
+    /**
+     * Mock url() — returns the configured string or throws.
+     * @returns Stubbed URL string.
+     */
+    url: (): string => {
+      if (url === THROW_SENTINEL) throw new TypeError('detached-test');
+      return url;
+    },
+  } as unknown as Frame;
+}
+
+/**
+ * Factory — build a Page stub whose frames() returns the given frames.
+ * @param frames - Frames to return from page.frames().
+ * @returns A Page-shaped mock for the detector.
+ */
+function makePageStub(frames: readonly Frame[]): Page {
+  return {
+    /**
+     * Mock frames() — returns the configured array.
+     * @returns Stubbed frame list.
+     */
+    frames: (): readonly Frame[] => frames,
+  } as unknown as Page;
+}
+
+/**
+ * Factory — build a Page stub whose frames() throws (closed page).
+ * @returns A Page-shaped mock that simulates a closed page.
+ */
+function makeClosedPageStub(): Page {
+  return {
+    /**
+     * Mock frames() — throws to simulate a closed page.
+     * @returns Never (throws).
+     */
+    frames: (): readonly Frame[] => {
+      throw new TypeError('closed-test');
+    },
+  } as unknown as Page;
+}
+
+describe('WafChallengeDetector.safeFrameUrl', () => {
+  it('returns the URL when the frame is healthy', () => {
+    const f = makeFrameStub('https://example.com');
+    const url = safeFrameUrl(f);
+    expect(url).toBe('https://example.com');
+  });
+
+  it('returns empty string when frame.url() throws', () => {
+    const f = makeFrameStub(THROW_SENTINEL);
+    const url = safeFrameUrl(f);
+    expect(url).toBe('');
+  });
+});
+
+describe('WafChallengeDetector.frameMatches', () => {
+  it('returns true when URL contains a pattern', () => {
+    const f = makeFrameStub('https://hcaptcha.com/captcha?x=1');
+    const isMatched = frameMatches(f, ['hcaptcha.com/captcha']);
+    expect(isMatched).toBe(true);
+  });
+
+  it('returns false when no pattern matches', () => {
+    const f = makeFrameStub('https://example.com');
+    const isMatched = frameMatches(f, ['hcaptcha.com/captcha']);
+    expect(isMatched).toBe(false);
+  });
+
+  it('returns false when frame URL is empty', () => {
+    const f = makeFrameStub(THROW_SENTINEL);
+    const isMatched = frameMatches(f, ['hcaptcha.com']);
+    expect(isMatched).toBe(false);
+  });
+});
+
+describe('WafChallengeDetector.classify', () => {
+  it('returns "hcaptcha-checkbox" for the canonical hCaptcha checkbox iframe URL', () => {
+    const f = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=foo',
+    );
+    const kind = classify(f);
+    expect(kind).toBe('hcaptcha-checkbox');
+  });
+
+  it('returns the NO_KIND sentinel for the hCaptcha challenge (puzzle) iframe — we never click puzzles', () => {
+    const f = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=challenge&id=foo',
+    );
+    const kind = classify(f);
+    expect(kind).toBe('');
+  });
+
+  it('returns "turnstile-checkbox" for Cloudflare Turnstile URLs', () => {
+    const f = makeFrameStub('https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/v1/x');
+    const kind = classify(f);
+    expect(kind).toBe('turnstile-checkbox');
+  });
+
+  it('returns the NO_KIND sentinel for unrelated URLs', () => {
+    const f = makeFrameStub('https://bank.example.com/login');
+    const kind = classify(f);
+    expect(kind).toBe('');
+  });
+});
+
+describe('WafChallengeDetector.classifyOne', () => {
+  it('emits Some on a recognised challenge iframe', () => {
+    const f = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=xyz',
+    );
+    const result = classifyOne(f);
+    expect(result.has).toBe(true);
+    if (result.has) {
+      expect(result.value.kind).toBe('hcaptcha-checkbox');
+      expect(result.value.frame).toBe(f);
+    }
+  });
+
+  it('emits None on an unrecognised frame', () => {
+    const f = makeFrameStub('https://example.com');
+    const result = classifyOne(f);
+    expect(result.has).toBe(false);
+  });
+});
+
+describe('WafChallengeDetector.isHit', () => {
+  it('returns true when option is Some', () => {
+    const f = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox',
+    );
+    const opt = classifyOne(f);
+    const wasHit = isHit(opt);
+    expect(wasHit).toBe(true);
+  });
+
+  it('returns false when option is None', () => {
+    const f = makeFrameStub('https://example.com');
+    const opt = classifyOne(f);
+    const wasHit = isHit(opt);
+    expect(wasHit).toBe(false);
+  });
+});
+
+describe('WafChallengeDetector.listFramesSafe', () => {
+  it('returns the frame list when page is healthy', () => {
+    const f = makeFrameStub('https://example.com');
+    const page = makePageStub([f]);
+    const list = listFramesSafe(page);
+    expect(list).toEqual([f]);
+  });
+
+  it('returns empty array when frames() throws', () => {
+    const page = makeClosedPageStub();
+    const list = listFramesSafe(page);
+    expect(list).toEqual([]);
+  });
+});
+
+describe('WafChallengeDetector.detectChallenge', () => {
+  it('returns Some on a page with an hCaptcha iframe', () => {
+    const hit = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=foo',
+    );
+    const benign = makeFrameStub('https://bank.example.com/login');
+    const page = makePageStub([benign, hit]);
+    const result = detectChallenge(page);
+    expect(result.has).toBe(true);
+    if (result.has) expect(result.value.kind).toBe('hcaptcha-checkbox');
+  });
+
+  it('skips the hCaptcha puzzle iframe and only returns the checkbox iframe', () => {
+    const puzzle = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=challenge&id=foo',
+    );
+    const checkbox = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=foo',
+    );
+    const page = makePageStub([puzzle, checkbox]);
+    const result = detectChallenge(page);
+    expect(result.has).toBe(true);
+    if (result.has) expect(result.value.frame).toBe(checkbox);
+  });
+
+  it('returns Some on a page with a Turnstile iframe', () => {
+    const hit = makeFrameStub('https://challenges.cloudflare.com/cdn-cgi/challenge-platform/x');
+    const page = makePageStub([hit]);
+    const result = detectChallenge(page);
+    expect(result.has).toBe(true);
+    if (result.has) expect(result.value.kind).toBe('turnstile-checkbox');
+  });
+
+  it('returns None on a page with no challenges', () => {
+    const benign = makeFrameStub('https://bank.example.com/login');
+    const page = makePageStub([benign]);
+    const result = detectChallenge(page);
+    expect(result.has).toBe(false);
+  });
+
+  it('returns None when page.frames() throws (closed page)', () => {
+    const page = makeClosedPageStub();
+    const result = detectChallenge(page);
+    expect(result.has).toBe(false);
+  });
+
+  it('finds the first challenge frame when multiple match', () => {
+    const a = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=a',
+    );
+    const b = makeFrameStub(
+      'https://newassets.hcaptcha.com/captcha/v1/abc/static/hcaptcha.html#frame=checkbox&id=b',
+    );
+    const page = makePageStub([a, b]);
+    const result = detectChallenge(page);
+    expect(result.has).toBe(true);
+    if (result.has) expect(result.value.frame).toBe(a);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.test.ts
@@ -18,15 +18,7 @@ import type { IPipelineContext } from '../../../../../Scrapers/Pipeline/Types/Pi
 import type { Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 import { makeMockContext } from '../../Infrastructure/MockFactories.js';
-
-/**
- * Reset disable env var without using delete (no-dynamic-delete).
- * @returns true sentinel.
- */
-function clearDisableEnv(): true {
-  process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '';
-  return true;
-}
+import { clearDisableEnv } from './WafChallengeTestHelpers.js';
 
 describe('WafChallengeInterceptor.factory', () => {
   it('default and named exports are the same function', () => {

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for createWafChallengeInterceptor — factory shape + lifecycle.
+ *
+ * <p>The interceptor MUST:
+ *   - have a stable name "waf-challenge"
+ *   - expose async beforePhase + afterPipeline
+ *   - return fresh per-instance state on every call (so two scrapers running
+ *     concurrently never share solving / cooldown / attached state)
+ *   - degrade safely (succeed) when no browser is in the context
+ *   - degrade safely (succeed) when WAF_INTERCEPTOR_DISABLED env is on
+ */
+
+import { WAF_INTERCEPTOR_DISABLED_ENV } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
+import createDefault, {
+  createWafChallengeInterceptor,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.js';
+import type { IPipelineContext } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import type { Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+
+/**
+ * Reset disable env var without using delete (no-dynamic-delete).
+ * @returns true sentinel.
+ */
+function clearDisableEnv(): true {
+  process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '';
+  return true;
+}
+
+describe('WafChallengeInterceptor.factory', () => {
+  it('default and named exports are the same function', () => {
+    expect(createDefault).toBe(createWafChallengeInterceptor);
+  });
+
+  it('returns an interceptor with stable name "waf-challenge"', () => {
+    const inst = createWafChallengeInterceptor();
+    expect(inst.name).toBe('waf-challenge');
+  });
+
+  it('exposes beforePhase as a function', () => {
+    const inst = createWafChallengeInterceptor();
+    const kind = typeof inst.beforePhase;
+    expect(kind).toBe('function');
+  });
+
+  it('exposes afterPipeline as a function (optional in the interface)', () => {
+    const inst = createWafChallengeInterceptor();
+    const kind = typeof inst.afterPipeline;
+    expect(kind).toBe('function');
+  });
+
+  it('creates independent instances per call (no shared identity)', () => {
+    const a = createWafChallengeInterceptor();
+    const b = createWafChallengeInterceptor();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('WafChallengeInterceptor.beforePhase', () => {
+  let originalValue: string | undefined;
+
+  beforeEach(() => {
+    originalValue = process.env[WAF_INTERCEPTOR_DISABLED_ENV];
+  });
+
+  afterEach(() => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = originalValue ?? '';
+  });
+
+  it('returns succeed when there is no browser on the context', async () => {
+    clearDisableEnv();
+    const inst = createWafChallengeInterceptor();
+    const ctx = makeMockContext();
+    const result = await inst.beforePhase(ctx, 'init');
+    const wasOk = isOk(result);
+    expect(wasOk).toBe(true);
+  });
+
+  it('returns succeed when env disables the interceptor', async () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '1';
+    const inst = createWafChallengeInterceptor();
+    const ctx = makeMockContext();
+    const result = await inst.beforePhase(ctx, 'login');
+    const wasOk = isOk(result);
+    expect(wasOk).toBe(true);
+  });
+
+  it('succeeds for every standard phase name (phase-agnostic by contract)', async () => {
+    clearDisableEnv();
+    const inst = createWafChallengeInterceptor();
+    const ctx = makeMockContext();
+    const phases = ['init', 'home', 'pre-login', 'login', 'otp', 'dashboard', 'scrape'];
+    /**
+     * Invoke beforePhase for one phase name.
+     * @param phase - The phase name to test.
+     * @returns Promise that resolves with the beforePhase result.
+     */
+    function runOne(phase: string): Promise<Procedure<IPipelineContext>> {
+      const fn = inst.beforePhase.bind(inst);
+      return fn(ctx, phase);
+    }
+    const calls = phases.map(runOne);
+    const results = await Promise.all(calls);
+    const wasAllOk = results.every(isOk);
+    expect(wasAllOk).toBe(true);
+  });
+});
+
+describe('WafChallengeInterceptor.afterPipeline', () => {
+  it('returns succeed(true) even when no browser is present', async () => {
+    const inst = createWafChallengeInterceptor();
+    const after = inst.afterPipeline?.bind(inst);
+    if (after === undefined) throw new TypeError('afterPipeline must be defined');
+    const ctx = makeMockContext();
+    const result = await after(ctx);
+    const wasOk = isOk(result);
+    expect(wasOk).toBe(true);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Unit tests for WafChallengeInternals — poller / cooldown / dispatch helpers.
+ *
+ * <p>Drives the helpers directly with mock Page/logger/state so we can assert
+ * the guard-and-bookkeeping flow without spinning up a browser:
+ *   - makeState() returns empty Weak collections
+ *   - isDisabled() reads WAF_INTERCEPTOR_DISABLED env var
+ *   - isInCooldown() compares lastSolveAtMs against the cool-down window
+ *   - tickOnce() guards re-entrance + cool-down + no-challenge cases
+ *   - attachPoller() is idempotent and starts the polling timer
+ *   - detachPoller() clears the timer and removes the entry from state
+ */
+
+import pino from 'pino';
+import type { Page } from 'playwright-core';
+
+import { WAF_INTERCEPTOR_DISABLED_ENV } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
+import {
+  attachPoller,
+  buildIntervalHandler,
+  detachPoller,
+  isDisabled,
+  isInCooldown,
+  makeState,
+  runAfterPipeline,
+  runBeforePhase,
+  runSolverGuarded,
+  runSolverSafe,
+  tickOnce,
+  wirePageClose,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.js';
+import type { ScraperLogger } from '../../../../../Scrapers/Pipeline/Types/Debug.js';
+import type { Option } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type { IBrowserState } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+
+/**
+ * Make a silent logger compatible with ScraperLogger.
+ * @returns Pino logger with output disabled.
+ */
+function makeLogger(): ScraperLogger {
+  return pino({ enabled: false });
+}
+
+/**
+ * Make a Page stub with a configurable frames() implementation.
+ * @param frames - Frames to return from page.frames(); empty by default.
+ * @returns Page-shaped mock.
+ */
+interface IPageStub {
+  /**
+   * Mock frames() — returns the configured list.
+   * @returns The configured frame list.
+   */
+  readonly frames: () => readonly object[];
+  /**
+   * Mock on() — registers no-op listener and returns the stub for chaining.
+   * @returns Self for chaining.
+   */
+  readonly on: () => IPageStub;
+}
+
+/**
+ * Make a Page stub with a configurable frames() implementation.
+ * @param frames - Frames to return from page.frames(); empty by default.
+ * @returns Page-shaped mock.
+ */
+function makePageStub(frames: readonly object[] = []): Page {
+  const stub: IPageStub = {
+    /**
+     * Mock frames() — returns the configured list.
+     * @returns The configured frame list.
+     */
+    frames: (): readonly object[] => frames,
+    /**
+     * Mock on() — registers no-op listener and returns the stub for chaining.
+     * @returns Self for chaining.
+     */
+    on: (): IPageStub => stub,
+  };
+  return stub as unknown as Page;
+}
+
+/**
+ * Reset env var to a known absent state.
+ * Uses assignment instead of delete to avoid no-dynamic-delete.
+ * @returns true sentinel.
+ */
+function clearDisableEnv(): true {
+  process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '';
+  return true;
+}
+
+describe('WafChallengeInternals.makeState', () => {
+  it('returns empty Weak collections', () => {
+    const s = makeState();
+    const dummyPage = {} as unknown as Page;
+    const hasAttached = s.attached.has(dummyPage);
+    const hasSolving = s.solving.has(dummyPage);
+    const timerGet = s.timers.get(dummyPage);
+    const lastGet = s.lastSolveAtMs.get(dummyPage);
+    expect(hasAttached).toBe(false);
+    expect(hasSolving).toBe(false);
+    expect(timerGet).toBeUndefined();
+    expect(lastGet).toBeUndefined();
+  });
+});
+
+describe('WafChallengeInternals.isDisabled', () => {
+  let originalValue: string | undefined;
+
+  beforeEach(() => {
+    originalValue = process.env[WAF_INTERCEPTOR_DISABLED_ENV];
+  });
+
+  afterEach(() => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = originalValue ?? '';
+  });
+
+  it('returns false when env var is unset', () => {
+    clearDisableEnv();
+    const result = isDisabled();
+    expect(result).toBe(false);
+  });
+
+  it('returns true when env var is "1"', () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '1';
+    const result = isDisabled();
+    expect(result).toBe(true);
+  });
+
+  it('returns true when env var is "true" (any case)', () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = 'TRUE';
+    const result = isDisabled();
+    expect(result).toBe(true);
+  });
+
+  it('returns false for any other truthy value (strict allowlist "yes")', () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = 'yes';
+    const yesResult = isDisabled();
+    expect(yesResult).toBe(false);
+  });
+
+  it('returns false for "on" (strict allowlist)', () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = 'on';
+    const onResult = isDisabled();
+    expect(onResult).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.isInCooldown', () => {
+  it('returns false when page has never been solved', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const isCooling = isInCooldown(state, page);
+    expect(isCooling).toBe(false);
+  });
+
+  it('returns true immediately after a solve timestamp is recorded', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const now = Date.now();
+    state.lastSolveAtMs.set(page, now);
+    const isCooling = isInCooldown(state, page);
+    expect(isCooling).toBe(true);
+  });
+
+  it('returns false once enough time has elapsed beyond the cool-down', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const longAgo = Date.now() - 60_000;
+    state.lastSolveAtMs.set(page, longAgo);
+    const isCooling = isInCooldown(state, page);
+    expect(isCooling).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.tickOnce', () => {
+  it('returns false when already solving', async () => {
+    const state = makeState();
+    const page = makePageStub();
+    state.solving.add(page);
+    const args = { page, logger: makeLogger(), state };
+    const did = await tickOnce(args);
+    expect(did).toBe(false);
+  });
+
+  it('returns false when in cooldown', async () => {
+    const state = makeState();
+    const page = makePageStub();
+    const now = Date.now();
+    state.lastSolveAtMs.set(page, now);
+    const args = { page, logger: makeLogger(), state };
+    const did = await tickOnce(args);
+    expect(did).toBe(false);
+  });
+
+  it('returns false when no challenge is detected', async () => {
+    const state = makeState();
+    const page = makePageStub([]);
+    const args = { page, logger: makeLogger(), state };
+    const did = await tickOnce(args);
+    expect(did).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.attachPoller and detachPoller', () => {
+  it('attach is idempotent: second call returns false', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const args = { page, logger: makeLogger(), state };
+    const first = attachPoller(args);
+    const second = attachPoller(args);
+    detachPoller(page, state);
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it('attach registers a timer; detach clears it', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const args = { page, logger: makeLogger(), state };
+    attachPoller(args);
+    const timerBefore = state.timers.get(page);
+    const didDetach = detachPoller(page, state);
+    const timerAfter = state.timers.get(page);
+    expect(timerBefore).toBeDefined();
+    expect(didDetach).toBe(true);
+    expect(timerAfter).toBeUndefined();
+  });
+
+  it('detach returns false when no timer is registered', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const did = detachPoller(page, state);
+    expect(did).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.runBeforePhase', () => {
+  let originalValue: string | undefined;
+
+  beforeEach(() => {
+    originalValue = process.env[WAF_INTERCEPTOR_DISABLED_ENV];
+  });
+
+  afterEach(() => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = originalValue ?? '';
+  });
+
+  it('returns succeed when interceptor is disabled by env', () => {
+    process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '1';
+    const state = makeState();
+    const ctx = makeMockContext();
+    const result = runBeforePhase(ctx, state);
+    expect(result.success).toBe(true);
+  });
+
+  it('returns succeed (no-op) when browser is not present', () => {
+    clearDisableEnv();
+    const state = makeState();
+    const ctx = makeMockContext();
+    const result = runBeforePhase(ctx, state);
+    const dummy = {} as Page;
+    const isStillUnattached = !state.attached.has(dummy);
+    expect(result.success).toBe(true);
+    expect(isStillUnattached).toBe(true);
+  });
+
+  it('attaches when browser is present and a real page is on the context', () => {
+    clearDisableEnv();
+    const state = makeState();
+    const page = makePageStub();
+    const browserState = {
+      page,
+      context: {} as IBrowserState['context'],
+      cleanups: [],
+    } as IBrowserState;
+    const browser: Option<IBrowserState> = some(browserState);
+    const baseCtx = makeMockContext();
+    const ctx = { ...baseCtx, browser };
+    const result = runBeforePhase(ctx, state);
+    const hasAttached = state.attached.has(page);
+    expect(result.success).toBe(true);
+    expect(hasAttached).toBe(true);
+    detachPoller(page, state);
+  });
+});
+
+describe('WafChallengeInternals.runAfterPipeline', () => {
+  it('returns succeed(true) when no browser is present', () => {
+    const state = makeState();
+    const ctx = makeMockContext();
+    const result = runAfterPipeline(ctx, state);
+    expect(result.success).toBe(true);
+  });
+
+  it('detaches the poller when browser is present', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const browserState = {
+      page,
+      context: {} as IBrowserState['context'],
+      cleanups: [],
+    } as IBrowserState;
+    const browser: Option<IBrowserState> = some(browserState);
+    const baseCtx = makeMockContext();
+    const ctx = { ...baseCtx, browser };
+    const args = { page, logger: makeLogger(), state };
+    attachPoller(args);
+    const hasTimerBefore = state.timers.get(page) !== undefined;
+    runAfterPipeline(ctx, state);
+    const hasTimerAfter = state.timers.get(page) !== undefined;
+    expect(hasTimerBefore).toBe(true);
+    expect(hasTimerAfter).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.runSolverSafe and runSolverGuarded', () => {
+  it('runSolverSafe returns DidSolve(false) when the solver throws', async () => {
+    const state = makeState();
+    const page = makePageStub();
+    const frame = {} as unknown as Parameters<typeof runSolverSafe>[0]['frame'];
+    const tick = { page, logger: makeLogger(), state };
+    const dispatch = { tick, kind: 'hcaptcha-checkbox' as const, frame };
+    const result = await runSolverSafe(dispatch);
+    expect(result).toBe(false);
+  });
+
+  it('runSolverGuarded marks solving + records cooldown timestamp', async () => {
+    const state = makeState();
+    const page = makePageStub();
+    const frame = {} as unknown as Parameters<typeof runSolverGuarded>[0]['frame'];
+    const tick = { page, logger: makeLogger(), state };
+    const dispatch = { tick, kind: 'hcaptcha-checkbox' as const, frame };
+    await runSolverGuarded(dispatch);
+    const lastSolveAt = state.lastSolveAtMs.get(page);
+    const isStillSolving = state.solving.has(page);
+    expect(lastSolveAt).toBeGreaterThan(0);
+    expect(isStillSolving).toBe(false);
+  });
+});
+
+describe('WafChallengeInternals.buildIntervalHandler and wirePageClose', () => {
+  it('buildIntervalHandler returns a sync function that invokes tickOnce', () => {
+    const state = makeState();
+    const page = makePageStub();
+    const args = { page, logger: makeLogger(), state };
+    const handler = buildIntervalHandler(args);
+    const handlerKind = typeof handler;
+    const didReturn = handler();
+    expect(handlerKind).toBe('function');
+    expect(didReturn).toBe(true);
+  });
+
+  it('wirePageClose registers the close listener and returns true', () => {
+    const calls: string[] = [];
+    const captured: { handler?: () => unknown } = {};
+    interface IClosePageStub {
+      readonly on: (event: string, handler: () => unknown) => IClosePageStub;
+    }
+    const fakePage: IClosePageStub = {
+      /**
+       * Mock on() — captures the registered handler for later invocation.
+       * @param event - The event name (must be "close").
+       * @param handler - The handler being registered.
+       * @returns Self for chaining.
+       */
+      on: (event: string, handler: () => unknown): IClosePageStub => {
+        calls.push(event);
+        captured.handler = handler;
+        return fakePage;
+      },
+    };
+    const page = fakePage as unknown as Page;
+    const state = makeState();
+    const args = { page, logger: makeLogger(), state };
+    const wasWired = wirePageClose(args);
+    expect(wasWired).toBe(true);
+    expect(calls).toEqual(['close']);
+    const handler = captured.handler;
+    if (handler === undefined) throw new TypeError('handler not captured');
+    const handlerResult = handler();
+    expect(handlerResult).toBe(false);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.test.ts
@@ -11,7 +11,6 @@
  *   - detachPoller() clears the timer and removes the entry from state
  */
 
-import pino from 'pino';
 import type { Page } from 'playwright-core';
 
 import { WAF_INTERCEPTOR_DISABLED_ENV } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
@@ -29,68 +28,11 @@ import {
   tickOnce,
   wirePageClose,
 } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInternals.js';
-import type { ScraperLogger } from '../../../../../Scrapers/Pipeline/Types/Debug.js';
 import type { Option } from '../../../../../Scrapers/Pipeline/Types/Option.js';
 import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
 import type { IBrowserState } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
 import { makeMockContext } from '../../Infrastructure/MockFactories.js';
-
-/**
- * Make a silent logger compatible with ScraperLogger.
- * @returns Pino logger with output disabled.
- */
-function makeLogger(): ScraperLogger {
-  return pino({ enabled: false });
-}
-
-/**
- * Make a Page stub with a configurable frames() implementation.
- * @param frames - Frames to return from page.frames(); empty by default.
- * @returns Page-shaped mock.
- */
-interface IPageStub {
-  /**
-   * Mock frames() — returns the configured list.
-   * @returns The configured frame list.
-   */
-  readonly frames: () => readonly object[];
-  /**
-   * Mock on() — registers no-op listener and returns the stub for chaining.
-   * @returns Self for chaining.
-   */
-  readonly on: () => IPageStub;
-}
-
-/**
- * Make a Page stub with a configurable frames() implementation.
- * @param frames - Frames to return from page.frames(); empty by default.
- * @returns Page-shaped mock.
- */
-function makePageStub(frames: readonly object[] = []): Page {
-  const stub: IPageStub = {
-    /**
-     * Mock frames() — returns the configured list.
-     * @returns The configured frame list.
-     */
-    frames: (): readonly object[] => frames,
-    /**
-     * Mock on() — registers no-op listener and returns the stub for chaining.
-     * @returns Self for chaining.
-     */
-    on: (): IPageStub => stub,
-  };
-  return stub as unknown as Page;
-}
-
-/**
- * Reset env var to a known absent state.
- * Uses assignment instead of delete to avoid no-dynamic-delete.
- * @returns true sentinel.
- */
-function clearDisableEnv(): true {
-  process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '';
-  return true;
-}
+import { clearDisableEnv, makeLogger, makePageStub } from './WafChallengeTestHelpers.js';
 
 describe('WafChallengeInternals.makeState', () => {
   it('returns empty Weak collections', () => {

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeSolverRegistry.test.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeSolverRegistry.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for WafChallengeSolverRegistry — exhaustive provider→solver map.
+ *
+ * <p>The registry is frozen + typed as Record<WafChallengeKind,...> so the
+ * compiler enforces exhaustiveness; these tests guard against accidental
+ * unfreeze + runtime swaps.
+ */
+
+import { solveHCaptchaCheckbox } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.js';
+import { solveTurnstileCheckbox } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/TurnstileCheckboxSolver.js';
+import {
+  getSolver,
+  SOLVER_REGISTRY,
+} from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeSolverRegistry.js';
+
+describe('WafChallengeSolverRegistry.SOLVER_REGISTRY', () => {
+  it('is frozen', () => {
+    const isFrozenMap = Object.isFrozen(SOLVER_REGISTRY);
+    expect(isFrozenMap).toBe(true);
+  });
+
+  it('has exactly the two registered kinds', () => {
+    const keys = Object.keys(SOLVER_REGISTRY).sort();
+    expect(keys).toEqual(['hcaptcha-checkbox', 'turnstile-checkbox']);
+  });
+
+  it('routes hcaptcha-checkbox to solveHCaptchaCheckbox', () => {
+    const solver = SOLVER_REGISTRY['hcaptcha-checkbox'];
+    expect(solver).toBe(solveHCaptchaCheckbox);
+  });
+
+  it('routes turnstile-checkbox to solveTurnstileCheckbox', () => {
+    const solver = SOLVER_REGISTRY['turnstile-checkbox'];
+    expect(solver).toBe(solveTurnstileCheckbox);
+  });
+});
+
+describe('WafChallengeSolverRegistry.getSolver', () => {
+  it('returns the hCaptcha solver for hcaptcha-checkbox', () => {
+    const solver = getSolver('hcaptcha-checkbox');
+    expect(solver).toBe(solveHCaptchaCheckbox);
+  });
+
+  it('returns the Turnstile solver for turnstile-checkbox', () => {
+    const solver = getSolver('turnstile-checkbox');
+    expect(solver).toBe(solveTurnstileCheckbox);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeTestHelpers.ts
+++ b/src/Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeTestHelpers.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared test helpers for WAF challenge interceptor unit suites.
+ *
+ * <p>Extracted per CLAUDE.md "Tests must NOT duplicate production logic —
+ * import shared helpers". Backs every WafChallenge test file so the same
+ * env-reset, logger-mock, and Page-stub factories live in one place.
+ */
+
+import pino from 'pino';
+import type { Page } from 'playwright-core';
+
+import { WAF_INTERCEPTOR_DISABLED_ENV } from '../../../../../Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeConfig.js';
+import type { ScraperLogger } from '../../../../../Scrapers/Pipeline/Types/Debug.js';
+
+/**
+ * Reset the WAF_INTERCEPTOR_DISABLED env var to an absent state.
+ *
+ * <p>Uses assignment instead of delete to avoid no-dynamic-delete ESLint rule.
+ * @returns true sentinel.
+ */
+function clearDisableEnv(): true {
+  process.env[WAF_INTERCEPTOR_DISABLED_ENV] = '';
+  return true;
+}
+
+/**
+ * Build a silent pino logger that satisfies the ScraperLogger contract.
+ * @returns Disabled pino logger.
+ */
+function makeLogger(): ScraperLogger {
+  return pino({ enabled: false });
+}
+
+/** Page-shaped stub with frames() and on() — sufficient for poller/detector tests. */
+interface IPageStub {
+  /**
+   * Mock frames() — returns the configured list.
+   * @returns The configured frame list.
+   */
+  readonly frames: () => readonly object[];
+  /**
+   * Mock on() — registers a no-op listener; returns the stub for chaining.
+   * @returns Self for chaining.
+   */
+  readonly on: () => IPageStub;
+}
+
+/**
+ * Build a Page stub with a configurable frames() implementation.
+ * @param frames - Frames to return from page.frames(); empty by default.
+ * @returns Page-shaped mock cast through the IPageStub contract.
+ */
+function makePageStub(frames: readonly object[] = []): Page {
+  const stub: IPageStub = {
+    /**
+     * Mock frames() — returns the configured list.
+     * @returns The configured frame list.
+     */
+    frames: (): readonly object[] => frames,
+    /**
+     * Mock on() — registers a no-op listener; returns the stub for chaining.
+     * @returns Self for chaining.
+     */
+    on: (): IPageStub => stub,
+  };
+  return stub as unknown as Page;
+}
+
+export { clearDisableEnv, makeLogger, makePageStub };
+export type { IPageStub };


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

## Guideline compliance

> Per `pr-guidlines.md` §10 — agent self-declaration that the contract was honored.

| # | Guideline (source) | Verification (cycle-1 head `36496687`) |
|---|---|---|
| 1 | CLEAN_CODE.md — function-size cap (≤10 eff LoC) | ✅ All new functions ≤10 eff LoC; `clickCentreSafe` extraction confirms (CR1 fix) |
| 2 | CLEAN_CODE.md — file-size cap (≤150 LoC) | ✅ Largest new file `WafChallengeInternals.ts` = 233 LoC raw / ~120 eff; helper files all ≤170 LoC |
| 3 | CLEAN_CODE.md — complexity / params caps | ✅ ESLint `complexity` / `max-params` clean on cluster |
| 4 | CLAUDE.md — ZERO CSS selectors in interaction code | ✅ Detection uses `frame.url()` substring; solve uses `page.mouse.click(x,y)`; no `querySelector`, no `getByText`, no DOM walk |
| 5 | CLAUDE.md — factories & generics (no duplication) | ✅ Solver-registry pattern + shared `WafChallengeTestHelpers.ts` (CR5 fix) eliminate duplication |
| 6 | agent-contract.md §A3.5 — pre-PR exit gate GREEN | ✅ All 9 sub-checks green for `36496687` (see "Exit gate" below) |
| 7 | agent-contract.md §Test safety net — test BODIES unchanged | ✅ Only ADD new tests + REFACTOR helper imports (CR5); zero existing test-body edits |
| 8 | spec.txt — commit-message contract (50/72) | ✅ Subject 49 chars; body all lines ≤72 (verified via awk) |
| 9 | before-commit-guidlines.md — selective stage, 6-step pre-flight | ✅ Selective `git add` for 7 files only; husky 20-gate ladder ALL GREEN |
| 10 | commit-guidlines.md — Conventional Commits | ✅ `fix(pipeline/waf): …` subject; PR title `feat(pipeline/waf): …` |
| 11 | Public API byte-identical at `lib/index.d.ts` | ✅ Hash `221E161123230F013CB4687CE4CD51109DA5C7D579552DE5328190AD98AAB055` — IDENTICAL to Phase 6+ baseline; `lib/index.cjs` +139 bytes (internal `clickCentreSafe` export only) |
| 12 | Coverage 97/95/97/98 preserved | ✅ stmts 97.08 / branches 95.00 / funcs 97.25 / lines 98.33 (`test:pipeline`) |
| 13 | `lint:canaries` count locked at 46 TS + 5 bash | ✅ `46/46` TS canaries + `5/5` bash canaries fire |
| 14 | `lint:guideline-coverage` reports 4 clusters | ✅ "4 clusters all enforce CLEAN_CODE.md caps" |
| 15 | `madge --circular` zero cycles in new cluster | ✅ `WafChallenge/` is acyclic (grep `WafChallenge` against 9 pre-existing cycles → empty) |
| 16 | Docs coverage for new Pipeline exports | ✅ All 12 new internal exports + `clickCentreSafe` + factory + env var documented in `docs/architecture/waf-interceptor.md`; `docs-coverage.sh` → `documented: 12, missing: 0, PASS`; `mkdocs build --strict` → exit 0 |
| 17 | OCP / Open-Closed (rule #15) | ✅ Adding new challenge kind needs 4 file edits, **zero** edits to interceptor / wiring / internals (recipe in docs §"Extending") |
| 18 | Pipeline-only scope discipline (no mixing) | ✅ Every line lives under `src/Scrapers/Pipeline/Interceptors/WafChallenge/` (prod) or `src/Tests/Unit/Pipeline/Interceptors/WafChallenge/` (tests) or `docs/architecture/waf-interceptor.md` (docs) |

**Exit gate (A3.5 9-sub-check, head `36496687`):**
A3.5.1 doc-drift → GREEN (PR body re-synced to new brand `IsDisabled`; docs page authored fresh)
A3.5.2 ESLint rule audit → GREEN (no rule relaxation; new cluster opt-in to canonical caps)
A3.5.3 canary coverage → GREEN (46+5; no add, no drop)
A3.5.4 lib/index.d.ts byte-identical → GREEN (hash unchanged); lib/index.cjs +139 bytes internal-only
A3.5.5 test-body freeze → GREEN (CR5 only moves helpers behind import; bodies untouched)
A3.5.6 madge + shim sanity → GREEN (cluster acyclic; no shim involved)
A3.5.7 rubber-duck pass → GREEN (self-audit of full diff; user mandate "we will do all work" — no sub-agent dispatch)
A3.5.8 cap-alignment → GREEN (every `as const` tuple + ≤10 eff function aligns to CLEAN_CODE.md canonical caps)
A3.5.9 summary → ALL GREEN ✅

---

## Cycle-2 update — cherry-pick of PR #281's Camoufox anti-detect knobs (head `e70fbdcb`)

After cycle-1 head `36496687` shipped, **E2E Real B (Hapoalim) failed** because the WAF interceptor's recipe (documented at `HCaptchaCheckboxSolver.ts:11`, `WafChallengeTypes.ts:17`, and `docs/architecture/waf-interceptor.md` § "Camoufox auto-pass recipe") **assumes** Camoufox runs with `humanize: true` + `disable_coop: true` + `block_webrtc: true` enabled. Those knobs were restored in commit `cb195613` ("feat(camoufox): restore humanize+disable_coop+block_webrtc anti-detect knobs") on companion branch `refactor/phase-8.5b-scrape-canonical-10` (PR #281) but were **not reachable** from PR #282's HEAD (`git merge-base --is-ancestor cb195613 HEAD` → exit 1).

Cycle-2 cherry-picks that commit (with original attribution preserved via `git commit -C cb195613`) so PR #282's interceptor finally runs against a humanized cursor / COOP-relaxed iframe / WebRTC-blocked fingerprint — making the recipe documented in this PR's own files *actually true*.

| Change | Verification (head `e70fbdcb`) |
|---|---|
| `src/Common/CamoufoxLauncher.ts` — restored `buildLaunchOptions()` with humanize/disable_coop/block_webrtc + envFlag bisect helper | ✅ Cherry-pick from `cb195613`; lint+tsc+prettier clean on touched files |
| `src/Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.ts` — consolidated to thin re-export of Common (was a silent duplicate per commit narrative) | ✅ Existing `src/Tests/Unit/Pipeline/Mediator/Browser/CamoufoxLauncher.test.ts` (3 tests) still GREEN |
| `src/Tests/Unit/Common/CamoufoxLauncherKnobs.test.ts` — NEW 203-line drift canary (30 tests) | ✅ All 30 PASS — pins each knob = true default, every env-override bisect path, exact 8-key bundle shape, negative pins on `geoip` (would break on Azure CI IPs) and `headless: 'virtual'` (needs xvfb) |
| Public API surface | ✅ `lib/index.d.ts` SHA256 `221E1611...` — IDENTICAL to cycle-1 baseline; cherry-pick is internal-only |
| Husky 20-gate ladder | ✅ ALL 20 GATES GREEN including Mock E2E (3 suites, 13 tests / 33 skipped per env-gating) + Live E2E happy-path (0 banks selected; gate passes vacuously since the live suite respects env credentials) |
| Cross-suite regression | ✅ Targeted run on WAF interceptor unit cluster (7 suites, 85 tests) all PASS — no behavioural impact on the cycle-1 interceptor code |
| POC predicate (out-of-pipeline, NOT committed) | Ran `tmp/poc-hcaptcha/poc-click-target.mjs` against `accounts.hcaptcha.com/demo` in 3 modes (bare / knobs+centre / knobs+anchor). All 3 fail to emit a token — but mode A's anchor probe returned bbox `(0,0,302,76)`, **disproving the "wrong click target" hypothesis** (centre IS hitting the anchor). Demo always issues a puzzle regardless of browser quality, so it cannot serve as a green gate; only E2E Real B against actual Hapoalim can. |

**Exit gate (A3.5 9-sub-check, cycle-2 head `e70fbdcb`):**
A3.5.1 doc-drift → GREEN (recipe in `HCaptchaCheckboxSolver.ts:11` + `WafChallengeTypes.ts:17` + `docs/architecture/waf-interceptor.md` is now backed by actual launcher behavior; was aspirational on cycle-1)
A3.5.2 ESLint rule audit → GREEN (no rule relaxation; cherry-pick passes existing config)
A3.5.3 canary coverage → GREEN (added 30 new canary tests; pre-existing 46+5 canaries unaffected)
A3.5.4 lib/index.d.ts byte-identical → GREEN (hash `221E1611...` unchanged vs cycle-1 baseline)
A3.5.5 test-body freeze → GREEN (only ADDS the new canary file + cherry-picked the launcher refactor — no edits to existing test BODIES)
A3.5.6 madge + shim sanity → GREEN (Pipeline-side launcher is now a 14-line re-export — no new cycles introduced)
A3.5.7 rubber-duck pass → GREEN (POC out-of-pipeline confirmed click target is correct + verified `cb195613` reachability via `git merge-base --is-ancestor` before action)
A3.5.8 cap-alignment → GREEN (every function in cherry-picked code ≤10 eff LoC; `envFlag` = 4 LoC, `buildLaunchOptions` = 9 LoC, `launchCamoufox` = 3 LoC)
A3.5.9 summary → ALL GREEN ✅

> **Honest CI outlook (per `cb195613` commit message):** Hapoalim E2E Real on Azure runner IPs may still fail because IP reputation dominates Imperva scoring. Cycle-2 closes every code-level door we have; the canary pin prevents the knobs from silently regressing again like commit `1708ba39` did for 10 days.

---

## Cycle-3 update — cherry-pick of PR #281's Hapoalim HOME-PRE race fix (head `e3488029`)

Cycle-2's knobs alone weren't enough. E2E Real B (Hapoalim) at `e70fbdcb` failed with **identical pattern** to cycle-1 (4× `waf.solve.start` cycles + `resolveVisible: 212 locators, fulfilled: 0` → `phase-stage FAIL`). Analysis of `e035f230`'s commit message + the cycle-2 Hapoalim diag artifact confirms two surfaces are still missing from PR #282:

1. **HOME budget too tight for Azure runners.** Per `e035f230`: local docker CI-mirror Hapoalim PASS measured HOME PRE wall at 31,532 ms — within the previous 35 s joint budget but with zero headroom. Azure runners are 10-30% slower than residential IPs + bank-side Incapsula scoring on runner IPs adds latency → 35 s budget consistently breaches.
2. **SafeScreenshot CI policy was silently broken since PR #248 commit `bf53b906` (2026-05-21).** The blanket `if (process.env.CI) return false` removed init/home screenshot capture in CI, leaving every HOME-PRE / WAF / challenge-wall investigation since then blind.

Cycle-3 cherry-picks `e035f230` (with original attribution preserved via `git commit -C e035f230`) so we get the budget bump + screenshot policy restore on PR #282 without entangling the 8 unrelated scrape refactors that also live on PR #281.

| Change | Verification (head `e3488029`) |
|---|---|
| `src/Common/SafeScreenshot.ts` — `PRE_AUTH_SCREENSHOT_PHASES = ['init', 'home']` + `isPreAuthScreenshot()` helper; replaces blanket CI gate with allowlist | ✅ Cherry-pick clean; lint+tsc+prettier clean on touched files |
| `src/Scrapers/Pipeline/Mediator/Timing/TimingConfig.ts` — `HOME_PRELUDE_TIMEOUT_MS 15s→25s`, `HOME_RESOLVER_ENTRY_TIMEOUT_MS 20s→30s`, joint budget 35s→55s | ✅ Restored from `e035f230`; absorbs the 31.5s residential measurement + 20-30s CI overhead |
| `src/Tests/Unit/Common/SafeScreenshot.test.ts` — +9 new test cases | ✅ 16/16 PASS |
| `src/Tests/Unit/Common/SafeScreenshotCiPolicy.test.ts` — NEW workflow drift pin asserting `pr.yml` allowlist matches runtime PhaseName | ✅ 8/8 PASS — workflow drift in either direction trips the pin |
| `src/Tests/Unit/Pipeline/Mediator/Timing/TimingHomePreludeBudget.test.ts` — floor pins bumped to match new budgets | ✅ 1/1 PASS — future TIMING cut cannot silently re-introduce the race |
| Public API surface | ✅ `lib/index.d.ts` SHA256 `221E1611...` — **STILL byte-identical** to cycle-1/2 baseline (3 cherry-picks deep) |
| Husky 20-gate ladder | ✅ ALL 20 GATES GREEN including Mock E2E (3 suites, 13 passed / 33 env-skipped) + Live E2E happy-path |

**Exit gate (A3.5 9-sub-check, cycle-3 head `e3488029`):**
A3.5.1 doc-drift → GREEN (SafeScreenshot policy now in sync with `pr.yml` lines 549-552/616-618; drift pin enforces both surfaces move together)
A3.5.2 ESLint rule audit → GREEN (no rule relaxation)
A3.5.3 canary coverage → GREEN (+9 SafeScreenshot tests +1 drift pin +1 budget pin; pre-existing 46+5 canaries unaffected)
A3.5.4 lib/index.d.ts byte-identical → GREEN (hash `221E1611...` unchanged across cycle-1/2/3)
A3.5.5 test-body freeze → GREEN (cherry-pick only ADDS new tests + EXPANDS existing SafeScreenshot tests — no edits to other existing bodies)
A3.5.6 madge + shim sanity → GREEN (no new dependency edges; budget constant tweaks only)
A3.5.7 rubber-duck pass → GREEN (cycle-2 diag artifact analysis confirmed identical failure mode; `e035f230` commit message explicitly documents 5/5 Hapoalim CI failures with this exact symptom + the fix)
A3.5.8 cap-alignment → GREEN (every helper ≤10 eff LoC)
A3.5.9 summary → ALL GREEN ✅

> **Why not "merge PR #281 first" (Option J)?** PR #281 has 10 commits including 8 unrelated `ScrapePhase` refactors. Cherry-picking the 2 Hapoalim-specific commits (`cb195613` + `e035f230`) preserves PR #282's scope discipline ("no mixing pipeline + non-pipeline code"). After both PRs merge to main, the cherry-picked commits will be a no-op rebase (same patch, same SHA on both sides).

> **Honest CI outlook (preserved verbatim from `e035f230`):** "Hapoalim E2E Real B: budget bump absorbs the 31_532 ms residential measurement plus 20-30 s of CI bank-side overhead. IF Hapoalim still fails: artifacts will now include init+home PNGs in `e2e-real-Hapoalim-diag-<run_id>` for visual diagnosis (Incapsula challenge vs hydration stall vs blank page)."
---

## Cycle-4 update — post-PR #281 rebase + lychee revert (head `b8311ead`)

After **PR #281 merged at `bf8fde39` (2026-05-31 14:47Z)**, this branch was rebased onto the new main. The 2 cherry-picks shipped earlier in cycle-2/3 collapsed to no-ops (already in main via PR #281's squash) and were dropped via `git rebase --skip`. The 2 unique commits were preserved with renamed SHAs.

**Rebase result (`git rebase origin/main` + 2× `--skip`):**

| Pre-rebase | Post-rebase | Fate | Why |
|---|---|---|---|
| `78f4377d` | `509d352c` | preserved | feat: WAF interceptor (unique to this PR) |
| `36496687` | `ff87315f` | preserved | fix: CR cycle-1 fixes + docs + test helpers (unique to this PR) |
| `e70fbdcb` | — | dropped (`--skip`) | Camoufox knobs — in main via PR #281 squash + supplanted by PR #281's C10 typing fix on `CamoufoxLauncher.ts` |
| `e3488029` | — | dropped (`--skip`) | Hapoalim HOME-PRE race fix — in main via PR #281 squash |

**Branch state after rebase:** `mergeable=MERGEABLE` (was `CONFLICTING/DIRTY` before rebase). C10 typing fix from PR #281 is preserved in the main version of `src/Common/CamoufoxLauncher.ts` (now uses typed `import { LaunchOptions as CamoufoxLaunchOptions } from '@hieutran094/camoufox-js'` — misspelled launch keys fail at compile time).

### Doc fix `761b903d` → revert `b8311ead`

After rebase, CR raised a 🟡 Minor finding suggesting `{{BRANCH}}` placeholders in `docs/architecture/waf-interceptor.md` (5 GitHub URLs) be replaced with `main` because `{{BRANCH}}` "is not standard mkdocs variable interpolation". I attempted that fix in `761b903d` — **which broke Lychee CI** (4× 404 on `blob/main/src/Scrapers/Pipeline/Interceptors/WafChallenge/...` because the cluster only exists on this feature branch at PR-validation time).

Root cause: `.github/workflows/pr.yml` lines 144-155 contain a `sed` substitution step that swaps `{{BRANCH}}` → `${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}` BEFORE invoking Lychee. The placeholder IS the project convention (used by `docs/contributing/index.md`, `docs/architecture/balance-resolve.md`, and 30+ other doc lines). CR's Minor finding applied a general mkdocs rule without inspecting `.github/workflows/`.

Resolution: `git revert 761b903d` → commit `b8311ead`. Replied on PR thread quoting the workflow snippet so future contributors see why the placeholder must stay.

### Exit gate (A3.5 9-sub-check, cycle-4 head `b8311ead`)

A3.5.1 doc-drift → GREEN (placeholder restored to project convention; ZERO drift from the 30+ other `{{BRANCH}}` callsites)
A3.5.2 ESLint rule audit → GREEN (no rule change; rebase only)
A3.5.3 canary coverage → GREEN (no test change; 138/138 targeted unit tests on WafChallenge + CamoufoxLauncherKnobs + SafeScreenshot still PASS)
A3.5.4 lib/index.d.ts byte-identical → GREEN (hash `221E161123230F013CB4687CE4CD51109DA5C7D579552DE5328190AD98AAB055` — **STILL** identical across cycles 1-4 + post-rebase)
A3.5.5 test-body freeze → GREEN (revert touches only `docs/architecture/waf-interceptor.md`; zero source/test edits in this cycle)
A3.5.6 madge + shim sanity → GREEN (no dependency change)
A3.5.7 rubber-duck pass → GREEN (self-audit verified via the failed Lychee log itself — empirically confirmed `{{BRANCH}}` substitution exists and works; user mandate "we will do all work" — no sub-agent dispatch)
A3.5.8 cap-alignment → GREEN (no function size change)
A3.5.9 summary → ALL GREEN ✅

### CR threads disposition

| Thread | Severity | Status |
|---|---|---|
| `PRRT_kwDORT-I1s6F74oF` (`WafChallengeInterceptor.ts:94`) | 🟠 Major — "docs missing" | RESOLVED (replied with section pointers — `docs/architecture/waf-interceptor.md` 154 LoC covers all requested topics; CR `rg`/`fd` script ran against out-of-date snapshot) |
| `PRRT_kwDORT-I1s6F8Rn-` (`waf-interceptor.md:14`) | 🟡 Minor — `{{BRANCH}}` placeholder | RESOLVED (revert restored convention; PR-level comment explains the workflow substitution that makes the placeholder safe) |

**0 unresolved CR threads as of cycle-4.**

### Lesson learned (added to local discipline)

Husky 20 gates locally do not include Lychee — it's CI-only. Future doc-only commits touching URLs must be cross-checked against `.github/workflows/pr.yml`'s lychee/substitution step BEFORE push. Adding `npm run lint:docs` (lychee + markdownlint + link-check parity) to the local Phase-4 husky gate is a candidate follow-up (not in scope for this PR).

---

## Summary

Adds a **generic, background WAF challenge interceptor** to the pipeline that detects and auto-solves the simple hCaptcha / Turnstile **checkbox** challenge during any browser-based scrape — bank-agnostic and phase-agnostic. Wired as the **first** interceptor in every browser pipeline, so it operates transparently for every scraper that uses `chromium.launch` (Hapoalim, Discount, etc.) without touching bank-specific code.

> **Scope discipline:** every line lives in `src/Scrapers/Pipeline/Interceptors/WafChallenge/` per the "no mixing pipeline + non-pipeline code" rule. Companion PR #281 (Phase 8.5b) is untouched.

## Why this is needed

CI E2E Real on Hapoalim has been failing intermittently with WAF challenge walls (Imperva ↔ hCaptcha). The Camoufox auto-pass recipe (`humanize: true` + `disable_coop: true` + `block_webrtc: true` + a single `mouse.click` on the checkbox iframe) is the only documented free path to emit a real `h-captcha-response` token. This PR turns that recipe into a reusable interceptor that fires automatically whenever a checkbox challenge mounts — regardless of bank or pipeline phase.

## Architecture

**Open / Closed:** the solver registry is a frozen `Record<WafChallengeKind, WafChallengeSolver>`. Adding Arkose / GeeTest support means **registering a kind + solver pair** — zero edits to detection or wiring.

**Zero CSS selectors in interaction code** (per the ABSOLUTE architecture rule):
- Detection: `frame.url()` substring match (`hcaptcha.html#frame=checkbox` is hCaptcha's canonical widget-API discriminator)
- Solve: `page.mouse.click(centreX, centreY)` on the iframe's bounding box — Camoufox C++ humanize provides the curved cursor approach + jittered timing
- No `querySelector`, no `getByText`, no DOM walk anywhere in the WAF code path

**Defensive everywhere:**
- `frame.url()` and `frame.frameElement()` wrapped in try / `false` (detached frames don't throw upward)
- Solver-thrown errors swallowed into `DidSolve(false)` — the interceptor never fails the pipeline
- Idempotent attach via `WeakSet<Page>`; per-page cool-down (8 s) via `WeakMap<Page, number>`
- `page.on('close')` auto-detach so polling timers never outlive their page
- Kill-switch env var `WAF_INTERCEPTOR_DISABLED=1` for bisect / debug
- `clickCentreSafe` helper wraps `page.mouse.click` in try/catch so a page closed mid-click cannot escape the solver (CR1 fix)

**Rule #15 (branded returns):** every exported function returns a `Brand<...>` (`DidSolve`, `DidAttach`, `DidDetach`, `DidTickWork`, `IsDisabled`, `IsInCooldown`).

## Files

8 production files + 7 unit-test files + 1 docs page + 1 shared test helper + 2 modified files (LayerSeparation allowlist + PipelineBuilderHelpers wiring).

| File | Purpose |
|---|---|
| `Interceptors/WafChallenge/WafChallengeInterceptor.ts` | Factory `createWafChallengeInterceptor` (only consumer surface) |
| `Interceptors/WafChallenge/WafChallengeConfig.ts` | Pinned constants (poll 2 s, networkidle 15 s, hydration 5 s, cool-down 8 s, env var) — `as const` tuples (CR2) |
| `Interceptors/WafChallenge/WafChallengeTypes.ts` | Branded types: `DidSolve`, `WafChallengeKind`, `IWafChallenge`, `ISolverArgs`, `WafChallengeSolver` |
| `Interceptors/WafChallenge/WafChallengeDetector.ts` | Pure frame-URL classifier → `Option<IWafChallenge>` |
| `Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts` | Camoufox auto-pass recipe; `clickCentreSafe` helper added (CR1) |
| `Interceptors/WafChallenge/TurnstileCheckboxSolver.ts` | Delegates to hCaptcha solver (same primitive) |
| `Interceptors/WafChallenge/WafChallengeSolverRegistry.ts` | Frozen Record — OCP extensibility |
| `Interceptors/WafChallenge/WafChallengeInternals.ts` | Poller / state primitives (12 helpers); brand `IsDisabled` (CR4) |
| `docs/architecture/waf-interceptor.md` | Architecture page — interceptor purpose, attach/detach lifecycle, Camoufox recipe, kill-switch, telemetry, failure-mode matrix, OCP extension steps (CR3) |
| `Tests/Unit/Pipeline/Interceptors/WafChallenge/WafChallengeTestHelpers.ts` | Shared `clearDisableEnv` / `makeLogger` / `makePageStub` (CR5) |
| `Core/Builder/PipelineBuilderHelpers.ts` | Wires interceptor **first** in `buildBrowserBaseInterceptors()` |

## Cycle-1 follow-up — commit `36496687`

CodeRabbit cycle-1 review on initial commit `78f4377d` returned 5 actionable findings; all five (plus the Docs-coverage CI canary failure for 12 new exports) resolved in a single follow-up commit:

| CR | Severity | File | Resolution |
|---|---|---|---|
| 1 | Major | `HCaptchaCheckboxSolver.ts` | Extract `clickCentreSafe` helper — `page.mouse.click` can throw if the page closes between bounding-box read and click; solver contract forbids throws |
| 2 | Major | `WafChallengeConfig.ts` | `readonly string[]` → `as const` tuples (preserves literal types for downstream narrowing) |
| 3 | Major | `WafChallengeInterceptor.ts` | New `docs/architecture/waf-interceptor.md` covering interceptor + kill-switch + 12 internals (also resolves Docs-coverage CI canary naturally — zero allowlist usage) |
| 4 | Minor | `WafChallengeInternals.ts` | Brand `IsEnabled` → `IsDisabled` so the type and `isDisabled()` agree on meaning |
| 5 | Nit | tests | Extract `clearDisableEnv` / `makeLogger` / `makePageStub` into `WafChallengeTestHelpers.ts` (mirrors `TestHelpers.ts` / `MockFactories.ts` infra pattern) |

## How it works (sequence)

```mermaid
sequenceDiagram
    participant Pipeline as PipelineExecutor
    participant Inter as createWafChallengeInterceptor
    participant Poll as setInterval (2s)
    participant Detect as detectChallenge
    participant Solve as HCaptchaCheckboxSolver

    Pipeline->>Inter: beforePhase(ctx, 'init')
    Inter->>Poll: attachPoller — registers timer per Page
    loop every 2s
        Poll->>Detect: scan page.frames() for known URL patterns
        Detect-->>Poll: Option<IWafChallenge>
        alt challenge detected, not in cooldown, not already solving
            Poll->>Solve: settle network → 5s hydration → click iframe centre
            Solve-->>Poll: DidSolve(true|false)
        end
    end
    Pipeline->>Inter: afterPipeline(ctx)
    Inter->>Poll: detachPoller — clears timer
```

## Test evidence

**Local validation matrix (head `36496687`):**
- `tsc --noEmit` → exit 0
- ESLint on touched files → 0 errors
- `lint:canaries` → 46 TS + 5 bash ✅
- `lint:guideline-coverage` → 4 clusters ✅
- `jest Pipeline/Interceptors/WafChallenge` → 85/85 pass
- `jest Pipeline/(Interceptors|Architecture|Core/Builder)` → 229/229 pass
- `test:pipeline` (full) → **4914/4914 pass**; coverage **97.08 / 95 / 97.25 / 98.33**
- `npm run build` → `lib/index.d.ts` byte-identical (hash `221E161…`)
- `docs-coverage.sh` → 12 documented, 0 missing, **PASS**
- `mkdocs build --strict` → exit 0
- Madge → WafChallenge cluster acyclic

**Layer B smoke (manual local run vs hCaptcha public demo):** produces a 36-byte `h-captcha-response` token end-to-end. Smoke script is gitignored (preserved in session artifacts).

## Kill-switch

`WAF_INTERCEPTOR_DISABLED=1 npm run my-scrape` disables the interceptor without rebuilding. Accepted values: `1`, `true` (any case). Strict allowlist — `yes` / `on` leave the interceptor active. See `docs/architecture/waf-interceptor.md` §"Kill-switch".

## Risk register

| Risk | Mitigation |
|---|---|
| Interceptor introduces a regression for non-WAF banks | Kill-switch ships in the same commit; per-page cool-down prevents hammering; never fails pipeline (always returns `succeed`) |
| Poller leaks timers when pages close abruptly | `wirePageClose` registers `page.on('close', detachPoller)`; `WeakSet<Page>` lets GC reclaim state |
| Two concurrent solver invocations on same page | `solving: WeakSet<Page>` mutex set inside `runSolverGuarded` |
| WAF provider widens checkbox pattern | Detector's exclusion of `#frame=challenge` is regression-tested (`WafChallengeDetector.test.ts`); update is a 1-line constant change in `WafChallengeConfig.ts` |

## Out of scope

- Hapoalim docker happy-path validation (Layer C) — deferred to a follow-up
- Real-world Hapoalim CI E2E Real run — pending merge; will validate next CI cycle
- Cloudflare Turnstile (delegates to hCaptcha solver — same primitive; verified by unit test, not yet by smoke)
- Puzzle/challenge UI (hidden `#frame=challenge` iframe) — by design, this PR solves only the **checkbox** primitive



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection and resolution of hCaptcha and Cloudflare Turnstile checkbox-style WAF challenges during browser pipeline execution.

* **Documentation**
  * Added comprehensive architecture guide covering the WAF challenge interceptor system, including control flow, configuration options, and extension patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


