### PR TITLE
fix(ci): exempt bot PRs from §10 body-section check

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -19,7 +19,37 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const body = context.payload.pull_request.body || '';
+            // Bot-authored PRs (Dependabot, release-please) cannot generate the §10
+            // guideline-compliance table by design. Exempt them so dependency bumps and
+            // release PRs are not blocked from auto-merge. Human PRs remain enforced.
+            //
+            // Bot signals — ANY match exempts the PR:
+            //   - pull_request.user.login matches a known bot account
+            //   - pull_request.head.ref matches a known bot branch prefix
+            //     (release-please uses a human PAT, so user.login alone is unreliable)
+            const pr = context.payload.pull_request;
+            const author = (pr.user && pr.user.login) || '';
+            const headRef = (pr.head && pr.head.ref) || '';
+            const BOT_AUTHORS = new Set([
+              'dependabot[bot]',
+              'release-please[bot]',
+              'github-actions[bot]',
+            ]);
+            const BOT_BRANCH_PREFIXES = [
+              'dependabot/',
+              'release-please--',
+            ];
+            const isBotPr =
+              BOT_AUTHORS.has(author) ||
+              BOT_BRANCH_PREFIXES.some((prefix) => headRef.startsWith(prefix));
+            if (isBotPr) {
+              core.info(
+                `PR-body check skipped — bot-authored PR (author='${author}', head='${headRef}').`,
+              );
+              return;
+            }
+
+            const body = pr.body || '';
             const required = [
               { header: '## Guideline compliance', cite: 'pr-guidlines.md §10' },
               { header: '## Why',                  cite: 'pr-guidlines.md §7'  },


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Status | Verification |
|---|---|---|---|
|  1 | Conventional Commits + 50/72 + Co-authored-by trailer (commit-guidlines.md) | ✅ | `git log -1 --format='%s%n%b'` shows `fix(ci):` subject ≤ 50, body wraps at 72, trailer present |
|  2 | One PR == one logical change (pr-guidlines.md §1) | ✅ | 1 file changed, 31 insertions(+), 1 deletion(-) — single bot-exempt guard |
|  3 | No `--no-verify` (before-commit-guidlines.md §3) | ✅ | husky pre-commit ran cleanly: `⏭️  No source code changes — skipping quality gates` (line 8 grep filter excludes `.github/**`) |
|  4 | Pin third-party actions by SHA (pr-template CI/security) | ✅ | reused `actions/github-script@ed597411…` — already pinned + already in repo |
|  5 | No secrets in code / commit message (CI/security) | ✅ | `git diff main...HEAD` ⇒ no secrets |
|  6 | No PII / customer identifiers (CI/security) | ✅ | YAML fix touches only bot detection literals |
|  7 | YAML syntactically valid (pr-body-check.yml is a workflow file) | ✅ | parses as valid GitHub Actions workflow; `actions/github-script@v8` `script:` block uses standard JS |
|  8 | Pre-commit 20 gates green (or skipped per filter) (before-commit-guidlines.md) | ✅ | `.github/**` YAML-only ⇒ husky exits 0 with "No source code changes" — see commit log |
|  9 | Public API of `@sergienko4/israeli-bank-scrapers` byte-identical (CLAUDE.md / Phase 3 AC9) | ✅ | no `src/**` change; `lib/index.cjs bytes: 878970` from post-commit snapshot |
| 10 | Coverage 97/95/97/98 preserved (CLEAN_CODE.md) | ✅ | no source change ⇒ coverage unchanged |
| 11 | `lint:canaries` count matches (status.txt declared 53) | ✅ | no canary change ⇒ count still 53 |
| 12 | `madge --circular` returns zero new cycles | ✅ | no source change ⇒ cycle count unchanged |
| 13 | ZERO CSS selectors in interaction code (CLAUDE.md) | ✅ | N/A — no interaction code touched |
| 14 | Methods ≤ 10 lines (CLEAN_CODE.md) | ✅ | YAML `script:` block has one early-return guard (8 logic lines) + the existing 21-line validator (pre-existing, not authored by this PR) |
| 15 | Documentation updated for user-visible behaviour change | ✅ | N/A — CI infrastructure change. The `pr-guidlines.md` enforcement contract for HUMAN PRs is unchanged. |
| 16 | agent-contract.md §A3.5 exit-gate (CI parity) | ✅ | local husky parity green; CI will re-validate via PR Body Compliance running on this very PR |
| 17 | Frozen-test invariant (master spec.txt §13.1) | ✅ | N/A — no test files touched |
| 18 | Reversibility (general-rules-guidlines.md) | ✅ | revert SHA restores the pre-fix behaviour; no schema/data migration |

## Why

Dependabot PR #265 (playwright-core 1.59.1 → 1.60.0) and release-please PR #284 (release 8.5.0) are both blocked by the `PR Body Compliance` check failing with `## Guideline compliance / ## Why / ## What missing`. Bots cannot author these sections by design — they generate body content from a fixed template (dependency changelog, release notes). The current validator treats bot PRs identically to human PRs, so the weekly dependency-update train and the release-please train have both stalled. Without this fix:

- new `playwright-core` security/regression patches cannot land
- release 8.5.0 cannot publish to npm
- every future dependabot + release-please PR repeats the same stuck state

## What

Add an early-return guard at the top of `.github/workflows/pr-body-check.yml`'s `script:` block that exempts bot-authored PRs based on TWO independent signals (either match exempts):

- `pull_request.user.login` ∈ `{dependabot[bot], release-please[bot], github-actions[bot]}`
- `pull_request.head.ref` starts with `dependabot/` or `release-please--`

The two signals are belt-and-braces: release-please uses a human PAT (`RELEASE_TOKEN`), so its `user.login` is the repo owner (`sergienko4`) — only the head-ref prefix catches it. Dependabot can be matched by either. Future GitHub-internal renames of either bot account won't silently re-block the train.

Human PRs continue to flow through the unchanged validator below the guard — the §10 18-row guideline-compliance table + §7 Why/What remain mandatory for humans. This very PR is a human PR and complies above.

- `.github/workflows/pr-body-check.yml` — +31/-1, single commit (`fix(ci): exempt bot PRs from §10 body-section check`)

## Test plan

- [ ] unit tests added / updated — N/A (workflow YAML, logic verified inline)
- [ ] integration tests added / updated where the surface warrants — N/A
- [X] `npm run lint` passes — N/A for `.github/**` (no `src/**` touched)
- [X] `npm run lint:guideline-coverage` passes — N/A (no `eslint.config.mjs` change)
- [X] `npm run lint:canaries` passes — N/A (no canary change)
- [X] `npm run test:pipeline` passes — N/A (no source change)
- [X] `npm run test:e2e:mock` passes — N/A (no source change)

After this PR merges, validate the fix end-to-end by:
1. Comment `@dependabot recreate` on PR #265 — body-check should now PASS, dependabot-auto-merge should kick in, PR should land
2. Edit PR #284 (release-please) trivially to retrigger checks — body-check should now PASS

## Docs

- [X] page added or updated under `docs/` — N/A (CI infrastructure change, no user-facing surface)
- [X] `mkdocs.yml` nav updated — N/A
- [X] JSDoc comments updated — N/A
- [X] N/A — explain why: pure CI-side bot-exemption guard; the canonical PR template (`.github/PULL_REQUEST_TEMPLATE.md`) for HUMAN authors is unchanged and remains the contract.

## CI / security

- [X] no secrets committed
- [X] no PII or customer identifiers in code, tests, or commit messages
- [X] new third-party action pinned by SHA (not by tag) — N/A (reused already-pinned `actions/github-script@ed597411…`)
- [X] new shell scripts include `set -euo pipefail` — N/A (no shell scripts added)

## Notes for reviewer

- The guard runs FIRST in the script block — bot PRs short-circuit and skip the body validator entirely. Human PRs proceed unchanged.
- Detection is fail-open by design (favours unblocking the train over strict enforcement on bots) because bots have no facility to add the §10 table.
- If a HUMAN happens to push from a branch named `dependabot/foo` or `release-please--foo`, they will accidentally bypass the check. This is acceptable: the branch-prefix space is reserved-by-convention for the bots; humans never use these prefixes in practice. The much-larger risk (every dependabot + release-please PR stuck forever) is the one being solved.
