### PR TITLE
chore(husky): add T1-INVERSE pre-commit guard for test-only branches

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,6 +11,39 @@ if [ -z "$CODE_FILES" ]; then
     exit 0
 fi
 
+# ── T1-INVERSE: test-only branch lockdown ─────────────────────────────
+# Symmetric to the existing T1 test-body-freeze guard (commit-msg hook).
+# Blocks production-code changes on test-only branches so test-refactor
+# PRs cannot silently smuggle behaviour changes.
+#
+# Activates when branch matches: refactor/phase-7-*, refactor/phase-9-*,
+# or chore/test-*. Production-code = anything under src/ that is NOT
+# under src/Tests/ or src/Scrapers/Pipeline/EslintCanaries/.
+#
+# If you discovered a production bug while doing test-only work, open
+# a separate fix(prod): PR FIRST, merge it, rebase this branch on the
+# new main, then resume the test-only work. Test-only PRs must stay
+# behaviour-preserving for review reliability.
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+case "$BRANCH" in
+    refactor/phase-7-*|refactor/phase-9-*|chore/test-*)
+        PROD_DIFF=$(echo "$STAGED_FILES" | grep -E '^src/' \
+            | grep -v -E '^src/Tests/' \
+            | grep -v -E '^src/Scrapers/Pipeline/EslintCanaries/' \
+            || true)
+        if [ -n "$PROD_DIFF" ]; then
+            echo "❌ T1-INVERSE: test-only branch '$BRANCH' contains production-code changes:" | tee -a "$LOG_FILE"
+            echo "$PROD_DIFF" | sed 's/^/   /' | tee -a "$LOG_FILE"
+            echo "" | tee -a "$LOG_FILE"
+            echo "Test-only branches forbid src/Scrapers/** diffs (canaries excepted)." | tee -a "$LOG_FILE"
+            echo "If you discovered a production bug, open a separate fix(prod): PR" | tee -a "$LOG_FILE"
+            echo "FIRST, merge it, rebase this branch, then resume the test-only work." | tee -a "$LOG_FILE"
+            exit 1
+        fi
+        echo "✅ T1-INVERSE: zero production-code diff on test-only branch '$BRANCH'" | tee -a "$LOG_FILE"
+        ;;
+esac
+
 log() { echo "$1" | tee -a "$LOG_FILE"; }
 FAIL_COUNT=0
 FAIL_NAMES=""

--- a/.husky/tests/t1-inverse-hook.test.sh
+++ b/.husky/tests/t1-inverse-hook.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Unit test for the T1-INVERSE pre-commit guard in .husky/pre-commit.
+#
+# T1-INVERSE blocks production-code (src/Scrapers/**) changes on
+# test-only branches (refactor/phase-7-*, refactor/phase-9-*, chore/test-*)
+# so test-refactor PRs cannot silently smuggle behaviour changes.
+#
+# This test extracts the guard's predicate logic and runs it against
+# synthetic STAGED_FILES / BRANCH combinations. Run via:
+#
+#   bash .husky/tests/t1-inverse-hook.test.sh
+#
+# Exit 0 = all scenarios behave correctly; 1 = a scenario regressed.
+
+set -o pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+
+run_scenario() {
+    local name="$1" branch="$2" staged="$3" expected_exit="$4"
+    local actual_exit=0
+    local prod_diff
+    prod_diff=$(echo "$staged" | grep -E '^src/' \
+        | grep -v -E '^src/Tests/' \
+        | grep -v -E '^src/Scrapers/Pipeline/EslintCanaries/' \
+        || true)
+    case "$branch" in
+        refactor/phase-7-*|refactor/phase-9-*|chore/test-*)
+            if [ -n "$prod_diff" ]; then
+                actual_exit=1
+            fi
+            ;;
+    esac
+
+    if [ "$actual_exit" = "$expected_exit" ]; then
+        echo "PASS: $name (exit $actual_exit)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name (expected exit $expected_exit, got $actual_exit)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+run_scenario "test-only branch + test files only" \
+    "refactor/phase-7-test-diamond-structural" \
+    "src/Tests/Unit/Pipeline/Login.test.ts
+src/Tests/Helpers/factory.ts" \
+    0
+
+run_scenario "test-only branch + prod file staged (BLOCK)" \
+    "refactor/phase-7-test-diamond-structural" \
+    "src/Tests/Unit/Pipeline/Login.test.ts
+src/Scrapers/Pipeline/Mediator/Login/LoginResolver.ts" \
+    1
+
+run_scenario "test-only branch + canary file (ALLOW)" \
+    "refactor/phase-9-max-lines" \
+    "src/Scrapers/Pipeline/EslintCanaries/new-rule.canary.ts" \
+    0
+
+run_scenario "fix/foo branch + prod file (hook inactive)" \
+    "fix/some-bug" \
+    "src/Scrapers/Pipeline/Mediator/Login/LoginResolver.ts" \
+    0
+
+run_scenario "chore/test-* branch + .husky only (ALLOW)" \
+    "chore/test-husky-t1-inverse-hook" \
+    ".husky/pre-commit" \
+    0
+
+run_scenario "phase-7 branch + mixed test+prod (BLOCK)" \
+    "refactor/phase-7-flow-diamond" \
+    "src/Tests/Unit/Pipeline/Flow/Login.test.ts
+src/Scrapers/Pipeline/Strategy/Fetch/FetchStrategy.ts
+src/Tests/Helpers/banks.ts" \
+    1
+
+run_scenario "chore/test-* + Tests only (ALLOW)" \
+    "chore/test-add-helper" \
+    "src/Tests/Helpers/new.ts" \
+    0
+
+run_scenario "main branch + prod file (hook inactive)" \
+    "main" \
+    "src/Scrapers/Pipeline/Mediator/Login/LoginResolver.ts" \
+    0
+
+run_scenario "phase-7 branch + zero staged (ALLOW)" \
+    "refactor/phase-7-test-diamond-structural" \
+    "" \
+    0
+
+run_scenario "detached HEAD + prod file (hook inactive)" \
+    "" \
+    "src/Scrapers/Pipeline/Mediator/Login/LoginResolver.ts" \
+    0
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" = "0" ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Adds a **symmetric counterpart** to the existing T1 test-body-freeze guard:

| Hook | Hook file | Active on | Blocks |
|---|---|---|---|
| **T1** (existing) | `.husky/commit-msg` | `refactor(phase-N):` / `feat(phase-N):` / `fix(phase-N):` subjects | Test-body reshape on production-refactor phases |
| **T1-INVERSE** (this PR) | `.husky/pre-commit` | Branches matching `refactor/phase-7-*` / `refactor/phase-9-*` / `chore/test-*` | Production-code changes on test-only phases |

Together they enforce the master plan's invariant: **production refactor phases freeze tests; test-only phases freeze production.**

## Why

Phase 7 (test diamond consolidation) and Phase 9 (test max-lines enforcement) are **behaviour-preserving** by contract — the cross-bank `it.each(BANKS)` reshape and the max-lines split must not change any production code. Without this guard, an agent or contributor can silently smuggle a one-line production fix into a test-only PR, where reviewers focus on test changes and miss the prod delta.

The guard also encodes the recovery path: if you discover a real production bug while doing test work, open a separate `fix(prod):` PR first, merge it, rebase the test-only branch on the new main.

## What it blocks

```
git diff --cached --name-only | grep '^src/' | grep -v '^src/Tests/' | grep -v '^src/Scrapers/Pipeline/EslintCanaries/'
```

If that pipeline returns any path while the current branch matches the test-only prefix list, the commit is rejected with a clear diagnostic.

## What it does NOT block

- `.husky/**`, `.github/**`, `tasks/**`, `*.md`, `*.json`, `*.yml` — already exempted by the existing "Skip for non-code changes" early exit (line 12 of `.husky/pre-commit`). T1-INVERSE runs **after** that gate, so doc-only and CI-only chores on a test-only branch still succeed.
- `src/Tests/**` — the very files the test-only phase is allowed to touch.
- `src/Scrapers/Pipeline/EslintCanaries/**` — adding a canary IS the test-rule lockdown that test-only phases ship.

## Insertion point

Surgical: after the existing 'Skip for non-code changes' block (line 12), before the 12-gate cache pipeline. Adds 33 lines to `.husky/pre-commit`. No existing gate's behaviour changes.

## Test coverage

`.husky/tests/t1-inverse-hook.test.sh` — 10 scenarios, all PASS:

| # | Branch | Staged files | Expected |
|---|---|---|---|
| 1 | `refactor/phase-7-test-diamond-structural` | Tests only | ALLOW (exit 0) |
| 2 | `refactor/phase-7-test-diamond-structural` | Tests + prod | **BLOCK (exit 1)** |
| 3 | `refactor/phase-9-max-lines` | Canary only | ALLOW (exit 0) |
| 4 | `fix/some-bug` | Prod file | ALLOW — hook inactive |
| 5 | `chore/test-husky-t1-inverse-hook` | `.husky/` only | ALLOW (exit 0) |
| 6 | `refactor/phase-7-flow-diamond` | Mixed test + prod + helper | **BLOCK (exit 1)** |
| 7 | `chore/test-add-helper` | Tests only | ALLOW (exit 0) |
| 8 | `main` | Prod file | ALLOW — hook inactive |
| 9 | `refactor/phase-7-test-diamond-structural` | Empty | ALLOW (exit 0) |
| 10 | (detached HEAD) | Prod file | ALLOW — hook inactive |

Run via: `bash .husky/tests/t1-inverse-hook.test.sh`

## Verification done on this PR's own commit

Branch name `chore/test-husky-t1-inverse-hook` matches the `chore/test-*` activation pattern — the guard is active on this very commit. Staged files were only `.husky/pre-commit` + `.husky/tests/t1-inverse-hook.test.sh` → zero `src/` paths → guard passes by construction.

## Why this is its own PR (not bundled with Phase 7)

- Husky hook is **infrastructure**, not test refactor. Mixing into Phase 7 would muddy a behaviour-preserving PR's diff with policy-enforcement code.
- Lands before Phase 7 OBSERVE → Phase 7's first commit immediately benefits from the guard.
- File count: 2 (under the 150 PR cap by a wide margin).

## Out of scope (deferred)

- Tightening the existing T1 hook (commit-msg) is **not** touched — that hook is already production-tested across 17 PR #298 commits.
- No ESLint rule, no eslint canary, no CI workflow change.

## Guideline compliance

- [x] Conventional commit (`chore(husky):`)
- [x] Single concern (`pr-guidlines.md` §2 SRP)
- [x] `Co-authored-by: Copilot` trailer
- [x] No public API surface change (`src/index.ts` / `src/Scrapers/index.ts` byte-identical)
- [x] No test-body reshape (this PR is itself test-only-PR-like; only adds a NEW test file)
- [x] File count ≤ 150 (this PR: 2 files)
- [x] No `--no-verify`, no `git push --force`