### PR TITLE
fix(build): restore side-effect query registrations dropped by tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "provenance": true
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "src/**/graphql/*Queries.ts",
+    "lib/index.cjs",
+    "lib/index.mjs"
+  ],
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/src/Common/Transactions.ts
+++ b/src/Common/Transactions.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { sortBy } from 'lodash';
 import moment, { type Moment } from 'moment';
 
 import { type ITransaction, TransactionTypes } from '../Transactions.js';
@@ -67,7 +67,7 @@ export function fixInstallments(txns: ITransaction[]): ITransaction[] {
  * @returns A new array of transactions sorted by date.
  */
 export function sortTransactionsByDate(txns: ITransaction[]): ITransaction[] {
-  return _.sortBy(txns, ['date']);
+  return sortBy(txns, ['date']);
 }
 
 /**

--- a/src/Tests/Unit/PackageSideEffectsPolicy.test.ts
+++ b/src/Tests/Unit/PackageSideEffectsPolicy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Drift pin for package.json `sideEffects` allowlist.
+ *
+ * Two surfaces must move together or the published npm bundle silently
+ * loses critical side-effect work:
+ *
+ *   1. **Source side-effect imports** — bank pipelines bootstrap their
+ *      GraphQL queries via bare `import './graphql/<Bank>Queries.js'`
+ *      side-effect imports that fire `registerWkQuery(...)` at module
+ *      load time. The well-known query registry (`WK`) is populated this
+ *      way and is read by the API-DIRECT-CALL phase.
+ *
+ *   2. **package.json `sideEffects`** — declares which files actually
+ *      have side effects so the bundler (tsup/esbuild with treeshake)
+ *      and downstream consumers (Webpack/Vite) do NOT tree-shake them
+ *      away.
+ *
+ * A blanket `"sideEffects": false` (as briefly shipped in PR #280)
+ * silently drops every bare side-effect import → published bundle has
+ * ZERO `registerWkQuery` calls → OneZero & Pepper scrapes fail at
+ * runtime with empty WK registry.
+ *
+ * This pin asserts:
+ *   - `sideEffects` is an array allowlist (not `false`, not `true`)
+ *   - The allowlist matches every `*Queries.ts` file in the source tree
+ *   - The published bundle paths (`lib/index.cjs` and `lib/index.mjs`)
+ *     are included so downstream bundlers do not tree-shake the inlined
+ *     `registerWkQuery` calls after our build.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { globSync } from 'glob';
+
+const SELF_URL = import.meta.url;
+const SELF_PATH = fileURLToPath(SELF_URL);
+const SELF_DIR = path.dirname(SELF_PATH);
+const REPO_ROOT = path.join(SELF_DIR, '..', '..', '..');
+const PACKAGE_JSON_PATH = path.join(REPO_ROOT, 'package.json');
+
+const SOURCE_QUERIES_GLOB = 'src/**/graphql/*Queries.ts';
+const PUBLISHED_BUNDLE_PATHS = ['lib/index.cjs', 'lib/index.mjs'];
+
+/**
+ * Read and parse the root package.json.
+ * @returns Parsed package.json content as a plain object.
+ */
+function loadPackageJson(): Record<string, unknown> {
+  const raw = readFileSync(PACKAGE_JSON_PATH, 'utf8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe('package.json sideEffects allowlist drift pin', () => {
+  it('sideEffects is an array allowlist (not a blanket boolean)', () => {
+    const pkg = loadPackageJson();
+    const sideEffects = pkg.sideEffects;
+    const isAllowlist = Array.isArray(sideEffects);
+    expect(isAllowlist).toBe(true);
+  });
+
+  it('declares the source query side-effect file glob', () => {
+    const pkg = loadPackageJson();
+    const sideEffects = pkg.sideEffects as string[];
+    expect(sideEffects).toContain(SOURCE_QUERIES_GLOB);
+  });
+
+  it('declares both published bundle entry points', () => {
+    const pkg = loadPackageJson();
+    const sideEffects = pkg.sideEffects as string[];
+    for (const bundlePath of PUBLISHED_BUNDLE_PATHS) {
+      expect(sideEffects).toContain(bundlePath);
+    }
+  });
+
+  it('allowlist glob matches every *Queries.ts side-effect source file', () => {
+    const globOptions = { cwd: REPO_ROOT };
+    const found = globSync(SOURCE_QUERIES_GLOB, globOptions);
+    expect(found.length).toBeGreaterThanOrEqual(2);
+    for (const file of found) {
+      const absolutePath = path.join(REPO_ROOT, file);
+      const body = readFileSync(absolutePath, 'utf8');
+      expect(body).toMatch(/^registerWkQuery\(/m);
+    }
+  });
+});


### PR DESCRIPTION
## Why

PR #280 ( + "efactor/phase-8.5a" +  — commit `43e9f16e`) added `"sideEffects": false` to `package.json` to enable tree-shaking. This **silently broke** the bare side-effect imports that bootstrap GraphQL queries into the WK (well-known) registry at module load time.

The published `lib/index.mjs` bundle currently being produced on `main` contains **ZERO** `registerWkQuery` calls. The next `release-please` npm release would have shipped a broken bundle that fails to scrape OneZero & Pepper at runtime.

8.4.0 (current latest on npm) predates PR #280 and is unaffected.

### Build evidence — before fix

 + "`" + ` + "" + ` + "" + 
$ npm run build
[warn] ▲ [WARNING] Ignoring this import because OneZeroQueries.ts was marked
       as having no side effects [ignored-bare-import]
[warn] ▲ [WARNING] Ignoring this import because PepperQueries.ts was marked
       as having no side effects [ignored-bare-import]
       (×2 — once for CJS, once for ESM = 4 warnings total)

$ Select-String -Path lib\index.mjs -Pattern registerWkQuery | Measure-Object
Count: 0    # <-- broken bundle
 + "`" + ` + "" + ` + "" + 

### Build evidence — after fix

 + "`" + ` + "" + ` + "" + 
$ npm run build  # no ignored-bare-import warnings
$ Select-String -Path lib\index.mjs -Pattern registerWkQuery | Measure-Object
Count: 7    # 1 function definition + 6 call sites (OneZero ×3, Pepper ×3)
$ Select-String -Path lib\index.cjs -Pattern registerWkQuery | Measure-Object
Count: 7
 + "`" + ` + "" + ` + "" + 

## Changes

### 1. `package.json` — sideEffects allowlist (replaces blanket `false`)
 + "`" + ` + "" + ` + "" + diff
-  "sideEffects": false,
+  "sideEffects": [
+    "src/**/graphql/*Queries.ts",
+    "lib/index.cjs",
+    "lib/index.mjs"
+  ],
 + "`" + ` + "" + ` + "" + 

The allowlist covers both contexts:
- **source-time** (our tsup build): matches the OneZero/Pepper Queries.ts files
- **consume-time** (downstream Webpack/Vite/Rollup): matches the published bundle paths so consumers do not re-tree-shake the inlined `registerWkQuery` calls

### 2. `src/Common/Transactions.ts` — named lodash import
 + "`" + ` + "" + ` + "" + diff
-import _ from 'lodash';
+import { sortBy } from 'lodash';
-  return _.sortBy(txns, ['date']);
+  return sortBy(txns, ['date']);
 + "`" + ` + "" + ` + "" + 

Resolves the `"default" is imported from external module "lodash" but never used` warning. Named imports are more tree-shake-friendly. The build still emits an informational `"sortBy" is imported … but never used` warning, but this is **honest dead-code detection** — `sortTransactionsByDate` is only referenced by its own tests and is not re-exported from `src/index.ts`. Previously this was hidden behind the lodash default wrapper.

### 3. NEW `src/Tests/Unit/PackageSideEffectsPolicy.test.ts` — regression pin (77 LoC, 4 tests)

Asserts:
1. `sideEffects` is an array allowlist (not `false`, not `true`)
2. `src/**/graphql/*Queries.ts` is declared
3. `lib/index.cjs` and `lib/index.mjs` are declared
4. The glob matches every `*Queries.ts` source file AND each file contains a `registerWkQuery(` call

Any future drift on either surface (silent flip back to `sideEffects: false`, or a new bank pipeline shipped without an allowlisted side-effect path) trips this pin.

## Validation

| Gate | Status |
|---|---|
| `npx tsc --noEmit` | ✅ clean |
| `npx eslint` (changed files) | ✅ clean |
| `npx prettier --check` (changed files) | ✅ clean |
| `PackageSideEffectsPolicy.test.ts` | ✅ 4/4 PASS |
| `Transactions.test.ts` (lodash rename regression) | ✅ 27/27 PASS |
| `npm run build` warnings | ✅ ignored-bare-import GONE |
| `lib/index.mjs` `registerWkQuery` count | ✅ 0 → 7 |
| Husky 20-gate ladder (Phase 1 → Phase 5 incl. Mock E2E + Live E2E happy-path) | ✅ ALL GREEN |

## Refs

- PR #280 commit `43e9f16e` — introduced the blanket `"sideEffects": false` that triggered this regression
- PR #206 commit `60b49133` — original side-effect imports for OneZero/Pepper queries

## Scope discipline

This is a **standalone surgical fix** — not folded into PR #282 (WAF interceptor) which already has 3 cherry-picks deep of careful scope management. The bug is tangential and high-severity (next npm release impact), so it ships independently.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot/cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>