### PR TITLE
refactor(tests): Phase 9 — drive test helpers ≤10 stmts + install §19.9 ESLint guardrail

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -228,6 +228,24 @@ const NO_DIRECT_SCREENSHOT_RULE = {
     'page.screenshot(...) — use safeScreenshot() from src/Scrapers/Pipeline/Mediator/Browser/SafeScreenshot.ts (PII-safe CI gate). The src/Common/SafeScreenshot.ts shim is deprecated since v8.5; new imports MUST use the canonical Pipeline path.',
 };
 
+// §19.9 TEST-HELPER STATEMENT CAP — fires on any `function foo() { ...11+ stmts }`
+// inside `src/Tests/**`. Scoped to `FunctionDeclaration` so legitimate
+// `describe('...', () => { ... })` / `it('...', () => { ... })` /
+// `it.each(cases)('...', (...) => { ... })` arrow callbacks stay
+// excluded (their bodies are ArrowFunctionExpression nodes). Drives
+// helper extraction without touching natural test-block length.
+//
+// Why a separate const (not embedded in RESTRICTED_SYNTAX_RULES):
+// the shared set is also used by production scopes, where this rule
+// would double-fire alongside `max-statements:10` (and over-fire vs
+// grandfather caps in §19.1-§19.5). Keeping it test-only avoids
+// redundant noise in production lint output.
+const TEST_HELPER_OVER_10_STMTS_RULE = {
+  selector: 'FunctionDeclaration[body.body.length>10]',
+  message:
+    '🚫 §19.9 TEST HELPER CAP: Named test helper functions cannot exceed 10 statements. Extract focused sub-helpers (Extract Function) so each helper does one thing. Arrow callbacks of describe/it/it.each are exempt (only FunctionDeclaration fires).',
+};
+
 const RESTRICTED_SYNTAX_RULES_NEW = [
   // 1. Coverage Bypasses
   {
@@ -770,8 +788,8 @@ export default tseslint.config(
       // jsdoc/check-tag-names does not reject it.
       'jsdoc/check-tag-names': ['error', { definedTags: ['jest-environment'] }],
 
-      //🚨 Prevent the 'as never' / 'as any' bypass in mocks
-      'no-restricted-syntax': ['error', ...RESTRICTED_SYNTAX_RULES],
+      //🚨 Prevent the 'as never' / 'as any' bypass in mocks + §19.9 test-helper cap
+      'no-restricted-syntax': ['error', ...RESTRICTED_SYNTAX_RULES, TEST_HELPER_OVER_10_STMTS_RULE],
     },
   },
 
@@ -835,6 +853,7 @@ export default tseslint.config(
           selector: "CallExpression[callee.object.name='page']",
           message: "🚫 Rule #10: Direct calls to 'page' are forbidden. Use ctx.mediator instead.",
         },
+        TEST_HELPER_OVER_10_STMTS_RULE,
       ],
     },
   },
@@ -2342,6 +2361,20 @@ export default tseslint.config(
     files: ['src/Tests/**/*.ts'],
     rules: {
       'max-statements': ['error', 30],
+    },
+  },
+
+  // 19.9 CANARY — TEST-HELPER FUNCTION-DECLARATION ≤10-STMT CAP.
+  //
+  // The §19.9 rule (defined inline in §4 + §5) bans
+  // FunctionDeclaration bodies > 10 stmts inside `src/Tests/**`.
+  // This canary-only block re-enables the rule on a single fixture
+  // under `EslintCanaries/` (globally ignored at line 539) so
+  // `verify.sh` can confirm the guardrail stays armed.
+  {
+    files: ['src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts'],
+    rules: {
+      'no-restricted-syntax': ['error', TEST_HELPER_OVER_10_STMTS_RULE],
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -235,16 +235,88 @@ const NO_DIRECT_SCREENSHOT_RULE = {
 // excluded (their bodies are ArrowFunctionExpression nodes). Drives
 // helper extraction without touching natural test-block length.
 //
+// Selector `[id.name]` constraint: only named FunctionDeclarations
+// trigger. Anonymous `export default function() {}` form (rare) is
+// excluded per CR cycle 2 finding — defaults are caught by §6 default-
+// export ban anyway.
+//
 // Why a separate const (not embedded in RESTRICTED_SYNTAX_RULES):
 // the shared set is also used by production scopes, where this rule
 // would double-fire alongside `max-statements:10` (and over-fire vs
 // grandfather caps in §19.1-§19.5). Keeping it test-only avoids
 // redundant noise in production lint output.
 const TEST_HELPER_OVER_10_STMTS_RULE = {
-  selector: 'FunctionDeclaration[body.body.length>10]',
+  selector: 'FunctionDeclaration[id.name][body.body.length>10]',
   message:
     '🚫 §19.9 TEST HELPER CAP: Named test helper functions cannot exceed 10 statements. Extract focused sub-helpers (Extract Function) so each helper does one thing. Arrow callbacks of describe/it/it.each are exempt (only FunctionDeclaration fires).',
 };
+
+// §19.10 TEST-HELPER LINE CAP — fires on any
+// `function foo() { ...12+ lines }` inside the Phase 9 files. Complements
+// §19.9 (which counts statements only). CR cycle 2 exposed the gap:
+// a helper of 21 lines / 5 statements slipped through §19.9 because the
+// AST selector grammar cannot compute `loc.end.line - loc.start.line`.
+//
+// Implemented as a tiny inline plugin (ESLint v9 flat-config supports
+// this via `plugins: { 'phase9-local': ... }`) because the built-in
+// `max-lines-per-function` rule cannot filter by AST node type, and
+// enabling it globally on `src/Tests/**` would fire on every long
+// `describe`/`it` arrow callback (3,049 violators per AST audit).
+//
+// Scope: Phase 9's 6 touched files only. A future "Phase 10 — Tests
+// strict 10/10" master plan extends the `files:` glob in waves
+// (analogous to §19.1→§19.5 grandfather drains in production).
+const phase9LocalPlugin = {
+  meta: { name: 'phase9-local', version: '1.0.0' },
+  rules: {
+    'fn-declaration-max-lines': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Cap named FunctionDeclaration bodies by total line count (excludes arrow callbacks of describe/it/it.each).',
+        },
+        messages: {
+          tooLong:
+            "🚫 §19.10 TEST HELPER LINE CAP: Named test helper '{{name}}' is {{lines}} lines (max {{max}}). Extract focused sub-helpers (Extract Function). Arrow callbacks of describe/it/it.each are exempt (only FunctionDeclaration fires).",
+        },
+        schema: [
+          {
+            type: 'object',
+            properties: { max: { type: 'integer', minimum: 1 } },
+            additionalProperties: false,
+          },
+        ],
+      },
+      create(context) {
+        const max = (context.options[0] && context.options[0].max) || 10;
+        return {
+          FunctionDeclaration(node) {
+            if (!node.id || !node.loc) return;
+            const lines = node.loc.end.line - node.loc.start.line + 1;
+            if (lines > max) {
+              context.report({
+                node,
+                messageId: 'tooLong',
+                data: { name: node.id.name, lines: String(lines), max: String(max) },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
+// §19.10 enforcement scope — Phase 9 6 files. Extend in Phase 10.
+const PHASE_9_TEST_FILES = [
+  'src/Tests/E2eReal/Helpers.ts',
+  'src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts',
+  'src/Tests/Tools/probe-beinleumi-nth.ts',
+  'src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts',
+  'src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts',
+  'src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts',
+];
 
 const RESTRICTED_SYNTAX_RULES_NEW = [
   // 1. Coverage Bypasses
@@ -2375,6 +2447,31 @@ export default tseslint.config(
     files: ['src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts'],
     rules: {
       'no-restricted-syntax': ['error', TEST_HELPER_OVER_10_STMTS_RULE],
+    },
+  },
+
+  // 19.10 TEST-HELPER LINE CAP — `fn-declaration-max-lines:10` on the
+  // 6 Phase 9 files. Closes the lines-vs-statements gap CR cycle 2
+  // exposed (named helpers of 21 lines / 5 stmts slipped through §19.9
+  // because AST selectors cannot compute line counts). Phase 10 master
+  // plan extends the `files:` glob to all `src/Tests/**` in waves.
+  {
+    files: PHASE_9_TEST_FILES,
+    plugins: { 'phase9-local': phase9LocalPlugin },
+    rules: {
+      'phase9-local/fn-declaration-max-lines': ['error', { max: 10 }],
+    },
+  },
+
+  // 19.10 CANARY — re-enable the rule on a single fixture under
+  // `EslintCanaries/` (globally ignored at line 539) so `verify.sh` can
+  // confirm the guardrail stays armed. Fixture is 12 lines / 5 stmts —
+  // proves §19.10 fires on a function §19.9 would miss.
+  {
+    files: ['src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-lines.canary.ts'],
+    plugins: { 'phase9-local': phase9LocalPlugin },
+    rules: {
+      'phase9-local/fn-declaration-max-lines': ['error', { max: 10 }],
     },
   },
 );

--- a/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-lines.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-lines.canary.ts
@@ -1,0 +1,42 @@
+// Canary: §19.10 — test-helper FunctionDeclaration ≤10-line cap.
+//
+// The §19.10 rule (defined as `phase9-local/fn-declaration-max-lines`
+// in eslint.config.mjs via an inline plugin) bans named-FunctionDeclaration
+// helpers whose body exceeds 10 LINES (not statements). It closes the gap
+// CR cycle 2 exposed in PR #305: a helper of 21 lines / 5 statements
+// (`buildMediatorWithEndpoints` in DashboardPhase.test.ts) slipped through
+// §19.9 because the AST selector grammar cannot compute line counts.
+//
+// This canary lives outside `src/Tests/**` (it is in `EslintCanaries/`
+// which is globally ignored at eslint.config.mjs:539) but is opted
+// back in by the §19.10-canary single-file block so `verify.sh` can
+// confirm the guardrail stays armed.
+//
+// The function body below spans exactly 12 LINES and contains only
+// 5 STATEMENTS — proving §19.10 fires where §19.9 would miss. Do NOT
+// shrink this body. Do NOT add suppression directives — the project's
+// no-suppression rule (and the §19.10 contract) bars silencing this
+// canary.
+
+/**
+ * Padded helper used purely as an ESLint fixture for the §19.10
+ * test-helper FunctionDeclaration ≤10-line cap. Proves the rule
+ * fires on a function §19.9 would miss (5 statements, 12 lines).
+ * @returns The literal 42 (irrelevant — value is unused).
+ */
+function canaryTestHelperOverTenLines(): number {
+  const obj = {
+    first: 1,
+    second: 2,
+    third: 3,
+    fourth: 4,
+    fifth: 5,
+    sixth: 6,
+  };
+  return obj.first + obj.second + obj.third + obj.fourth + obj.fifth + obj.sixth;
+}
+
+/** Second named export — keeps `import-x/prefer-default-export` quiet. */
+const CANARY_LABEL_LINES = '§19.10-test-helper-over-10-lines' as const;
+
+export { CANARY_LABEL_LINES, canaryTestHelperOverTenLines };

--- a/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts
@@ -1,0 +1,40 @@
+// Canary: §19.9 — test-helper FunctionDeclaration ≤10-statement cap.
+//
+// The §19.9 rule (in eslint.config.mjs, inlined into §4 + §5 via
+// TEST_HELPER_OVER_10_STMTS_RULE) bans named-FunctionDeclaration
+// helpers in `src/Tests/**` whose body exceeds 10 statements. This
+// canary lives outside `src/Tests/**` (it is in `EslintCanaries/`
+// which is globally ignored at eslint.config.mjs:539) but is opted
+// back in by the §19.9 single-file block so `verify.sh` can confirm
+// the guardrail stays armed.
+//
+// The function body below contains exactly 12 statements so the
+// `FunctionDeclaration[body.body.length>10]` AST selector fires.
+// Do NOT shrink this body. Do NOT add suppression directives — the
+// project's no-suppression rule (and the §19.9 contract) bars
+// silencing this canary.
+
+/**
+ * Padded helper used purely as an ESLint fixture for the §19.9
+ * test-helper FunctionDeclaration ≤10-stmt cap.
+ * @returns Twelfth incremental sum (irrelevant — value is unused).
+ */
+function canaryTestHelperOverTenStatements(): number {
+  const a = 1;
+  const b = a + 1;
+  const c = b + 1;
+  const d = c + 1;
+  const e = d + 1;
+  const f = e + 1;
+  const g = f + 1;
+  const h = g + 1;
+  const i = h + 1;
+  const j = i + 1;
+  const k = j + 1;
+  return k;
+}
+
+/** Second named export — keeps `import-x/prefer-default-export` quiet. */
+const CANARY_LABEL = '§19.9-test-helper-over-10';
+
+export { CANARY_LABEL, canaryTestHelperOverTenStatements };

--- a/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-stmts.canary.ts
@@ -35,6 +35,6 @@ function canaryTestHelperOverTenStatements(): number {
 }
 
 /** Second named export — keeps `import-x/prefer-default-export` quiet. */
-const CANARY_LABEL = '§19.9-test-helper-over-10';
+const CANARY_LABEL = '§19.9-test-helper-over-10' as const;
 
 export { CANARY_LABEL, canaryTestHelperOverTenStatements };

--- a/src/Tests/E2eReal/Helpers.ts
+++ b/src/Tests/E2eReal/Helpers.ts
@@ -45,6 +45,23 @@ function isPlaywrightAddPageErrorFalsePositive(err: Error): boolean {
 }
 
 /**
+ * The uncaughtException listener body for the Playwright filter.
+ * Swallows the known false-positive teardown TypeError; re-throws others
+ * so jest still fails the run.
+ * @param err - Uncaught error.
+ * @returns True when the error was the known Playwright false positive.
+ */
+function handlePlaywrightUncaught(err: Error): boolean {
+  if (isPlaywrightAddPageErrorFalsePositive(err)) {
+    // Known Playwright-internal teardown TypeError — scrape already
+    // completed; let the test's assertions decide pass/fail.
+    return true;
+  }
+  // Any other uncaught error — re-emit so jest still fails the run.
+  throw err;
+}
+
+/**
  * Install the Playwright `addPageError` uncaughtException filter.
  * Idempotent — safe to call from every test file's import surface.
  * @returns True once installed (or already installed).
@@ -52,15 +69,7 @@ function isPlaywrightAddPageErrorFalsePositive(err: Error): boolean {
 function installPlaywrightAddPageErrorFilter(): boolean {
   if (isPlaywrightFilterInstalled) return true;
   isPlaywrightFilterInstalled = true;
-  process.on('uncaughtException', (err: Error): boolean => {
-    if (isPlaywrightAddPageErrorFalsePositive(err)) {
-      // Known Playwright-internal teardown TypeError — scrape already
-      // completed; let the test's assertions decide pass/fail.
-      return true;
-    }
-    // Any other uncaught error — re-emit so jest still fails the run.
-    throw err;
-  });
+  process.on('uncaughtException', handlePlaywrightUncaught);
   return true;
 }
 

--- a/src/Tests/E2eReal/Helpers.ts
+++ b/src/Tests/E2eReal/Helpers.ts
@@ -82,6 +82,65 @@ const FAILED_LOGIN_TYPES: string[] = [
 ];
 
 /**
+ * Assert that a result reports no error (typed result.errorType +
+ * errorMessage both empty). Extracted from assertSuccessfulScrape to
+ * keep the orchestrator within the test-helper statement cap.
+ * @param result - the scraper result to validate
+ * @returns true when no error reported
+ */
+function assertNoErrorReported(result: IScraperScrapingResult): true {
+  const errorType = result.errorType ?? '';
+  const errorMessage = result.errorMessage ?? '';
+  const error = `${errorType} ${errorMessage}`.trim();
+  expect(error).toBe('');
+  return true;
+}
+
+/**
+ * Synthetic fallback `accountNumber` value the SCRAPE phase emits when
+ * no record carries a display id. Mirrored from the production
+ * constant `DEFAULT_ACCOUNT_NUMBER` in
+ * `src/Scrapers/Pipeline/Strategy/Scrape/ScrapeDataActions.ts:402`
+ * (file-private over there; test-only PR cannot export it without
+ * touching production). Any account that lands in CI with this id
+ * means account-resolution leaked the fallback and the scrape is a
+ * regression — `redactAccount` masks it as `***fault` in production
+ * traces.
+ */
+const BEINLEUMI_DEFAULT_FALLBACK_ID = 'default' as const;
+
+/**
+ * Assert that one account has a usable accountNumber and a txns array.
+ * Rejects the Beinleumi-class fallback id explicitly — see
+ * {@link BEINLEUMI_DEFAULT_FALLBACK_ID}.
+ * @param account - one transactions-account from the scrape result
+ * @returns true when the account passes per-account assertions
+ */
+function assertAccountValid(account: ITransactionsAccount): true {
+  expect(account.accountNumber).toBeTruthy();
+  expect(account.accountNumber).not.toBe(BEINLEUMI_DEFAULT_FALLBACK_ID);
+  const isArray = Array.isArray(account.txns);
+  expect(isArray).toBe(true);
+  return true;
+}
+
+/**
+ * Assert that the bank reported at least one transaction across all
+ * accounts in the 180-day window. Extractor regressions (e.g. Discount
+ * returning 6 txns from the API but reporting 0 to the pipeline)
+ * silently passed before this stricter assertion was added — every CI
+ * bank is known to have activity in the default look-back window, so
+ * total === 0 means data is being lost downstream of the scrape.
+ * @param accounts - non-empty accounts slice from the scraper result
+ * @returns true when total txn count is positive
+ */
+function assertNonZeroTotalTxns(accounts: readonly ITransactionsAccount[]): true {
+  const totalTxns = accounts.reduce((acc, a): number => acc + a.txns.length, 0);
+  expect(totalTxns).toBeGreaterThan(0);
+  return true;
+}
+
+/**
  * Asserts that a scrape result indicates successful login AND meaningful
  * data retrieval per the project rule: a bank with zero accounts, an
  * account with no usable identifier, or a result with zero transactions
@@ -92,33 +151,13 @@ const FAILED_LOGIN_TYPES: string[] = [
  * @returns true when all assertions pass
  */
 export function assertSuccessfulScrape(result: IScraperScrapingResult): boolean {
-  const errorType = result.errorType ?? '';
-  const errorMessage = result.errorMessage ?? '';
-  const error = `${errorType} ${errorMessage}`.trim();
-  expect(error).toBe('');
+  assertNoErrorReported(result);
   expect(result.success).toBe(true);
   expect(result.accounts).toBeDefined();
   const accounts = result.accounts ?? [];
-  // Non-zero accounts: a bank with no accounts is always a regression.
   expect(accounts.length).toBeGreaterThan(0);
-  for (const account of accounts) {
-    expect(account.accountNumber).toBeTruthy();
-    // 'default' is the Beinleumi-class fallback id leaked by an early
-    // account-discovery path that scraped without resolving the real
-    // account number — redactAccount turns it into '***fault' which
-    // showed up in production traces. Reject it explicitly.
-    expect(account.accountNumber).not.toBe('default');
-    const isArray = Array.isArray(account.txns);
-    expect(isArray).toBe(true);
-  }
-  // Non-zero total txns across the bank: extractor regressions (e.g.
-  // Discount returning 6 txns from the API but reporting 0 to the
-  // pipeline) silently passed before this stricter assertion was
-  // added — every CI bank is known to have activity in the 180-day
-  // window, so total === 0 means data is being lost downstream of
-  // the scrape.
-  const totalTxns = accounts.reduce((acc, a): number => acc + a.txns.length, 0);
-  expect(totalTxns).toBeGreaterThan(0);
+  for (const account of accounts) assertAccountValid(account);
+  assertNonZeroTotalTxns(accounts);
   return true;
 }
 

--- a/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
+++ b/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
@@ -26,7 +26,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as process from 'node:process';
 
-import type { Browser, BrowserContext, Frame, Page } from 'playwright-core';
+import type { Browser, BrowserContext, Frame, Locator, Page } from 'playwright-core';
 
 import { launchCamoufox } from '../../../Common/CamoufoxLauncher.js';
 import { CompanyTypes } from '../../../Definitions.js';
@@ -142,16 +142,19 @@ function pickTimeout(argv: readonly string[]): number {
 /** Resolved bank-config row from PIPELINE_BANK_CONFIG. */
 type ResolvedBankCfg = NonNullable<(typeof PIPELINE_BANK_CONFIG)[CompanyTypes]>;
 
+/** Capture row + production bank-config row pair. */
+interface IBankCfgPair {
+  cfg: IBankCaptureConfig;
+  bankCfg: ResolvedBankCfg;
+}
+
 /**
  * Look up the per-bank capture row + the production PIPELINE_BANK_CONFIG
  * row for the chosen bank key, throwing when the production row is missing.
  * @param bankKey - Validated CLI bank key.
  * @returns Capture + production bank-config pair.
  */
-function lookupBankConfig(bankKey: BankKey): {
-  cfg: IBankCaptureConfig;
-  bankCfg: ResolvedBankCfg;
-} {
+function lookupBankConfig(bankKey: BankKey): IBankCfgPair {
   const cfg = CAPTURES[bankKey];
   const bankCfg = PIPELINE_BANK_CONFIG[cfg.companyId];
   if (bankCfg === undefined) {
@@ -178,30 +181,52 @@ function resolveBankUrls(
 }
 
 /**
+ * Resolve the CLI bank key from argv. Throws with the usage message
+ * (listing valid keys) when no valid key is present.
+ * @param argv - process.argv.slice(2).
+ * @returns Validated bank key.
+ */
+function resolveBankKeyOrThrow(argv: readonly string[]): BankKey {
+  const bankKey = pickBankKey(argv);
+  if (bankKey !== false) return bankKey;
+  const keys = Object.keys(CAPTURES).join(', ');
+  throw new ScraperError(`Usage: CaptureInvalidLogin <bankKey>. Valid keys: ${keys}`);
+}
+
+/** Pre-resolved inputs threaded into assembleCliOptions. */
+interface IParseCliResolved {
+  bankKey: BankKey;
+  isHeadless: boolean;
+  timeoutMs: number;
+  cfg: IBankCaptureConfig;
+  bankCfg: ResolvedBankCfg;
+}
+
+/**
+ * Combine the pre-resolved inputs into the final ICliOptions bundle.
+ * Extracted per §19.10 so `parseCli` stays ≤10 lines.
+ * @param r - Pre-resolved CLI inputs.
+ * @returns Final CLI options bundle.
+ */
+function assembleCliOptions(r: IParseCliResolved): ICliOptions {
+  const { bankKey, isHeadless, timeoutMs, cfg } = r;
+  const outputRoot = path.join('C:', 'tmp', 'bank-html', bankKey);
+  const { baseUrl, entryUrl } = resolveBankUrls(cfg, r.bankCfg);
+  const { companyId } = cfg;
+  return { bankKey, isHeadless, timeoutMs, outputRoot, companyId, baseUrl, entryUrl };
+}
+
+/**
  * Parse process.argv into a validated options bundle.
  * @returns CLI options.
  */
 function parseCli(): ICliOptions {
   const argv = process.argv.slice(2);
-  const bankKey = pickBankKey(argv);
-  if (bankKey === false) {
-    const keys = Object.keys(CAPTURES).join(', ');
-    throw new ScraperError(`Usage: CaptureInvalidLogin <bankKey>. Valid keys: ${keys}`);
-  }
+  const bankKey = resolveBankKeyOrThrow(argv);
   const { cfg, bankCfg } = lookupBankConfig(bankKey);
   const isHeadless = argv.includes('--headless');
   const timeoutMs = pickTimeout(argv);
-  const outputRoot = path.join('C:', 'tmp', 'bank-html', bankKey);
-  const { baseUrl, entryUrl } = resolveBankUrls(cfg, bankCfg);
-  return {
-    bankKey,
-    isHeadless,
-    timeoutMs,
-    outputRoot,
-    companyId: cfg.companyId,
-    baseUrl,
-    entryUrl,
-  };
+  return assembleCliOptions({ bankKey, isHeadless, timeoutMs, cfg, bankCfg });
 }
 
 /**
@@ -275,6 +300,34 @@ async function swallowPromise(p: Promise<unknown>): Promise<true> {
 }
 
 /**
+ * Log a successful input fill (truncated value preview for privacy).
+ * Extracted per §19.10 so `fillOneInput` stays ≤10 lines.
+ * @param input - Filled input locator (for the name attribute).
+ * @param idx - Input index in the visible-inputs collection.
+ * @param value - Value used to fill the input (only prefix is logged).
+ * @returns Always true (caller propagates as `isFilled` indicator).
+ */
+async function logFilledInput(input: Locator, idx: number, value: string): Promise<true> {
+  const name = await input.getAttribute('name').catch((): string => '');
+  LOG.info({ idx, name, value: value.slice(0, 4) + '***' }, 'filled input');
+  return true;
+}
+
+/**
+ * Wrap Playwright's `input.fill(...).then.catch` chain in a single
+ * helper so `fillOneInput` stays ≤10 lines per §19.10.
+ * @param input - Input locator to fill.
+ * @param value - Value to write (already privacy-truncated for logging).
+ * @returns True on success, false when the fill rejected.
+ */
+function tryFillInput(input: Locator, value: string): Promise<boolean> {
+  return input
+    .fill(value, { timeout: 4000 })
+    .then((): boolean => true)
+    .catch((): boolean => false);
+}
+
+/**
  * Fill one input at a given locator index. Sequential semantics —
  * the locator handle is RE-resolved per call so DOM mutations from
  * earlier fills cannot stale the remaining indices.
@@ -286,17 +339,38 @@ async function fillOneInput(page: Page, idx: number): Promise<boolean> {
   const inputs = page.locator('input:not([type="hidden"]):not([disabled])');
   const input = inputs.nth(idx);
   const value = await chooseCredValue(input);
-  const isFilled = await input
-    .fill(value, { timeout: 4000 })
-    .then((): boolean => true)
-    .catch((): boolean => false);
-  if (isFilled) {
-    const name = await input.getAttribute('name').catch((): string => '');
-    LOG.info({ idx, name, value: value.slice(0, 4) + '***' }, 'filled input');
-    return true;
-  }
+  const isFilled = await tryFillInput(input, value);
+  if (isFilled) return logFilledInput(input, idx, value);
   LOG.warn({ idx }, 'fill failed (input not actionable — skipped)');
   return false;
+}
+
+/**
+ * Build the sequential-fill reducer for `fillInvalidCreds`. Each step
+ * awaits the previous tally and adds 1 on successful fill. Extracted
+ * per §19.10.
+ * @param page - Playwright page passed to fillOneInput.
+ * @returns Reducer function consumed by Array.reduce.
+ */
+function buildFillReducer(page: Page): (accum: Promise<number>, idx: number) => Promise<number> {
+  return (accumPromise: Promise<number>, idx: number): Promise<number> =>
+    accumPromise.then(async (acc): Promise<number> => {
+      const isFilled = await fillOneInput(page, idx);
+      return isFilled ? acc + 1 : acc;
+    });
+}
+
+/**
+ * Query + log the count of visible inputs on the login page. Extracted
+ * per §19.10 so `fillInvalidCreds` stays ≤10 lines.
+ * @param page - Playwright page at the login URL.
+ * @returns Count of inputs the reducer will iterate over.
+ */
+async function countVisibleInputs(page: Page): Promise<number> {
+  const inputs = page.locator('input:not([type="hidden"]):not([disabled])');
+  const count = await inputs.count();
+  LOG.info({ count }, 'fillInvalidCreds — visible inputs detected');
+  return count;
 }
 
 /**
@@ -309,25 +383,9 @@ async function fillOneInput(page: Page, idx: number): Promise<boolean> {
  * @returns Number of inputs successfully filled.
  */
 async function fillInvalidCreds(page: Page): Promise<number> {
-  const inputs = page.locator('input:not([type="hidden"]):not([disabled])');
-  const count = await inputs.count();
-  LOG.info({ count }, 'fillInvalidCreds — visible inputs detected');
+  const count = await countVisibleInputs(page);
   const indexes = range(count);
-  // Sequential reduce — chains promises so each fill awaits the previous.
-  // Replaces a `for ... await` loop (no-await-in-loop) and Promise.all
-  // (which raced and dropped fills past the first).
-  /**
-   * Reducer step: chain a single fillOneInput call onto the running tally.
-   * @param accumPromise - Running promise of the filled-count tally.
-   * @param idx - Input index to fill.
-   * @returns Updated tally promise.
-   */
-  const reduceStep = (accumPromise: Promise<number>, idx: number): Promise<number> =>
-    accumPromise.then(async (acc): Promise<number> => {
-      const isFilled = await fillOneInput(page, idx);
-      if (isFilled) return acc + 1;
-      return acc;
-    });
+  const reduceStep = buildFillReducer(page);
   const seedPromise: Promise<number> = Promise.resolve(0);
   const filledCount = await indexes.reduce(reduceStep, seedPromise);
   LOG.info({ requested: count, filled: filledCount }, 'fillInvalidCreds done');
@@ -404,6 +462,20 @@ function buildFramePath(args: IWriteFrameArgs, slug: string): string {
 }
 
 /**
+ * Persist a single iframe's HTML to disk + emit the capture log line.
+ * Extracted per §19.10 so `writeOneFrame` stays ≤10 lines.
+ * @param framePath - Target on-disk path.
+ * @param frameUrl - Source frame URL (for the log line).
+ * @param html - HTML payload to write.
+ * @returns Always true (caller propagates as the success indicator).
+ */
+async function persistFrameHtml(framePath: string, frameUrl: string, html: string): Promise<true> {
+  await writeUtf8(framePath, html);
+  LOG.info({ path: framePath, url: frameUrl, bytes: html.length }, 'captured iframe');
+  return true;
+}
+
+/**
  * Write a single iframe's HTML to disk.
  * @param args - Index + frame + CLI options bundle.
  * @returns True when bytes were written.
@@ -414,10 +486,7 @@ async function writeOneFrame(args: IWriteFrameArgs): Promise<boolean> {
   const framePath = buildFramePath(args, slug);
   const html = await args.frame.content().catch((): string => '');
   if (html.length === 0) return false;
-  await writeUtf8(framePath, html);
-  const bytes = html.length;
-  LOG.info({ path: framePath, url: frameUrl, bytes }, 'captured iframe');
-  return true;
+  return persistFrameHtml(framePath, frameUrl, html);
 }
 
 /**
@@ -445,6 +514,22 @@ function collectChildFrames(page: Page): readonly Frame[] {
 }
 
 /**
+ * Write every child iframe's HTML in parallel. Returns the count of
+ * frames that actually produced bytes (some frames may have empty
+ * content during teardown). Extracted per §19.10.
+ * @param childFrames - Child frames (main excluded).
+ * @param opts - CLI options.
+ * @returns Number of iframe files written.
+ */
+async function writeChildFrames(childFrames: readonly Frame[], opts: ICliOptions): Promise<number> {
+  const tasks = childFrames.map(
+    (frame, index): Promise<boolean> => writeOneFrame({ index, frame, opts }),
+  );
+  const results = await Promise.all(tasks);
+  return results.filter(Boolean).length;
+}
+
+/**
  * Save the main frame + every child frame to a separate .html file
  * under opts.outputRoot. Iframe filenames carry a url-hash slug for
  * stability across captures.
@@ -460,12 +545,65 @@ async function saveFramesToDisk(
 ): Promise<number> {
   await writeMainFrame(page, opts);
   const childFrames = collectChildFrames(page);
-  const tasks = childFrames.map(
-    (frame, index): Promise<boolean> => writeOneFrame({ index, frame, opts }),
-  );
-  const results = await Promise.all(tasks);
-  const extra = results.filter(Boolean).length;
+  const extra = await writeChildFrames(childFrames, opts);
   return 1 + extra;
+}
+
+/** One route entry in the scaffold fixtures.json. */
+interface IFixtureRouteEntry {
+  method: string;
+  urlGlob: string;
+  fixture: string;
+  status: number;
+  note: string;
+}
+
+/** Top-level shape of the scaffold fixtures.json payload. */
+interface IFixturesPayload {
+  bankKey: BankKey;
+  capturedAt: string;
+  finalUrl: string;
+  routes: readonly IFixtureRouteEntry[];
+}
+
+/** Default GET-login route entry (human adjusts the glob post-capture). */
+const SCAFFOLD_LOGIN_ROUTE: IFixtureRouteEntry = {
+  method: 'GET',
+  urlGlob: '**/login*',
+  fixture: 'login.html',
+  status: 200,
+  note: 'Adjust glob to match the real login URL pattern.',
+};
+
+/** Default POST-submit route entry (human adjusts the glob post-capture). */
+const SCAFFOLD_SUBMIT_ROUTE: IFixtureRouteEntry = {
+  method: 'POST',
+  urlGlob: '**/auth/**',
+  fixture: 'login-post-invalid.html',
+  status: 200,
+  note: 'Adjust glob to match the real submit URL pattern.',
+};
+
+/** Combined default scaffold route list. */
+const SCAFFOLD_ROUTES: readonly IFixtureRouteEntry[] = [
+  SCAFFOLD_LOGIN_ROUTE,
+  SCAFFOLD_SUBMIT_ROUTE,
+];
+
+/**
+ * Build the scaffold fixtures.json payload. Extracted per §19.10 so
+ * `writeFixturesJson` stays ≤10 lines.
+ * @param opts - CLI options.
+ * @param finalUrl - URL of the page after form submit.
+ * @returns JSON-serialisable scaffold payload.
+ */
+function buildFixturesPayload(opts: ICliOptions, finalUrl: string): IFixturesPayload {
+  return {
+    bankKey: opts.bankKey,
+    capturedAt: new Date().toISOString(),
+    finalUrl,
+    routes: SCAFFOLD_ROUTES,
+  };
 }
 
 /**
@@ -477,27 +615,7 @@ async function saveFramesToDisk(
  */
 async function writeFixturesJson(opts: ICliOptions, finalUrl: string): Promise<void> {
   const fixturesPath = path.join(opts.outputRoot, 'fixtures.json');
-  const payload = {
-    bankKey: opts.bankKey,
-    capturedAt: new Date().toISOString(),
-    finalUrl,
-    routes: [
-      {
-        method: 'GET',
-        urlGlob: '**/login*',
-        fixture: 'login.html',
-        status: 200,
-        note: 'Adjust glob to match the real login URL pattern.',
-      },
-      {
-        method: 'POST',
-        urlGlob: '**/auth/**',
-        fixture: 'login-post-invalid.html',
-        status: 200,
-        note: 'Adjust glob to match the real submit URL pattern.',
-      },
-    ],
-  };
+  const payload = buildFixturesPayload(opts, finalUrl);
   const text = JSON.stringify(payload, null, 2);
   await writeUtf8(fixturesPath, `${text}\n`);
   LOG.info({ path: fixturesPath }, 'wrote fixtures.json scaffold');
@@ -511,17 +629,51 @@ interface IBrowserSession {
 }
 
 /**
+ * Close the browser, swallowing any late-close error. Used by cleanup
+ * paths in `bootBrowserSession` where the browser may already be torn
+ * down by an earlier failure.
+ * @param browser - Browser handle to close.
+ * @returns Always true (no `void`).
+ */
+async function closeQuietly(browser: Browser): Promise<true> {
+  await browser.close().catch((): boolean => false);
+  return true;
+}
+
+/**
+ * Open a context + page on an already-launched browser and configure
+ * the default timeout. Extracted per §19.10 + so `bootBrowserSession`
+ * can wrap it in try/catch for browser cleanup on failure (CR cycle 2).
+ * @param browser - Pre-launched Camoufox browser.
+ * @param opts - CLI options.
+ * @returns Session tuple.
+ */
+async function buildSessionFromBrowser(
+  browser: Browser,
+  opts: ICliOptions,
+): Promise<IBrowserSession> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.setDefaultTimeout(opts.timeoutMs);
+  return { browser, context, page };
+}
+
+/**
  * Launch Camoufox + open a fresh context + page configured with the
- * CLI default timeout.
+ * CLI default timeout. Guarantees the browser is closed if `newContext`,
+ * `newPage`, or `setDefaultTimeout` throws (CR cycle 2 — was leaking
+ * the browser on those failure paths).
  * @param opts - CLI options.
  * @returns Browser/context/page tuple.
  */
 async function bootBrowserSession(opts: ICliOptions): Promise<IBrowserSession> {
   const browser: Browser = await launchCamoufox(opts.isHeadless);
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  page.setDefaultTimeout(opts.timeoutMs);
-  return { browser, context, page };
+  try {
+    return await buildSessionFromBrowser(browser, opts);
+  } catch (err) {
+    await closeQuietly(browser);
+    throw err;
+  }
 }
 
 /**
@@ -604,6 +756,20 @@ async function persistCaptureArtifacts(
 }
 
 /**
+ * Run the post-login persistence + final-log step. Extracted from main
+ * per §19.10 so the orchestrator stays ≤10 lines.
+ * @param session - Browser session tuple.
+ * @param opts - CLI options.
+ * @returns Number of HTML files written.
+ */
+async function runCapturePersistence(session: IBrowserSession, opts: ICliOptions): Promise<number> {
+  const finalUrl = session.page.url();
+  const written = await persistCaptureArtifacts(session, opts, finalUrl);
+  LOG.info({ finalUrl, framesWritten: written }, 'capture complete');
+  return written;
+}
+
+/**
  * Entry — orchestrates the capture end-to-end.
  * @returns Exit code (0 OK, 1 error).
  */
@@ -613,9 +779,7 @@ async function main(): Promise<number> {
   logCaptureStart(opts, bankCfg);
   const session = await bootBrowserSession(opts);
   await executeLoginInteraction(session.page, opts, bankCfg);
-  const finalUrl = session.page.url();
-  const written = await persistCaptureArtifacts(session, opts, finalUrl);
-  LOG.info({ finalUrl, framesWritten: written }, 'capture complete');
+  await runCapturePersistence(session, opts);
   await session.browser.close();
   return 0;
 }

--- a/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
+++ b/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
@@ -139,6 +139,44 @@ function pickTimeout(argv: readonly string[]): number {
   return Number.parseInt(raw, 10);
 }
 
+/** Resolved bank-config row from PIPELINE_BANK_CONFIG. */
+type ResolvedBankCfg = NonNullable<(typeof PIPELINE_BANK_CONFIG)[CompanyTypes]>;
+
+/**
+ * Look up the per-bank capture row + the production PIPELINE_BANK_CONFIG
+ * row for the chosen bank key, throwing when the production row is missing.
+ * @param bankKey - Validated CLI bank key.
+ * @returns Capture + production bank-config pair.
+ */
+function lookupBankConfig(bankKey: BankKey): {
+  cfg: IBankCaptureConfig;
+  bankCfg: ResolvedBankCfg;
+} {
+  const cfg = CAPTURES[bankKey];
+  const bankCfg = PIPELINE_BANK_CONFIG[cfg.companyId];
+  if (bankCfg === undefined) {
+    throw new ScraperError(`PIPELINE_BANK_CONFIG entry missing for ${cfg.companyId}`);
+  }
+  return { cfg, bankCfg };
+}
+
+/**
+ * Pick base + entry URLs from the resolved bank rows. `entryUrl` wins
+ * over `baseUrl` when the CAPTURES row sets a `directLoginUrl` (banks
+ * whose login lives on a separate host).
+ * @param cfg - Capture config row.
+ * @param bankCfg - Production bank-config row.
+ * @returns Resolved URL pair.
+ */
+function resolveBankUrls(
+  cfg: IBankCaptureConfig,
+  bankCfg: ResolvedBankCfg,
+): { baseUrl: string; entryUrl: string } {
+  const baseUrl = bankCfg.urls.base;
+  const entryUrl = cfg.directLoginUrl ?? baseUrl;
+  return { baseUrl, entryUrl };
+}
+
 /**
  * Parse process.argv into a validated options bundle.
  * @returns CLI options.
@@ -150,18 +188,11 @@ function parseCli(): ICliOptions {
     const keys = Object.keys(CAPTURES).join(', ');
     throw new ScraperError(`Usage: CaptureInvalidLogin <bankKey>. Valid keys: ${keys}`);
   }
-  const cfg = CAPTURES[bankKey];
-  const bankCfg = PIPELINE_BANK_CONFIG[cfg.companyId];
-  if (bankCfg === undefined) {
-    throw new ScraperError(`PIPELINE_BANK_CONFIG entry missing for ${cfg.companyId}`);
-  }
+  const { cfg, bankCfg } = lookupBankConfig(bankKey);
   const isHeadless = argv.includes('--headless');
   const timeoutMs = pickTimeout(argv);
   const outputRoot = path.join('C:', 'tmp', 'bank-html', bankKey);
-  const baseUrl = bankCfg.urls.base;
-  // entryUrl wins over baseUrl when the CAPTURES row sets a
-  // directLoginUrl (banks whose login lives on a separate host).
-  const entryUrl = cfg.directLoginUrl ?? baseUrl;
+  const { baseUrl, entryUrl } = resolveBankUrls(cfg, bankCfg);
   return {
     bankKey,
     isHeadless,
@@ -360,6 +391,19 @@ interface IWriteFrameArgs {
 }
 
 /**
+ * Build the on-disk filename + path for one captured iframe. Filename
+ * carries an index + url-hash slug so re-captures stay stable across runs.
+ * @param args - Index + frame + CLI options bundle.
+ * @param slug - URL hash slug for filename stability.
+ * @returns Absolute output path.
+ */
+function buildFramePath(args: IWriteFrameArgs, slug: string): string {
+  const indexStr = String(args.index);
+  const fileName = `login-post-invalid-iframe-${indexStr}-${slug}.html`;
+  return path.join(args.opts.outputRoot, fileName);
+}
+
+/**
  * Write a single iframe's HTML to disk.
  * @param args - Index + frame + CLI options bundle.
  * @returns True when bytes were written.
@@ -367,15 +411,37 @@ interface IWriteFrameArgs {
 async function writeOneFrame(args: IWriteFrameArgs): Promise<boolean> {
   const frameUrl = args.frame.url();
   const slug = urlHash(frameUrl);
-  const indexStr = String(args.index);
-  const fileName = `login-post-invalid-iframe-${indexStr}-${slug}.html`;
-  const framePath = path.join(args.opts.outputRoot, fileName);
+  const framePath = buildFramePath(args, slug);
   const html = await args.frame.content().catch((): string => '');
   if (html.length === 0) return false;
   await writeUtf8(framePath, html);
   const bytes = html.length;
   LOG.info({ path: framePath, url: frameUrl, bytes }, 'captured iframe');
   return true;
+}
+
+/**
+ * Persist the main frame to its canonical filename under opts.outputRoot.
+ * @param page - Playwright page.
+ * @param opts - CLI options.
+ * @returns Void promise.
+ */
+async function writeMainFrame(page: Page, opts: ICliOptions): Promise<void> {
+  const mainContent = await page.content();
+  const mainPath = path.join(opts.outputRoot, 'login-post-invalid.html');
+  await writeUtf8(mainPath, mainContent);
+  LOG.info({ path: mainPath, bytes: mainContent.length }, 'captured main frame');
+}
+
+/**
+ * Collect every child iframe under the page (excludes the main frame).
+ * @param page - Playwright page.
+ * @returns Read-only frames array.
+ */
+function collectChildFrames(page: Page): readonly Frame[] {
+  const mainFrame = page.mainFrame();
+  const allFrames = page.frames();
+  return allFrames.filter((f): boolean => f !== mainFrame);
 }
 
 /**
@@ -392,13 +458,8 @@ async function saveFramesToDisk(
   page: Page,
   opts: ICliOptions,
 ): Promise<number> {
-  const mainContent = await page.content();
-  const mainPath = path.join(opts.outputRoot, 'login-post-invalid.html');
-  await writeUtf8(mainPath, mainContent);
-  LOG.info({ path: mainPath, bytes: mainContent.length }, 'captured main frame');
-  const mainFrame = page.mainFrame();
-  const allFrames = page.frames();
-  const childFrames: readonly Frame[] = allFrames.filter((f): boolean => f !== mainFrame);
+  await writeMainFrame(page, opts);
+  const childFrames = collectChildFrames(page);
   const tasks = childFrames.map(
     (frame, index): Promise<boolean> => writeOneFrame({ index, frame, opts }),
   );
@@ -442,32 +503,120 @@ async function writeFixturesJson(opts: ICliOptions, finalUrl: string): Promise<v
   LOG.info({ path: fixturesPath }, 'wrote fixtures.json scaffold');
 }
 
+/** Browser + context + page tuple kept together for the capture flow. */
+interface IBrowserSession {
+  readonly browser: Browser;
+  readonly context: BrowserContext;
+  readonly page: Page;
+}
+
+/**
+ * Launch Camoufox + open a fresh context + page configured with the
+ * CLI default timeout.
+ * @param opts - CLI options.
+ * @returns Browser/context/page tuple.
+ */
+async function bootBrowserSession(opts: ICliOptions): Promise<IBrowserSession> {
+  const browser: Browser = await launchCamoufox(opts.isHeadless);
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.setDefaultTimeout(opts.timeoutMs);
+  return { browser, context, page };
+}
+
+/**
+ * Navigate to opts.entryUrl + wait for networkidle. Navigation errors
+ * propagate (a `page.goto` failure means we never reached the bank's
+ * login surface — the capture has nothing to record, so fail fast).
+ * The subsequent `waitForLoadState('networkidle')` IS swallowed
+ * because bank login pages frequently never reach idle (long-poll
+ * trackers, telemetry beacons) and that is not a capture-blocking
+ * condition.
+ * @param page - Playwright page.
+ * @param opts - CLI options.
+ * @returns Void promise.
+ */
+async function navigateToLoginPage(page: Page, opts: ICliOptions): Promise<void> {
+  await page.goto(opts.entryUrl);
+  const idlePromise = page.waitForLoadState('networkidle');
+  await swallowPromise(idlePromise);
+}
+
+/**
+ * Fill invalid creds + click submit + wait the per-bank settle window.
+ * @param page - Playwright page.
+ * @param bankCfg - Capture config row.
+ * @returns Void promise.
+ */
+async function performLoginAttempt(page: Page, bankCfg: IBankCaptureConfig): Promise<void> {
+  await fillInvalidCreds(page);
+  await submitForm(page);
+  await page.waitForTimeout(bankCfg.postSubmitWaitMs);
+}
+
+/**
+ * Emit the two pre-flight log lines (CLI options + Camoufox launch).
+ * Single helper keeps main() within the test-helper statement cap.
+ * @param opts - CLI options.
+ * @param bankCfg - Capture config row.
+ * @returns True after both log lines emit.
+ */
+function logCaptureStart(opts: ICliOptions, bankCfg: IBankCaptureConfig): true {
+  LOG.info({ opts }, 'CaptureInvalidLogin starting');
+  LOG.info({ bank: bankCfg.bankKey, url: opts.entryUrl }, 'launching Camoufox');
+  return true;
+}
+
+/**
+ * Run the navigate → log → login sequence in one composite step.
+ * @param page - Playwright page.
+ * @param opts - CLI options.
+ * @param bankCfg - Capture config row.
+ * @returns Void promise.
+ */
+async function executeLoginInteraction(
+  page: Page,
+  opts: ICliOptions,
+  bankCfg: IBankCaptureConfig,
+): Promise<void> {
+  await navigateToLoginPage(page, opts);
+  LOG.info({ url: page.url() }, 'initial page ready — filling + submitting');
+  await performLoginAttempt(page, bankCfg);
+}
+
+/**
+ * Save HTML for the main frame + every child iframe AND emit the
+ * scaffold fixtures.json. Combined into one step so main() stays
+ * within the helper-statement cap.
+ * @param session - Browser session tuple.
+ * @param opts - CLI options.
+ * @param finalUrl - Post-submit URL.
+ * @returns Number of HTML files written.
+ */
+async function persistCaptureArtifacts(
+  session: IBrowserSession,
+  opts: ICliOptions,
+  finalUrl: string,
+): Promise<number> {
+  const written = await saveFramesToDisk(session.context, session.page, opts);
+  await writeFixturesJson(opts, finalUrl);
+  return written;
+}
+
 /**
  * Entry — orchestrates the capture end-to-end.
  * @returns Exit code (0 OK, 1 error).
  */
 async function main(): Promise<number> {
   const opts = parseCli();
-  LOG.info({ opts }, 'CaptureInvalidLogin starting');
   const bankCfg = CAPTURES[opts.bankKey];
-  LOG.info({ bank: bankCfg.bankKey, url: opts.entryUrl }, 'launching Camoufox');
-  const browser: Browser = await launchCamoufox(opts.isHeadless);
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  page.setDefaultTimeout(opts.timeoutMs);
-  const gotoPromise = page.goto(opts.entryUrl);
-  await swallowPromise(gotoPromise);
-  const idlePromise = page.waitForLoadState('networkidle');
-  await swallowPromise(idlePromise);
-  LOG.info({ url: page.url() }, 'initial page ready — filling + submitting');
-  await fillInvalidCreds(page);
-  await submitForm(page);
-  await page.waitForTimeout(bankCfg.postSubmitWaitMs);
-  const finalUrl = page.url();
-  const written = await saveFramesToDisk(context, page, opts);
-  await writeFixturesJson(opts, finalUrl);
+  logCaptureStart(opts, bankCfg);
+  const session = await bootBrowserSession(opts);
+  await executeLoginInteraction(session.page, opts, bankCfg);
+  const finalUrl = session.page.url();
+  const written = await persistCaptureArtifacts(session, opts, finalUrl);
   LOG.info({ finalUrl, framesWritten: written }, 'capture complete');
-  await browser.close();
+  await session.browser.close();
   return 0;
 }
 

--- a/src/Tests/Tools/probe-beinleumi-nth.ts
+++ b/src/Tests/Tools/probe-beinleumi-nth.ts
@@ -135,16 +135,46 @@ async function runProbeAssertions(page: Page, browser: Browser): Promise<0 | 1> 
 }
 
 /**
- * Close the browser if it is still open. Swallows the late-close error
- * because helpers like failAndClose may have already closed it.
+ * Playwright error-message fragments emitted when a Browser/Context/Page
+ * has already been closed by an earlier teardown call (e.g.
+ * `failAndClose`). All lower-case for case-insensitive matching.
+ * Source: Playwright's `lib/protocol/serializers.js` + connection.ts
+ * throw sites; verified empirically against Playwright 1.x.
+ */
+const ALREADY_CLOSED_FRAGMENTS = [
+  'browser closed',
+  'browser has been closed',
+  'browser has disconnected',
+  'target closed',
+  'target page, context or browser has been closed',
+  'connection closed',
+] as const;
+
+/**
+ * True iff `err` looks like a late-close error from Playwright.
+ * Used by closeIfOpen to swallow only the expected "already closed"
+ * path and re-throw any other teardown failure.
+ * @param err - Caught error from `await browser.close()`.
+ * @returns True when `err.message` matches a known already-closed fragment.
+ */
+function isAlreadyClosedError(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err);
+  const msg = raw.toLowerCase();
+  return ALREADY_CLOSED_FRAGMENTS.some((p): boolean => msg.includes(p));
+}
+
+/**
+ * Close the browser if it is still open. Swallows ONLY the late-close
+ * error path (helpers like failAndClose may have already closed it) —
+ * any other teardown failure is re-thrown so real bugs aren't masked.
  * @param browser - Browser handle that may already be closed.
  * @returns Always true so callers can return it directly (no `void`).
  */
 async function closeIfOpen(browser: Browser): Promise<true> {
   try {
     await browser.close();
-  } catch {
-    // Browser was already closed by failAndClose — late-close throws "Browser closed".
+  } catch (err) {
+    if (!isAlreadyClosedError(err)) throw err;
   }
   return true;
 }

--- a/src/Tests/Tools/probe-beinleumi-nth.ts
+++ b/src/Tests/Tools/probe-beinleumi-nth.ts
@@ -9,6 +9,8 @@
 
 import * as fs from 'node:fs';
 
+import type { Browser, Locator, Page } from 'playwright-core';
+
 import { launchCamoufox } from '../../Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.js';
 
 const FIXTURE = 'C:/tmp/bank-html/BEINLEUMI/09-dashboard-pre/main.html';
@@ -18,37 +20,71 @@ const EXPECTED_NTH0_ID = 'pm.mataf.portal.FibiMenu.Onln.TransBalances.PrivateAcc
 const EXPECTED_NTH1_ID = 'pm.q077';
 
 /**
- * Probe entrypoint.
- * @returns 0 on success, 1 on failure.
+ * Launch Camoufox + load the fixture HTML onto a fresh page.
+ * @returns Browser + page tuple ready for selector probing.
  */
-async function main(): Promise<0 | 1> {
+async function setupProbePage(): Promise<{ browser: Browser; page: Page }> {
   const html = fs.readFileSync(FIXTURE, 'utf8');
   const browser = await launchCamoufox(true);
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.setContent(html);
-  const locator = page.locator(SELECTOR);
-  const count = await locator.count();
-  console.log(`[PROBE] aria-label "${ARIA}" matches ${String(count)} DOM elements`);
-  if (count !== 2) {
-    console.error(`FAIL: expected 2 matches, got ${String(count)}`);
-    await browser.close();
-    return 1;
-  }
+  return { browser, page };
+}
+
+/**
+ * Emit a FAIL line, close the browser, and signal exit code 1.
+ * @param browser - Browser to tear down.
+ * @param message - Stderr-bound failure description.
+ * @returns Exit code 1.
+ */
+async function failAndClose(browser: Browser, message: string): Promise<1> {
+  console.error(message);
+  await browser.close();
+  return 1;
+}
+
+/**
+ * Verify locator.nth(0) and nth(1) carry the expected ids — closes
+ * the browser via failAndClose on mismatch.
+ * @param locator - Selector locator returning multiple matches.
+ * @param browser - Browser handle (for cleanup on fail).
+ * @returns 0 on success, 1 on mismatch (browser already closed).
+ */
+async function assertNthIds(locator: Locator, browser: Browser): Promise<0 | 1> {
   const id0 = await locator.nth(0).getAttribute('id');
   const id1 = await locator.nth(1).getAttribute('id');
   console.log(`[PROBE] nth(0) id="${id0 ?? ''}"`);
   console.log(`[PROBE] nth(1) id="${id1 ?? ''}"`);
   if (id0 !== EXPECTED_NTH0_ID) {
-    console.error(`FAIL: nth(0) expected id="${EXPECTED_NTH0_ID}", got "${id0 ?? ''}"`);
-    await browser.close();
-    return 1;
+    return failAndClose(
+      browser,
+      `FAIL: nth(0) expected id="${EXPECTED_NTH0_ID}", got "${id0 ?? ''}"`,
+    );
   }
   if (id1 !== EXPECTED_NTH1_ID) {
-    console.error(`FAIL: nth(1) expected id="${EXPECTED_NTH1_ID}", got "${id1 ?? ''}"`);
-    await browser.close();
-    return 1;
+    return failAndClose(
+      browser,
+      `FAIL: nth(1) expected id="${EXPECTED_NTH1_ID}", got "${id1 ?? ''}"`,
+    );
   }
+  return 0;
+}
+
+/**
+ * Probe entrypoint.
+ * @returns 0 on success, 1 on failure.
+ */
+async function main(): Promise<0 | 1> {
+  const { browser, page } = await setupProbePage();
+  const locator = page.locator(SELECTOR);
+  const count = await locator.count();
+  console.log(`[PROBE] aria-label "${ARIA}" matches ${String(count)} DOM elements`);
+  if (count !== 2) {
+    return failAndClose(browser, `FAIL: expected 2 matches, got ${String(count)}`);
+  }
+  const result = await assertNthIds(locator, browser);
+  if (result === 1) return 1;
   console.log(
     '[PROBE] PASS: smart fix would click pm.mataf (nth=0) → goback (no URL change) → pm.q077 (nth=1) → URL=/transactions ✓',
   );

--- a/src/Tests/Tools/probe-beinleumi-nth.ts
+++ b/src/Tests/Tools/probe-beinleumi-nth.ts
@@ -45,6 +45,40 @@ async function failAndClose(browser: Browser, message: string): Promise<1> {
 }
 
 /**
+ * Verify the nth(0) id matches expectation. Closes browser on mismatch
+ * via failAndClose. Split from assertNthIds per §19.10.
+ * @param locator - Selector locator returning multiple matches.
+ * @param browser - Browser handle (for cleanup on fail).
+ * @returns 0 on match, 1 on mismatch (browser closed).
+ */
+async function assertNth0Id(locator: Locator, browser: Browser): Promise<0 | 1> {
+  const id0 = await locator.nth(0).getAttribute('id');
+  console.log(`[PROBE] nth(0) id="${id0 ?? ''}"`);
+  if (id0 === EXPECTED_NTH0_ID) return 0;
+  return failAndClose(
+    browser,
+    `FAIL: nth(0) expected id="${EXPECTED_NTH0_ID}", got "${id0 ?? ''}"`,
+  );
+}
+
+/**
+ * Verify the nth(1) id matches expectation. Closes browser on mismatch
+ * via failAndClose. Split from assertNthIds per §19.10.
+ * @param locator - Selector locator returning multiple matches.
+ * @param browser - Browser handle (for cleanup on fail).
+ * @returns 0 on match, 1 on mismatch (browser closed).
+ */
+async function assertNth1Id(locator: Locator, browser: Browser): Promise<0 | 1> {
+  const id1 = await locator.nth(1).getAttribute('id');
+  console.log(`[PROBE] nth(1) id="${id1 ?? ''}"`);
+  if (id1 === EXPECTED_NTH1_ID) return 0;
+  return failAndClose(
+    browser,
+    `FAIL: nth(1) expected id="${EXPECTED_NTH1_ID}", got "${id1 ?? ''}"`,
+  );
+}
+
+/**
  * Verify locator.nth(0) and nth(1) carry the expected ids — closes
  * the browser via failAndClose on mismatch.
  * @param locator - Selector locator returning multiple matches.
@@ -52,44 +86,81 @@ async function failAndClose(browser: Browser, message: string): Promise<1> {
  * @returns 0 on success, 1 on mismatch (browser already closed).
  */
 async function assertNthIds(locator: Locator, browser: Browser): Promise<0 | 1> {
-  const id0 = await locator.nth(0).getAttribute('id');
-  const id1 = await locator.nth(1).getAttribute('id');
-  console.log(`[PROBE] nth(0) id="${id0 ?? ''}"`);
-  console.log(`[PROBE] nth(1) id="${id1 ?? ''}"`);
-  if (id0 !== EXPECTED_NTH0_ID) {
-    return failAndClose(
-      browser,
-      `FAIL: nth(0) expected id="${EXPECTED_NTH0_ID}", got "${id0 ?? ''}"`,
-    );
-  }
-  if (id1 !== EXPECTED_NTH1_ID) {
-    return failAndClose(
-      browser,
-      `FAIL: nth(1) expected id="${EXPECTED_NTH1_ID}", got "${id1 ?? ''}"`,
-    );
-  }
+  const nth0 = await assertNth0Id(locator, browser);
+  if (nth0 === 1) return 1;
+  return assertNth1Id(locator, browser);
+}
+
+/**
+ * Assert the selector matches exactly 2 DOM elements. Closes browser
+ * via failAndClose on mismatch. Split from main per §19.10.
+ * @param locator - Selector locator.
+ * @param browser - Browser handle (for cleanup on fail).
+ * @returns 0 on match, 1 on mismatch (browser closed).
+ */
+async function assertSelectorMatchCount(locator: Locator, browser: Browser): Promise<0 | 1> {
+  const count = await locator.count();
+  console.log(`[PROBE] aria-label "${ARIA}" matches ${String(count)} DOM elements`);
+  if (count === 2) return 0;
+  return failAndClose(browser, `FAIL: expected 2 matches, got ${String(count)}`);
+}
+
+/** PASS-banner text emitted at the end of a successful probe run. */
+const PROBE_PASS_BANNER =
+  '[PROBE] PASS: smart fix would click pm.mataf (nth=0) → goback (no URL change) → pm.q077 (nth=1) → URL=/transactions ✓';
+
+/**
+ * Emit the PASS banner via console.log — extracted per §19.10.
+ * @returns Always 0 (success exit code) so callers can return it directly.
+ */
+function logProbeSuccess(): 0 {
+  console.log(PROBE_PASS_BANNER);
   return 0;
 }
 
 /**
- * Probe entrypoint.
+ * Run the probe body once setup is complete. Split from main per §19.10
+ * so main only owns the setup → run → teardown try/finally.
+ * @param page - Probe page loaded with the fixture HTML.
+ * @param browser - Browser handle (for cleanup on fail).
+ * @returns 0 on success, 1 on assertion failure (browser closed on fail).
+ */
+async function runProbeAssertions(page: Page, browser: Browser): Promise<0 | 1> {
+  const locator = page.locator(SELECTOR);
+  const count = await assertSelectorMatchCount(locator, browser);
+  if (count === 1) return 1;
+  const nth = await assertNthIds(locator, browser);
+  if (nth === 1) return 1;
+  return logProbeSuccess();
+}
+
+/**
+ * Close the browser if it is still open. Swallows the late-close error
+ * because helpers like failAndClose may have already closed it.
+ * @param browser - Browser handle that may already be closed.
+ * @returns Always true so callers can return it directly (no `void`).
+ */
+async function closeIfOpen(browser: Browser): Promise<true> {
+  try {
+    await browser.close();
+  } catch {
+    // Browser was already closed by failAndClose — late-close throws "Browser closed".
+  }
+  return true;
+}
+
+/**
+ * Probe entrypoint — guarantees browser cleanup on every exit path
+ * via try/finally (CR cycle 2 outside-diff fix).
  * @returns 0 on success, 1 on failure.
  */
 async function main(): Promise<0 | 1> {
   const { browser, page } = await setupProbePage();
-  const locator = page.locator(SELECTOR);
-  const count = await locator.count();
-  console.log(`[PROBE] aria-label "${ARIA}" matches ${String(count)} DOM elements`);
-  if (count !== 2) {
-    return failAndClose(browser, `FAIL: expected 2 matches, got ${String(count)}`);
+  try {
+    return await runProbeAssertions(page, browser);
+  } finally {
+    await closeIfOpen(browser);
   }
-  const result = await assertNthIds(locator, browser);
-  if (result === 1) return 1;
-  console.log(
-    '[PROBE] PASS: smart fix would click pm.mataf (nth=0) → goback (no URL change) → pm.q077 (nth=1) → URL=/transactions ✓',
-  );
-  await browser.close();
-  return 0;
 }
 
 main()

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts
@@ -45,6 +45,76 @@ const MOCK_EP = {
   responseHeaders: {},
 };
 
+/** Shape of the makeDashCtx opts (shared with extracted helpers). */
+interface IMakeDashCtxOpts {
+  clickFound?: boolean;
+  resolveVisible?: IRaceResult;
+  hasFetchStrategy?: boolean;
+  withEndpoints?: boolean;
+}
+
+/**
+ * Build the resolveAndClick + resolveVisible race-result mocks from
+ * the opts. Centralises the "found vs not-found" mapping so the
+ * orchestrator stays within the test-helper statement cap.
+ * @param opts - makeDashCtx opts.
+ * @returns Click result + visible-race default.
+ */
+function buildClickAndVisibleMocks(opts: IMakeDashCtxOpts): {
+  clickResult: Procedure<IRaceResult>;
+  visibleResolved: IRaceResult;
+} {
+  const foundRace = { ...NOT_FOUND_RESULT, found: true } as IRaceResult;
+  const clickRace = opts.clickFound ? foundRace : NOT_FOUND_RESULT;
+  const clickResult = succeed(clickRace);
+  const visibleResolved = opts.resolveVisible ?? (opts.clickFound ? foundRace : NOT_FOUND_RESULT);
+  return { clickResult, visibleResolved };
+}
+
+/**
+ * Wrap the mock mediator's network surface with the endpoint stubs
+ * required by the POST gate (`getAllEndpoints` + the new
+ * `discoverTransactionsEndpoint` lookup).
+ * @param base - Mediator returned from makeMockMediator.
+ * @param withEndpoints - Seed-endpoints flag.
+ * @returns Same mediator shape with `network` overrides applied.
+ */
+function buildMediatorWithEndpoints(
+  base: ReturnType<typeof makeMockMediator>,
+  withEndpoints: boolean,
+): ReturnType<typeof makeMockMediator> {
+  const eps = withEndpoints ? [MOCK_EP] : [];
+  /**
+   * Return seeded endpoints for traffic gate.
+   * @returns Mock endpoints array.
+   */
+  const getAllEndpoints = (): typeof eps => eps;
+  /**
+   * Return the seeded txn endpoint when present (matches the new POST
+   * gate that uses `discoverTransactionsEndpoint` instead of any-endpoint
+   * count).
+   * @returns Seeded endpoint or false.
+   */
+  const discoverTransactionsEndpoint = (): typeof MOCK_EP | false =>
+    withEndpoints ? MOCK_EP : false;
+  const network = { ...base.network, getAllEndpoints, discoverTransactionsEndpoint };
+  return { ...base, network };
+}
+
+/**
+ * Build the fetch-strategy override block consumed by makeMockContext.
+ * Returns an empty object when fetch is intentionally disabled.
+ * @param hasFetchStrategy - Whether to include a fetch strategy mock.
+ * @returns Partial context overrides for fetchStrategy.
+ */
+function buildFetchOverrides(hasFetchStrategy: boolean): {
+  fetchStrategy?: ReturnType<typeof some<ReturnType<typeof makeMockFetchStrategy>>>;
+} {
+  if (!hasFetchStrategy) return {};
+  const fetchStrategy = makeMockFetchStrategy();
+  return { fetchStrategy: some(fetchStrategy) };
+}
+
 /**
  * Build a context with browser + mediator for dashboard tests.
  * @param opts - Mock configuration.
@@ -54,16 +124,8 @@ const MOCK_EP = {
  * @param opts.withEndpoints - Seed mock endpoints for POST gate.
  * @returns Pipeline context.
  */
-function makeDashCtx(opts: {
-  clickFound?: boolean;
-  resolveVisible?: IRaceResult;
-  hasFetchStrategy?: boolean;
-  withEndpoints?: boolean;
-}): IPipelineContext {
-  const foundRace = { ...NOT_FOUND_RESULT, found: true } as IRaceResult;
-  const clickRace = opts.clickFound ? foundRace : NOT_FOUND_RESULT;
-  const clickResult = succeed(clickRace);
-  const visibleDefault = opts.clickFound ? foundRace : NOT_FOUND_RESULT;
+function makeDashCtx(opts: IMakeDashCtxOpts): IPipelineContext {
+  const { clickResult, visibleResolved } = buildClickAndVisibleMocks(opts);
   const browserState = makeMockBrowserState();
   const base = makeMockMediator({
     /**
@@ -75,27 +137,10 @@ function makeDashCtx(opts: {
      * Return configured resolveVisible result.
      * @returns IRaceResult.
      */
-    resolveVisible: (): Promise<IRaceResult> =>
-      Promise.resolve(opts.resolveVisible ?? visibleDefault),
+    resolveVisible: (): Promise<IRaceResult> => Promise.resolve(visibleResolved),
   });
-  const eps = opts.withEndpoints ? [MOCK_EP] : [];
-  /**
-   * Return seeded endpoints for traffic gate.
-   * @returns Mock endpoints array.
-   */
-  const getAllEndpoints = (): typeof eps => eps;
-  /**
-   * Return the seeded txn endpoint when present (matches the new POST gate
-   * that uses `discoverTransactionsEndpoint` instead of any-endpoint count).
-   * @returns Seeded endpoint or false.
-   */
-  const discoverTransactionsEndpoint = (): typeof MOCK_EP | false =>
-    opts.withEndpoints ? MOCK_EP : false;
-  const network = { ...base.network, getAllEndpoints, discoverTransactionsEndpoint };
-  const mediator = { ...base, network };
-  const hasFetch = opts.hasFetchStrategy !== false;
-  const fetchStrategy = makeMockFetchStrategy();
-  const fetchOverrides = hasFetch ? { fetchStrategy: some(fetchStrategy) } : {};
+  const mediator = buildMediatorWithEndpoints(base, opts.withEndpoints ?? false);
+  const fetchOverrides = buildFetchOverrides(opts.hasFetchStrategy !== false);
   return makeMockContext({
     browser: some(browserState),
     mediator: some(mediator),

--- a/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts
@@ -84,21 +84,50 @@ function buildMediatorWithEndpoints(
   withEndpoints: boolean,
 ): ReturnType<typeof makeMockMediator> {
   const eps = withEndpoints ? [MOCK_EP] : [];
-  /**
-   * Return seeded endpoints for traffic gate.
-   * @returns Mock endpoints array.
-   */
-  const getAllEndpoints = (): typeof eps => eps;
-  /**
-   * Return the seeded txn endpoint when present (matches the new POST
-   * gate that uses `discoverTransactionsEndpoint` instead of any-endpoint
-   * count).
-   * @returns Seeded endpoint or false.
-   */
-  const discoverTransactionsEndpoint = (): typeof MOCK_EP | false =>
-    withEndpoints ? MOCK_EP : false;
-  const network = { ...base.network, getAllEndpoints, discoverTransactionsEndpoint };
+  const network = { ...base.network, ...buildEndpointOverrides(eps, withEndpoints) };
   return { ...base, network };
+}
+
+/** Endpoint stubs spread into `base.network` to seed POST-gate. */
+interface IEndpointOverrides {
+  getAllEndpoints: () => readonly (typeof MOCK_EP)[];
+  discoverTransactionsEndpoint: () => typeof MOCK_EP | false;
+}
+
+/**
+ * Build the network-surface overrides for `buildMediatorWithEndpoints`.
+ * Split out from the parent helper to comply with §19.10 (≤10 lines).
+ * @param eps - Seeded endpoints array (empty when withEndpoints false).
+ * @param withEndpoints - Whether to expose the seeded txn endpoint.
+ * @returns Object spread into `base.network` to seed POST-gate stubs.
+ */
+function buildEndpointOverrides(
+  eps: readonly (typeof MOCK_EP)[],
+  withEndpoints: boolean,
+): IEndpointOverrides {
+  const getAllEndpoints = makeEndpointGetter(eps);
+  const discoverTransactionsEndpoint = makeTxnEndpointGetter(withEndpoints);
+  return { getAllEndpoints, discoverTransactionsEndpoint };
+}
+
+/**
+ * Higher-order helper for the POST-gate `getAllEndpoints` stub.
+ * Returns a closure-over-eps thunk so `buildEndpointOverrides` stays ≤10 lines.
+ * @param eps - Seeded endpoints array.
+ * @returns Thunk that returns the array on each call.
+ */
+function makeEndpointGetter(eps: readonly (typeof MOCK_EP)[]): () => readonly (typeof MOCK_EP)[] {
+  return (): readonly (typeof MOCK_EP)[] => eps;
+}
+
+/**
+ * Higher-order helper for the POST-gate `discoverTransactionsEndpoint` stub.
+ * Returns the seeded endpoint when present, false otherwise.
+ * @param withEndpoints - Whether the test seeded a txn endpoint.
+ * @returns Thunk returning the seeded endpoint or false.
+ */
+function makeTxnEndpointGetter(withEndpoints: boolean): () => typeof MOCK_EP | false {
+  return (): typeof MOCK_EP | false => (withEndpoints ? MOCK_EP : false);
 }
 
 /**
@@ -125,27 +154,47 @@ function buildFetchOverrides(hasFetchStrategy: boolean): {
  * @returns Pipeline context.
  */
 function makeDashCtx(opts: IMakeDashCtxOpts): IPipelineContext {
-  const { clickResult, visibleResolved } = buildClickAndVisibleMocks(opts);
   const browserState = makeMockBrowserState();
-  const base = makeMockMediator({
-    /**
-     * Return configured resolveAndClick Procedure.
-     * @returns Procedure with IRaceResult.
-     */
-    resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(clickResult),
-    /**
-     * Return configured resolveVisible result.
-     * @returns IRaceResult.
-     */
-    resolveVisible: (): Promise<IRaceResult> => Promise.resolve(visibleResolved),
-  });
-  const mediator = buildMediatorWithEndpoints(base, opts.withEndpoints ?? false);
+  const browser = some(browserState);
+  const baseMediator = buildBaseMediator(opts);
+  const mediatorImpl = buildMediatorWithEndpoints(baseMediator, opts.withEndpoints ?? false);
+  const mediator = some(mediatorImpl);
   const fetchOverrides = buildFetchOverrides(opts.hasFetchStrategy !== false);
-  return makeMockContext({
-    browser: some(browserState),
-    mediator: some(mediator),
-    ...fetchOverrides,
+  return makeMockContext({ browser, mediator, ...fetchOverrides });
+}
+
+/**
+ * Build the base mock mediator with resolveAndClick / resolveVisible stubs
+ * configured from the test opts. Split from makeDashCtx for §19.10.
+ * @param opts - makeDashCtx opts (clickFound / resolveVisible).
+ * @returns Mock mediator before endpoint overrides apply.
+ */
+function buildBaseMediator(opts: IMakeDashCtxOpts): ReturnType<typeof makeMockMediator> {
+  const { clickResult, visibleResolved } = buildClickAndVisibleMocks(opts);
+  return makeMockMediator({
+    resolveAndClick: makeClickStub(clickResult),
+    resolveVisible: makeVisibleStub(visibleResolved),
   });
+}
+
+/**
+ * Higher-order helper that wraps a fixed click result in a Promise-returning
+ * stub matching the resolveAndClick mediator signature.
+ * @param clickResult - The fixed Procedure to resolve.
+ * @returns Mediator-shaped resolveAndClick stub.
+ */
+function makeClickStub(clickResult: Procedure<IRaceResult>): () => Promise<Procedure<IRaceResult>> {
+  return (): Promise<Procedure<IRaceResult>> => Promise.resolve(clickResult);
+}
+
+/**
+ * Higher-order helper that wraps a fixed race result in a Promise-returning
+ * stub matching the resolveVisible mediator signature.
+ * @param visibleResolved - The fixed IRaceResult to resolve.
+ * @returns Mediator-shaped resolveVisible stub.
+ */
+function makeVisibleStub(visibleResolved: IRaceResult): () => Promise<IRaceResult> {
+  return (): Promise<IRaceResult> => Promise.resolve(visibleResolved);
 }
 
 // -- PRE step --

--- a/src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts
@@ -268,6 +268,27 @@ function makeFixtureMediator(fixture: IBankFixture): IElementMediator {
 }
 
 /**
+ * Execute one AUTH-DISCOVERY phase step and assert the result was Ok.
+ * Centralises the isOk + ok-expect + Ok-unwrap pattern so the chain
+ * orchestrator stays within the test-helper statement cap.
+ * @param label - Phase step label ('PRE' | 'POST' | 'FINAL') for jest output.
+ * @param result - Procedure returned by the phase executor.
+ * @param fallback - Context to return when result wasn't Ok (unreachable
+ * in green path; satisfies type narrowing).
+ * @returns Unwrapped context.
+ */
+function expectOkAndUnwrap(
+  label: string,
+  result: Awaited<ReturnType<typeof executeAuthDiscoveryPre>>,
+  fallback: IPipelineContext,
+): IPipelineContext {
+  const isStepOk = isOk(result);
+  // jest's expect carries the label in the diff so the failing phase is obvious.
+  expect({ label, isOk: isStepOk }).toEqual({ label, isOk: true });
+  return result.success ? result.value : fallback;
+}
+
+/**
  * Run AUTH-DISCOVERY's full PRE → POST → FINAL chain against a
  * per-bank fixture and return the resulting context.
  * @param fixture - Per-bank fixture.
@@ -276,22 +297,13 @@ function makeFixtureMediator(fixture: IBankFixture): IElementMediator {
 async function runAuthDiscoveryChain(fixture: IBankFixture): Promise<IPipelineContext> {
   const baseCtx = makeMockContext();
   const mediator = makeFixtureMediator(fixture);
-  const ctx: IPipelineContext = {
-    ...baseCtx,
-    mediator: { has: true, value: mediator },
-  };
+  const ctx: IPipelineContext = { ...baseCtx, mediator: { has: true, value: mediator } };
   const preResult = await executeAuthDiscoveryPre(ctx);
-  const isPreOk = isOk(preResult);
-  expect(isPreOk).toBe(true);
-  const preCtx = preResult.success ? preResult.value : ctx;
+  const preCtx = expectOkAndUnwrap('PRE', preResult, ctx);
   const postResult = await executeAuthDiscoveryPost(preCtx);
-  const isPostOk = isOk(postResult);
-  expect(isPostOk).toBe(true);
-  const postCtx = postResult.success ? postResult.value : ctx;
+  const postCtx = expectOkAndUnwrap('POST', postResult, ctx);
   const finalResult = await executeAuthDiscoveryFinal(postCtx);
-  const isFinalOk = isOk(finalResult);
-  expect(isFinalOk).toBe(true);
-  return finalResult.success ? finalResult.value : ctx;
+  return expectOkAndUnwrap('FINAL', finalResult, ctx);
 }
 
 describe('Mission 1 — AuthDiscoveryFactoryTest cross-bank coverage', () => {

--- a/src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts
@@ -170,6 +170,196 @@ const BANK_FIXTURES: readonly IBankFixture[] = [
   },
 ];
 
+/** Default cookie metadata applied uniformly to every fixture cookie. */
+const COOKIE_DEFAULTS = {
+  value: 'redacted',
+  domain: 'example.bank',
+  path: '/',
+  expires: -1,
+  httpOnly: true,
+  secure: true,
+  sameSite: 'None',
+} as const;
+
+/**
+ * Build a single cookie snapshot from a fixture cookie name. Mock
+ * metadata is sourced from COOKIE_DEFAULTS. Extracted per §19.10.
+ * @param name - Cookie name from the fixture.
+ * @returns Cookie snapshot with default mock metadata applied.
+ */
+function cookieFromName(name: string): ICookieSnapshot {
+  return { name, ...COOKIE_DEFAULTS };
+}
+
+/**
+ * Build the per-bank cookie snapshots consumed by `makeFixtureMediator`.
+ * Extracted per §19.10 (≤10 lines) so the parent helper stays short.
+ * @param cookieNames - Fixture cookie names (only the name matters here).
+ * @returns Cookie snapshot array with mock metadata applied uniformly.
+ */
+function buildCookieSnapshots(cookieNames: readonly string[]): readonly ICookieSnapshot[] {
+  return cookieNames.map(cookieFromName);
+}
+
+/** Synthetic dashboard candidate emitted by the reveal stub. */
+const REVEALED_RESULT = {
+  found: true,
+  candidate: { kind: 'textContent', value: 'יתרה' },
+} as const;
+
+/** Sentinel emitted when the fixture has no dashboard reveal. */
+const NOT_REVEALED_RESULT = { found: false, candidate: false } as const;
+
+/**
+ * Build the `resolveVisible` stub for `makeFixtureMediator`. Returns a
+ * positive resolve when the fixture advertises a dashboard reveal, the
+ * not-found sentinel otherwise. Extracted per §19.10.
+ * @param fixture - Per-bank fixture (only `dashboardRevealed` is read).
+ * @returns Mediator-shaped resolveVisible stub.
+ */
+function buildResolveVisibleStub(fixture: IBankFixture): () => Promise<unknown> {
+  return (): Promise<unknown> =>
+    Promise.resolve(fixture.dashboardRevealed ? REVEALED_RESULT : NOT_REVEALED_RESULT);
+}
+
+/** Shape of the `network` sub-object on the fixture mediator. */
+interface IAuthDiscoveryNetworkStub {
+  getAllEndpoints: () => readonly [];
+  discoverAuthToken: () => Promise<string | false>;
+  discoverOrigin: () => string | false;
+  discoverSiteId: () => string | false;
+  buildDiscoveredHeaders: () => Promise<IFetchOpts>;
+}
+
+/**
+ * Empty endpoint pool stub — PRE counts captures only.
+ * Extracted per §19.10 so `buildNetworkStub` stays compact.
+ * @returns Thunk that returns the empty tuple.
+ */
+function makeEmptyEndpointsGetter(): () => readonly [] {
+  return (): readonly [] => [];
+}
+
+/**
+ * Fixture-scoped auth-token discovery stub.
+ * @param fixture - Per-bank fixture (only `authToken` is read).
+ * @returns Thunk that resolves to the fixture token.
+ */
+function makeAuthTokenGetter(fixture: IBankFixture): () => Promise<string | false> {
+  return (): Promise<string | false> => Promise.resolve(fixture.authToken);
+}
+
+/**
+ * Fixture-scoped origin discovery stub.
+ * @param fixture - Per-bank fixture (only `origin` is read).
+ * @returns Thunk that returns the fixture origin.
+ */
+function makeOriginGetter(fixture: IBankFixture): () => string | false {
+  return (): string | false => fixture.origin;
+}
+
+/**
+ * Fixture-scoped site-id discovery stub.
+ * @param fixture - Per-bank fixture (only `siteId` is read).
+ * @returns Thunk that returns the fixture siteId.
+ */
+function makeSiteIdGetter(fixture: IBankFixture): () => string | false {
+  return (): string | false => fixture.siteId;
+}
+
+/**
+ * Fixture-scoped fetch-header builder stub.
+ * @param fetchOpts - Pre-built fetch opts (headers merged in).
+ * @returns Thunk that resolves to the fetch opts.
+ */
+function makeDiscoveredHeadersBuilder(fetchOpts: IFetchOpts): () => Promise<IFetchOpts> {
+  return (): Promise<IFetchOpts> => Promise.resolve(fetchOpts);
+}
+
+/**
+ * Build the `network` sub-object for `makeFixtureMediator`. Implements
+ * only the surface AUTH-DISCOVERY touches. Extracted per §19.10.
+ * @param fixture - Per-bank fixture.
+ * @param fetchOpts - Pre-built fetch opts for buildDiscoveredHeaders.
+ * @returns Network helper bundle (5 stubs).
+ */
+function buildNetworkStub(fixture: IBankFixture, fetchOpts: IFetchOpts): IAuthDiscoveryNetworkStub {
+  return {
+    getAllEndpoints: makeEmptyEndpointsGetter(),
+    discoverAuthToken: makeAuthTokenGetter(fixture),
+    discoverOrigin: makeOriginGetter(fixture),
+    discoverSiteId: makeSiteIdGetter(fixture),
+    buildDiscoveredHeaders: makeDiscoveredHeadersBuilder(fetchOpts),
+  };
+}
+
+/** Settle sentinel emitted by buildSettleStub (avoids returning undefined). */
+const SETTLE_OK_SENTINEL = { success: true as const, value: 'settled' as const };
+
+/**
+ * Build a no-op `waitForNetworkIdle` stub. AUTH-DISCOVERY.PRE awaits it
+ * before inventorying the capture pool — instant resolve dodges the
+ * real timer cost in unit-test land. Extracted per §19.10.
+ * @returns Mediator-shaped waitForNetworkIdle stub.
+ */
+function buildSettleStub(): () => Promise<typeof SETTLE_OK_SENTINEL> {
+  return (): Promise<typeof SETTLE_OK_SENTINEL> => Promise.resolve(SETTLE_OK_SENTINEL);
+}
+
+/**
+ * Build a `getCurrentUrl` stub returning the empty-string "test path"
+ * sentinel — the FINAL gate disables the URL-change check when either
+ * side is `''` so the gate decides on REVEAL alone. Extracted per §19.10.
+ * @returns Mediator-shaped getCurrentUrl stub.
+ */
+function buildUrlStub(): () => string {
+  return (): string => '';
+}
+
+/**
+ * Build the `getCookies` stub for `makeFixtureMediator`. Extracted per
+ * §19.10 so the parent factory stays under the line cap.
+ * @param cookieSnapshots - Pre-built cookie snapshots from the fixture.
+ * @returns Mediator-shaped getCookies stub.
+ */
+function buildGetCookiesStub(
+  cookieSnapshots: readonly ICookieSnapshot[],
+): () => Promise<readonly ICookieSnapshot[]> {
+  return (): Promise<readonly ICookieSnapshot[]> => Promise.resolve(cookieSnapshots);
+}
+
+/** Internal shape of the assembled mediator stub before IElementMediator cast. */
+interface IFixtureMediatorStub {
+  getCookies: () => Promise<readonly ICookieSnapshot[]>;
+  resolveVisible: () => Promise<unknown>;
+  network: IAuthDiscoveryNetworkStub;
+  waitForNetworkIdle: () => Promise<typeof SETTLE_OK_SENTINEL>;
+  getCurrentUrl: () => string;
+}
+
+/** Params bundle for `assembleMediatorStub`. */
+interface IAssembleStubParams {
+  cookieSnapshots: readonly ICookieSnapshot[];
+  fixture: IBankFixture;
+  fetchOpts: IFetchOpts;
+}
+
+/**
+ * Assemble the fixture-mediator stub from its 5 component sub-builders.
+ * Extracted per §19.10 so `makeFixtureMediator` stays ≤10 lines.
+ * @param params - Pre-built inputs (cookies, fixture, fetch opts).
+ * @returns Stub object ready for the final IElementMediator cast.
+ */
+function assembleMediatorStub(params: IAssembleStubParams): IFixtureMediatorStub {
+  return {
+    getCookies: buildGetCookiesStub(params.cookieSnapshots),
+    resolveVisible: buildResolveVisibleStub(params.fixture),
+    network: buildNetworkStub(params.fixture, params.fetchOpts),
+    waitForNetworkIdle: buildSettleStub(),
+    getCurrentUrl: buildUrlStub(),
+  };
+}
+
 /**
  * Build a per-bank mock mediator that returns the fixture's
  * cookies + network helper outputs + dashboard reveal result. Type
@@ -185,86 +375,10 @@ const BANK_FIXTURES: readonly IBankFixture[] = [
  * @returns Mediator stub.
  */
 function makeFixtureMediator(fixture: IBankFixture): IElementMediator {
-  const cookieSnapshots: readonly ICookieSnapshot[] = fixture.cookieNames.map(
-    (name): ICookieSnapshot =>
-      ({
-        name,
-        value: 'redacted',
-        domain: 'example.bank',
-        path: '/',
-        expires: -1,
-        httpOnly: true,
-        secure: true,
-        sameSite: 'None',
-      }) as ICookieSnapshot,
-  );
+  const cookieSnapshots = buildCookieSnapshots(fixture.cookieNames);
   const fetchOpts: IFetchOpts = { extraHeaders: fixture.headers };
-  return {
-    /**
-     * Return the fixture cookies.
-     * @returns Cookie snapshots.
-     */
-    getCookies: (): Promise<readonly ICookieSnapshot[]> => Promise.resolve(cookieSnapshots),
-    /**
-     * Reveal probe — returns a found result with a synthetic
-     * dashboard candidate when `dashboardRevealed=true`, else a
-     * not-found shape (probeDashboardReveal returns 'no reveal'
-     * for the not-found case).
-     * @returns Resolve-visible result.
-     */
-    resolveVisible: (): Promise<unknown> => {
-      if (!fixture.dashboardRevealed) {
-        return Promise.resolve({ found: false, candidate: false });
-      }
-      return Promise.resolve({
-        found: true,
-        candidate: { kind: 'textContent', value: 'יתרה' },
-      });
-    },
-    network: {
-      /**
-       * Empty endpoint pool — PRE counts captures only.
-       * @returns Empty array.
-       */
-      getAllEndpoints: (): readonly [] => [],
-      /**
-       * Fixture-scoped auth-token discovery stub.
-       * @returns Fixture token (string | false).
-       */
-      discoverAuthToken: (): Promise<string | false> => Promise.resolve(fixture.authToken),
-      /**
-       * Fixture-scoped origin discovery stub.
-       * @returns Fixture origin (string | false).
-       */
-      discoverOrigin: (): string | false => fixture.origin,
-      /**
-       * Fixture-scoped site-id discovery stub.
-       * @returns Fixture siteId (string | false).
-       */
-      discoverSiteId: (): string | false => fixture.siteId,
-      /**
-       * Fixture-scoped fetch-header builder stub.
-       * @returns Fixture headers wrapped in IFetchOpts.
-       */
-      buildDiscoveredHeaders: (): Promise<IFetchOpts> => Promise.resolve(fetchOpts),
-    },
-    /**
-     * No-op settle wait — AUTH-DISCOVERY.PRE awaits this before
-     * inventorying the capture pool. Resolves immediately so the
-     * factory test does not pay a real timer in unit-test land.
-     * @returns Resolved succeed.
-     */
-    waitForNetworkIdle: () => Promise.resolve({ success: true as const, value: undefined }),
-    /**
-     * Synchronous URL probe — AUTH-DISCOVERY.FINAL reads it during
-     * the M4.F1 dashboard gate. Empty string is the "test path"
-     * sentinel: the predicate disables the URL-change check when
-     * either side is `''`, so the gate decides on REVEAL alone here.
-     *
-     * @returns Empty string — opts the fixture out of the URL gate.
-     */
-    getCurrentUrl: (): string => '',
-  } as unknown as IElementMediator;
+  const stub = assembleMediatorStub({ cookieSnapshots, fixture, fetchOpts });
+  return stub as unknown as IElementMediator;
 }
 
 /**
@@ -289,15 +403,26 @@ function expectOkAndUnwrap(
 }
 
 /**
+ * Build the initial AUTH-DISCOVERY pipeline context wired to the
+ * fixture mediator. Extracted per §19.10 so runAuthDiscoveryChain
+ * stays ≤10 lines.
+ * @param fixture - Per-bank fixture.
+ * @returns Pipeline context with the mediator option populated.
+ */
+function buildAuthDiscoveryCtx(fixture: IBankFixture): IPipelineContext {
+  const baseCtx = makeMockContext();
+  const mediator = makeFixtureMediator(fixture);
+  return { ...baseCtx, mediator: { has: true, value: mediator } };
+}
+
+/**
  * Run AUTH-DISCOVERY's full PRE → POST → FINAL chain against a
  * per-bank fixture and return the resulting context.
  * @param fixture - Per-bank fixture.
  * @returns Final pipeline context after FINAL.
  */
 async function runAuthDiscoveryChain(fixture: IBankFixture): Promise<IPipelineContext> {
-  const baseCtx = makeMockContext();
-  const mediator = makeFixtureMediator(fixture);
-  const ctx: IPipelineContext = { ...baseCtx, mediator: { has: true, value: mediator } };
+  const ctx = buildAuthDiscoveryCtx(fixture);
   const preResult = await executeAuthDiscoveryPre(ctx);
   const preCtx = expectOkAndUnwrap('PRE', preResult, ctx);
   const postResult = await executeAuthDiscoveryPost(preCtx);

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts
@@ -68,6 +68,61 @@ function makeFakeApi(scripts: ReadonlyMap<string, unknown>): IApiFetchContext {
 }
 
 /**
+ * Build the initial PipelineContext consumed by the BALANCE-RESOLVE chain
+ * (scrape + api options pre-seeded with identities + a scripted fake api).
+ * @param identities - Per-card identities (SCRAPE.post emission).
+ * @param template - Fetch template (SCRAPE.post emission).
+ * @param scripts - API response scripts.
+ * @returns Pipeline context ready for executeBalanceResolvePre.
+ */
+function buildInitialCtx(
+  identities: ReadonlyMap<string, IAccountIdentity>,
+  template: IBalanceFetchTemplate,
+  scripts: ReadonlyMap<string, unknown>,
+): ReturnType<typeof makeMockContext> {
+  const accounts = [...identities.keys()].map(
+    (id): { accountNumber: string; balance: number; txns: never[] } => ({
+      accountNumber: id,
+      balance: 0,
+      txns: [],
+    }),
+  );
+  const scrape = some({ accounts, accountIdentities: identities, balanceFetchTemplate: template });
+  const fakeApi = makeFakeApi(scripts);
+  const api = some(fakeApi);
+  return makeMockContext({ scrape, api });
+}
+
+/** Action-stage Ok value (kept narrow for downstream type discrimination). */
+type ActionOkValue = Extract<
+  Awaited<ReturnType<typeof executeBalanceResolveAction>>,
+  { success: true }
+>['value'];
+
+/** Discriminated stage outcome — fail-loud sentinel without null/undefined. */
+type StageOutcome = { kind: 'ok'; value: ActionOkValue } | { kind: 'fail' };
+
+/**
+ * Run pre → action → post and return the action-stage Ok value, or a
+ * fail sentinel when any stage failed. Centralises the isOk-guard +
+ * as-unknown-as recast pattern so the orchestrator stays branch-free
+ * inside the test-helper statement cap.
+ * @param ctx - Initial pipeline context.
+ * @returns Discriminated stage outcome.
+ */
+async function runPreActionPost(ctx: ReturnType<typeof makeMockContext>): Promise<StageOutcome> {
+  const preResult = await executeBalanceResolvePre(ctx);
+  if (!isOk(preResult)) return { kind: 'fail' };
+  const actionCtx = preResult.value as unknown as Parameters<typeof executeBalanceResolveAction>[0];
+  const actionResult = await executeBalanceResolveAction(actionCtx);
+  if (!isOk(actionResult)) return { kind: 'fail' };
+  const postCtx = actionResult.value as unknown as Parameters<typeof executeBalanceResolvePost>[0];
+  const postResult = await executeBalanceResolvePost(postCtx);
+  if (!isOk(postResult)) return { kind: 'fail' };
+  return { kind: 'ok', value: actionResult.value };
+}
+
+/**
  * Run pre → action → post end-to-end with a fake api and given inputs.
  * Returns {@link RUNCHAIN_FAILED} when any stage fails so the caller
  * stays branch-free (no null/undefined returns).
@@ -82,27 +137,11 @@ async function runChain(
   template: IBalanceFetchTemplate,
   scripts: ReadonlyMap<string, unknown>,
 ): Promise<ReadonlyMap<string, number | 'MISS'>> {
-  const accounts = [...identities.keys()].map(
-    (id): { accountNumber: string; balance: number; txns: never[] } => ({
-      accountNumber: id,
-      balance: 0,
-      txns: [],
-    }),
-  );
-  const scrape = some({ accounts, accountIdentities: identities, balanceFetchTemplate: template });
-  const fakeApi = makeFakeApi(scripts);
-  const api = some(fakeApi);
-  const ctx = makeMockContext({ scrape, api });
-  const preResult = await executeBalanceResolvePre(ctx);
-  if (!isOk(preResult)) return RUNCHAIN_FAILED;
-  const actionCtx = preResult.value as unknown as Parameters<typeof executeBalanceResolveAction>[0];
-  const actionResult = await executeBalanceResolveAction(actionCtx);
-  if (!isOk(actionResult)) return RUNCHAIN_FAILED;
-  const postCtx = actionResult.value as unknown as Parameters<typeof executeBalanceResolvePost>[0];
-  const postResult = await executeBalanceResolvePost(postCtx);
-  if (!isOk(postResult)) return RUNCHAIN_FAILED;
-  if (!actionResult.value.balanceExtracted.has) return RUNCHAIN_FAILED;
-  return actionResult.value.balanceExtracted.value;
+  const ctx = buildInitialCtx(identities, template, scripts);
+  const outcome = await runPreActionPost(ctx);
+  if (outcome.kind === 'fail') return RUNCHAIN_FAILED;
+  if (!outcome.value.balanceExtracted.has) return RUNCHAIN_FAILED;
+  return outcome.value.balanceExtracted.value;
 }
 
 const HAPOALIM_TEMPLATE: IBalanceFetchTemplate = {

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts
@@ -31,6 +31,47 @@ import { makeMockContext } from '../../Infrastructure/MockFactories.js';
 const RUNCHAIN_FAILED: ReadonlyMap<string, number | 'MISS'> = new Map();
 
 /**
+ * Look up a scripted response by composite key (`url#bodyJson`).
+ * Missing keys resolve to `null` so the extractor sees an empty body
+ * and yields MISS. Shared by both POST and GET scripted fetches.
+ * @param scripts - Map of (url+'#'+body) → response.
+ * @param key - Composite key built from url + body.
+ * @returns Procedure that always succeeds (null on miss).
+ */
+function lookupScripted(
+  scripts: ReadonlyMap<string, unknown>,
+  key: string,
+): Promise<Procedure<unknown>> {
+  const found = scripts.get(key) ?? null;
+  const procedure = succeed(found);
+  return Promise.resolve(procedure);
+}
+
+/**
+ * Build the scripted `fetchPost` for `makeFakeApi`. Splits per §19.10
+ * so the parent helper stays ≤10 lines.
+ * @param scripts - Response scripts.
+ * @returns POST fetch keyed by `url + '#' + JSON.stringify(body)`.
+ */
+function makeScriptedPost(
+  scripts: ReadonlyMap<string, unknown>,
+): (url: string, body: Record<string, unknown>) => Promise<Procedure<unknown>> {
+  return (url: string, body: Record<string, unknown>): Promise<Procedure<unknown>> =>
+    lookupScripted(scripts, `${url}#${JSON.stringify(body)}`);
+}
+
+/**
+ * Build the scripted `fetchGet` for `makeFakeApi`. Splits per §19.10.
+ * @param scripts - Response scripts.
+ * @returns GET fetch keyed by `url + '#'`.
+ */
+function makeScriptedGet(
+  scripts: ReadonlyMap<string, unknown>,
+): (url: string) => Promise<Procedure<unknown>> {
+  return (url: string): Promise<Procedure<unknown>> => lookupScripted(scripts, `${url}#`);
+}
+
+/**
  * Build a fake `IApiFetchContext` that returns scripted bodies keyed
  * by (url + '#' + JSON.stringify(body)). Missing keys resolve to
  * `succeed(null)` so the extractor sees an empty body and yields MISS.
@@ -39,32 +80,88 @@ const RUNCHAIN_FAILED: ReadonlyMap<string, number | 'MISS'> = new Map();
  * @returns Fake api context.
  */
 function makeFakeApi(scripts: ReadonlyMap<string, unknown>): IApiFetchContext {
-  /**
-   * Scripted POST fetch — looks up by url + JSON body.
-   *
-   * @param url - URL.
-   * @param body - JSON-encoded body.
-   * @returns Scripted procedure (always succeed; null on miss).
-   */
-  const fetchPost = (url: string, body: Record<string, unknown>): Promise<Procedure<unknown>> => {
-    const key = `${url}#${JSON.stringify(body)}`;
-    const found = scripts.get(key) ?? null;
-    const procedure = succeed(found);
-    return Promise.resolve(procedure);
-  };
-  /**
-   * Scripted GET fetch — looks up by url only.
-   *
-   * @param url - URL.
-   * @returns Scripted procedure (always succeed; null on miss).
-   */
-  const fetchGet = (url: string): Promise<Procedure<unknown>> => {
-    const key = `${url}#`;
-    const found = scripts.get(key) ?? null;
-    const procedure = succeed(found);
-    return Promise.resolve(procedure);
-  };
+  const fetchPost = makeScriptedPost(scripts);
+  const fetchGet = makeScriptedGet(scripts);
   return { fetchPost, fetchGet, transactionsUrl: false, balanceUrl: false } as IApiFetchContext;
+}
+
+/** Account stub shape consumed by the SCRAPE option. */
+interface IAccountStub {
+  accountNumber: string;
+  balance: number;
+  txns: never[];
+}
+
+/**
+ * Build a single zero-balance, zero-txn account stub for a given identity.
+ * @param id - Account identifier (map key).
+ * @returns Placeholder account.
+ */
+function makeIAccountStub(id: string): IAccountStub {
+  return { accountNumber: id, balance: 0, txns: [] };
+}
+
+/**
+ * Build the zero-balance account stubs consumed by the SCRAPE option.
+ * Split from buildInitialCtx per §19.10 (≤10 lines).
+ * @param identities - Per-card identities (SCRAPE.post emission).
+ * @returns One placeholder account per identity (balance 0, no txns).
+ */
+function buildAccountsFromIdentities(
+  identities: ReadonlyMap<string, IAccountIdentity>,
+): readonly IAccountStub[] {
+  return [...identities.keys()].map(makeIAccountStub);
+}
+
+/** Payload bundled by SCRAPE for the PRE → ACTION accounts handoff. */
+interface IScrapeOptionPayload {
+  accounts: readonly IAccountStub[];
+  accountIdentities: ReadonlyMap<string, IAccountIdentity>;
+  balanceFetchTemplate: IBalanceFetchTemplate;
+}
+
+/**
+ * Inner-payload builder for buildScrapeOption. Split out so the parent
+ * stays ≤10 lines once prettier expands the explicit-typed literal.
+ * @param identities - Per-card identities.
+ * @param template - Fetch template.
+ * @returns Payload to wrap in some().
+ */
+function buildScrapePayload(
+  identities: ReadonlyMap<string, IAccountIdentity>,
+  template: IBalanceFetchTemplate,
+): IScrapeOptionPayload {
+  const accounts = buildAccountsFromIdentities(identities);
+  return { accounts, accountIdentities: identities, balanceFetchTemplate: template };
+}
+
+/**
+ * Build the SCRAPE option that pre-seeds identities + template for PRE.
+ * Split from buildInitialCtx per §19.10 (≤10 lines).
+ * @param identities - Per-card identities (SCRAPE.post emission).
+ * @param template - Fetch template (SCRAPE.post emission).
+ * @returns Option<IScrapeOptionPayload> threaded into the initial context.
+ */
+function buildScrapeOption(
+  identities: ReadonlyMap<string, IAccountIdentity>,
+  template: IBalanceFetchTemplate,
+): ReturnType<typeof some<IScrapeOptionPayload>> {
+  const payload = buildScrapePayload(identities, template);
+  return some(payload);
+}
+
+/**
+ * Build the API option (scripted fake api wrapped in some()).
+ * Split from buildInitialCtx per §19.10 (≤10 lines) and to dodge the
+ * FORBIDDEN-NESTED-CALL rule.
+ * @param scripts - Response scripts.
+ * @returns Option<IApiFetchContext>.
+ */
+function buildApiOption(
+  scripts: ReadonlyMap<string, unknown>,
+): ReturnType<typeof some<IApiFetchContext>> {
+  const fakeApi = makeFakeApi(scripts);
+  return some(fakeApi);
 }
 
 /**
@@ -80,16 +177,8 @@ function buildInitialCtx(
   template: IBalanceFetchTemplate,
   scripts: ReadonlyMap<string, unknown>,
 ): ReturnType<typeof makeMockContext> {
-  const accounts = [...identities.keys()].map(
-    (id): { accountNumber: string; balance: number; txns: never[] } => ({
-      accountNumber: id,
-      balance: 0,
-      txns: [],
-    }),
-  );
-  const scrape = some({ accounts, accountIdentities: identities, balanceFetchTemplate: template });
-  const fakeApi = makeFakeApi(scripts);
-  const api = some(fakeApi);
+  const scrape = buildScrapeOption(identities, template);
+  const api = buildApiOption(scripts);
   return makeMockContext({ scrape, api });
 }
 
@@ -103,7 +192,23 @@ type ActionOkValue = Extract<
 type StageOutcome = { kind: 'ok'; value: ActionOkValue } | { kind: 'fail' };
 
 /**
- * Run pre → action → post and return the action-stage Ok value, or a
+ * Run the ACTION → POST tail of the chain starting from a PRE-stage success.
+ * Threads `actionResult.value` into POST and returns the POST-stage value
+ * (CR cycle 2 fix — consumers read the post-stage shape).
+ * @param preValue - The IPipelineContext returned by executeBalanceResolvePre.
+ * @returns Discriminated stage outcome carrying the post-stage value.
+ */
+async function runActionPost(preValue: ActionOkValue): Promise<StageOutcome> {
+  const actionResult = await executeBalanceResolveAction(preValue);
+  if (!isOk(actionResult)) return { kind: 'fail' };
+  const postCtx = actionResult.value as unknown as Parameters<typeof executeBalanceResolvePost>[0];
+  const postResult = await executeBalanceResolvePost(postCtx);
+  if (!isOk(postResult)) return { kind: 'fail' };
+  return { kind: 'ok', value: postResult.value as unknown as ActionOkValue };
+}
+
+/**
+ * Run pre → action → post and return the post-stage Ok value, or a
  * fail sentinel when any stage failed. Centralises the isOk-guard +
  * as-unknown-as recast pattern so the orchestrator stays branch-free
  * inside the test-helper statement cap.
@@ -113,13 +218,20 @@ type StageOutcome = { kind: 'ok'; value: ActionOkValue } | { kind: 'fail' };
 async function runPreActionPost(ctx: ReturnType<typeof makeMockContext>): Promise<StageOutcome> {
   const preResult = await executeBalanceResolvePre(ctx);
   if (!isOk(preResult)) return { kind: 'fail' };
-  const actionCtx = preResult.value as unknown as Parameters<typeof executeBalanceResolveAction>[0];
-  const actionResult = await executeBalanceResolveAction(actionCtx);
-  if (!isOk(actionResult)) return { kind: 'fail' };
-  const postCtx = actionResult.value as unknown as Parameters<typeof executeBalanceResolvePost>[0];
-  const postResult = await executeBalanceResolvePost(postCtx);
-  if (!isOk(postResult)) return { kind: 'fail' };
-  return { kind: 'ok', value: actionResult.value };
+  return runActionPost(preResult.value as unknown as ActionOkValue);
+}
+
+/**
+ * Extract the final `balanceExtracted` map from a successful pipeline
+ * outcome. Returns the failure sentinel when the option is empty so
+ * the caller stays branch-free.
+ * @param outcome - Outcome from runPreActionPost.
+ * @returns Extracted balance map or RUNCHAIN_FAILED.
+ */
+function extractBalanceMap(outcome: StageOutcome): ReadonlyMap<string, number | 'MISS'> {
+  if (outcome.kind === 'fail') return RUNCHAIN_FAILED;
+  if (!outcome.value.balanceExtracted.has) return RUNCHAIN_FAILED;
+  return outcome.value.balanceExtracted.value;
 }
 
 /**
@@ -139,9 +251,7 @@ async function runChain(
 ): Promise<ReadonlyMap<string, number | 'MISS'>> {
   const ctx = buildInitialCtx(identities, template, scripts);
   const outcome = await runPreActionPost(ctx);
-  if (outcome.kind === 'fail') return RUNCHAIN_FAILED;
-  if (!outcome.value.balanceExtracted.has) return RUNCHAIN_FAILED;
-  return outcome.value.balanceExtracted.value;
+  return extractBalanceMap(outcome);
 }
 
 const HAPOALIM_TEMPLATE: IBalanceFetchTemplate = {


### PR DESCRIPTION
## Why

The pipeline-decoupling master plan (12 phases) needed one final canonicalization
pass: a **statement-cap guardrail for named test-helper FunctionDeclarations**
under `src/Tests/**`. Without it, helpers like `runChain`, `makeDashCtx`,
`assertSuccessfulScrape`, `main` (probe), `CaptureInvalidLogin` writers etc.
were free to grow indefinitely (15-22 stmts observed), defeating the §19.6
`max-statements:10` rule that already governs production code. ESLint's
`max-statements` does not run on test files (they live behind the §19.8
arrow-test override at `max-statements:30`), so a separate AST-shaped rule
was required.

This PR installs **two complementary guardrails**:

- §19.9 (`FunctionDeclaration[id.name][body.body.length>10]` selector in
  `no-restricted-syntax`) — caps named test-helper FunctionDeclarations to
  **≤10 statements**. Arrow callbacks of `describe('…', () => {…})`,
  `it('…', () => {…})`, and `it.each(cases)('…', (…) => {…})` stay exempt.
- §19.10 (`phase9-local/fn-declaration-max-lines` inline plugin) — caps the
  same FunctionDeclarations to **≤10 LINES** (`loc.end.line - loc.start.line + 1`)
  scoped to the 6 Phase-9-touched test files. ESLint AST selectors cannot
  compute `loc.end.line - loc.start.line`, so the line-cap is delivered
  via an inline plugin rule (a custom plugin rule is the standard
  pattern in ESLint v9 flat-config + typescript-eslint when AST shape
  is not enough).

**Why two rules?** §19.9 caught FunctionDeclarations with >10 statements,
but multi-line object literals, JSDoc on inner arrows, and explicit-typed
return shapes let helpers slip past 10 LINES while staying ≤10 stmts.
§19.10 closes that gap — a function with a 4-line signature has only 6
body lines to play with.

This PR drives **19 named test helpers across the same 6 files** under
the §19.10 line cap, on top of the original 9 helpers already under the
§19.9 stmt cap, completing Phase 9 of 12 in the master sequence.

## What

| # | File | Helper(s) / change | Commit |
|---|---|---|---|
| T1 | `src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts` | `parseCli` / `writeOneFrame` / `saveFramesToDisk` / `main` (+CR-3 fail-fast `page.goto`) | `24da062e` |
| T2 | `src/Tests/E2eReal/Helpers.ts` | `assertSuccessfulScrape` (+CR-1 `assertNonZeroTotalTxns`, +CR-2 `BEINLEUMI_DEFAULT_FALLBACK_ID`) | `e234710d` |
| T3 | `src/Tests/Tools/probe-beinleumi-nth.ts` | `main` | `ed647ada` |
| T4 | `src/Tests/Unit/Pipeline/Infrastructure/DashboardPhase.test.ts` | `makeDashCtx` | `47e4e8e9` |
| T5 | `src/Tests/Unit/Pipeline/Mediator/AuthDiscovery/AuthDiscoveryFactoryTest.test.ts` | `runAuthDiscoveryChain` | `0f40a111` |
| T6 | `src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts` | `runChain` | `00ee4fb3` |
| T7 | `eslint.config.mjs` + `EslintCanaries/test-helper-over-10-stmts.canary.ts` | §19.9 rule install + canary (count 65 → 66) | `b599f99c` |
| **T8** | `eslint.config.mjs` + `EslintCanaries/test-helper-over-10-lines.canary.ts` | **§19.10 inline plugin (`phase9-local/fn-declaration-max-lines`) + canary (count 66 → 67); §19.9 selector tightened to `[id.name]`; `as const` on `CANARY_LABEL`** | `2afab0ea` |
| **T9** | 6 test files (Helpers, CaptureInvalidLogin, probe-beinleumi-nth, DashboardPhase.test, AuthDiscoveryFactoryTest.test, BalanceResolveCrossBank.test) | **19 named test helpers driven under the §19.10 line cap via Extract-Function (top-level higher-order helpers, interface-typed return shapes, sentinel objects); CR-5/CR-7/outside-diff fixes folded** | `85f5b8d9` |
| **T10** | `src/Tests/Tools/probe-beinleumi-nth.ts` | **CR-9 fix: narrow `closeIfOpen` suppression to known "already closed" Playwright messages via `ALREADY_CLOSED_FRAGMENTS` const + `isAlreadyClosedError(err)` predicate; re-throws unmatched close errors instead of swallowing every failure** | `df290e1e` |

**Scope sanity:** 9 files touched / 150 cap (§12). Test-only PR (branch
`refactor/phase-9-tests-max10` → T1-INVERSE husky hook enforced ZERO
production code in `src/Scrapers/Pipeline/**` outside `EslintCanaries/`).

## Guideline compliance

Every applicable guideline at `C:\tmp\guidelines\`, audited row-by-row per
§A3.5 (10 sub-checks) + `agent-contract.md §A4.GUIDELINES`. Each row cites
the verification command + its observed output. Any ❌ is documented with
the rationale; merge requires no unjustified ❌.

| # | Guideline | Verification | Result |
|---|---|---|---|
| G1 | `pr-guidlines.md §10` — PR body has `## Why` / `## What` / `## Guideline compliance` | this body | ✅ all three headers present |
| G2 | `pr-guidlines.md §11` — test-only PR: zero production-code change | `git diff --name-only main..HEAD` → 9 files, all under `src/Tests/` or `EslintCanaries/` or `eslint.config.mjs` (config, not production) | ✅ |
| G3 | `pr-guidlines.md §12` — ≤150-file cap | `git diff --name-only main..HEAD \| wc -l` = 9 | ✅ 9/150 |
| G4 | `commit-guidlines.md §1-4` — Conventional Commits | `gh pr checks 305` → "Validate PR Title" PASS | ✅ |
| G5 | `commit-guidlines.md §5` — subject ≤50 chars | `git log --format=%s 8796dc6e..HEAD \| awk '{print length}'` → all ≤49 | ✅ (T8/T9 confirmed) |
| G6 | `before-commit-guidlines.md` — pre-flight lint/test/type-check | `npm run lint && jest <patterns> && tsc --noEmit` all exit 0; husky pre-commit ran (21 gates) | ✅ |
| G7 | `eslint-rules-guidlines.md §2` — every numeric rule gets a canary | `Get-ChildItem EslintCanaries\*.canary.ts \| Measure` = 67 (was 65; +1 stmt cap, +1 line cap) | ✅ canary count +2 |
| G8 | `eslint-rules-guidlines.md §5` — ONE COMMIT, ONE GUARDRAIL CHANGE | T7 = §19.9 rule only; T8 = §19.10 rule + canary + nits; T9 = refactors + CR fixes (bundled per ONE-COMMIT-folds-prettier rule) | ✅ |
| G9 | `eslint-rules-guidlines.md §3` — no `eslint-disable` introduced | `git diff main..HEAD \| Select-String 'eslint-disable'` → 0 | ✅ |
| G10 | `coding-principle-guidlines.md` (SOLID/OCP/≤10) | every refactored helper ≤10 stmts AND ≤10 lines; new helpers use top-level factories, interface-typed return shapes | ✅ |
| G11 | `test-guidlines.md` + `test-cases-guidlines.md` — assertion semantics preserved | targeted jest 109/109 PASS; full test:e2e:mock 31/31 PASS in husky gate | ✅ |
| G12 | `mocking-test-guidlines.md` — no MOCK_MODE leakage | `git diff main..HEAD \| Select-String 'MOCK_MODE'` → 0 | ✅ |
| G13 | `comments-in-code-guidlines.md` + `j-doc-guidlines.md` — BLUF JSDoc on new exported helpers | every new helper carries BLUF /** … */ + @param/@returns | ✅ |
| G14 | `design-patterns-guidlines.md` — factories over duplication | T6 uses discriminated `{kind:'ok'\|'fail'}` union; T1/T4-T6 build mocks via factories; T9 uses `assembleMediatorStub` to flatten an 82-line monster to 5 lines | ✅ |
| G15 | `logging-pii-guidlines.md` — no PII leak | grep `password\|cookie\|token\|email` across diff → only test-fixture values + canonical type names; no real-credential strings | ✅ |
| G16 | `plan-ooda-loop-guidlines.md Appendix A` — A3.5 10-sub-check exit gate (see below) | see A3.5 table | ✅ all 10 GREEN |
| G17 | `general-rules-guidlines.md` — Co-authored-by Copilot trailer | every commit message ends with `Co-authored-by: Copilot <…>` | ✅ |

### A3.5 10-sub-check exit gate

| # | Check | Command / observation | Result |
|---|---|---|---|
| A3.5.1 | Doc-drift sweep | session `plan.md`, phase-9 `status.txt`, master `status.txt` all reference final SHAs + cap values (10 stmts + 10 lines) | ✅ |
| A3.5.2 | ESLint rule audit (no relaxation) | `Select-String eslint.config.mjs '\|max-statements\|TEST_HELPER_OVER_10_STMTS\|fn-declaration-max-lines'` → no production cap loosened; §19.9 + §19.10 newly added | ✅ |
| A3.5.3 | Canary coverage audit | `Get-ChildItem EslintCanaries\*.canary.ts` = 67 (status.txt declared 67); both stmt-cap and line-cap canaries proven to fire exactly 1 rule each | ✅ |
| A3.5.4 | Public-surface byte-identical | test-only PR; `lib/index.cjs` produced from `src/Scrapers/**` not regenerated this PR | ✅ |
| A3.5.5 | Test-body freeze | targeted jest 109/109 PASS unchanged; runtime assertion count preserved | ✅ |
| A3.5.6 | madge --circular | `npx madge --circular src/Scrapers/Pipeline/EslintCanaries` → 0 cycles | ✅ |
| A3.5.7 | Rubber-duck on FULL diff vs main | rubber-duck consult before T7 caught flat-config last-wins clobber risk; before T8 caught that AST selectors cannot compute `loc.end.line` → inline plugin required | ✅ |
| A3.5.8 | Cap-alignment trace | §19.9 cap (10 stmts) aligns with §19.6 production `max-statements:10`; §19.10 cap (10 lines) aligns with §19.6 implicit ≤10-line norm | ✅ |
| A3.5.9 | Exit-gate summary | jest 109/109, lint exit 0, tsc clean, prettier clean, 9 files, 67 canaries | ✅ ALL GREEN |
| A3.5.10 | File-count ≤150 (`pr-guidlines.md §12`) | 9/150 | ✅ |

### Verification outputs (abridged)

```
$ npm run lint
  (no warnings or errors — exit 0)
  ✅ All 67 TS canaries triggered at least one real rule

$ jest --testPathPatterns="DashboardPhase|AuthDiscoveryFactoryTest|BalanceResolveCrossBank"
  Test Suites: 8 passed, 8 total
  Tests:       109 passed, 109 total

$ npx madge --circular src/Scrapers/Pipeline/EslintCanaries
  ✔ No circular dependency found!

$ npx tsc --noEmit
  (clean — exit 0)

$ Get-ChildItem -Path src\Scrapers\Pipeline\EslintCanaries -Filter '*.canary.ts' -Recurse | Measure-Object
  Count: 67

$ git --no-pager diff --name-only main..HEAD | wc -l
  9
```

### CR cycle disposition

**Cycle 1** (3 findings, all RESOLVED in rebuild force-push to `b599f99c`):

| CR # | Severity | File | Finding | Disposition | Fix commit |
|---|---|---|---|---|---|
| CR-1 | Major | `Helpers.ts` 126-143 | `assertSuccessfulScrape` exceeds 10-line cap | RESOLVED — extracted `assertNonZeroTotalTxns` helper; body now 8 stmts | `e234710d` (T2) |
| CR-2 | Quick-win | `Helpers.ts` 108-111 | inline `'default'` sentinel is brittle | RESOLVED — extracted `BEINLEUMI_DEFAULT_FALLBACK_ID` const (mirrors production-private `DEFAULT_ACCOUNT_NUMBER`; test-only PR cannot export from production) | `e234710d` (T2) |
| CR-3 | — | `CaptureInvalidLogin.ts` 534-539 | `navigateToLoginPage` swallows `page.goto` errors | RESOLVED — `await page.goto()` direct (fail-fast); only `waitForLoadState('networkidle')` still swallowed | `24da062e` (T1) |

**Cycle 2** (5 findings, all RESOLVED in bundled force-push to `85f5b8d9`):

| CR # | Severity | File | Finding | Disposition | Fix commit |
|---|---|---|---|---|---|
| CR-4 | Nit | `eslint.config.mjs` §19.9 selector | Selector also fires on unnamed function expressions | RESOLVED — tightened to `FunctionDeclaration[id.name][body.body.length>10]` | `2afab0ea` (T8) |
| CR-5 | Nit | `test-helper-over-10-stmts.canary.ts` `CANARY_LABEL` | String literal not narrowed | RESOLVED — added `as const` | `2afab0ea` (T8) |
| CR-6 | Major | `CaptureInvalidLogin.ts` `bootBrowserSession` | Browser leaks if `buildSessionFromBrowser` throws | RESOLVED — wrapped in try/catch with `closeQuietly` on failure | `85f5b8d9` (T9) |
| CR-7 | Major | All Phase-9 touched test files | §19.9 stmt cap insufficient: 19 helpers slipped past 10 LINES while ≤10 stmts | RESOLVED — added §19.10 line cap (T8) + refactored 19 helpers (T9) | `2afab0ea` + `85f5b8d9` |
| CR-8 | Bug | `BalanceResolveCrossBank.test.ts` `runChain` | Returns post-stage value but expected action-stage value | RESOLVED — extracted `runActionPost` that returns `postResult.value` from the action stage | `85f5b8d9` (T9) |
| Outside-diff | Safety | `probe-beinleumi-nth.ts` `main` | Browser not closed when assertion throws | RESOLVED — wrapped assertions in try/finally with `closeIfOpen` cleanup | `85f5b8d9` (T9) |


**Cycle 3** (1 finding, RESOLVED in fast-forward push to `df290e1e`):

| CR # | Severity | File | Finding | Disposition | Fix commit |
|---|---|---|---|---|---|
| CR-9 | Minor (Quick win) | `probe-beinleumi-nth.ts` `closeIfOpen` L146 | Bare `catch {}` swallows ALL close errors, hiding real teardown failures | RESOLVED — added `ALREADY_CLOSED_FRAGMENTS` lower-cased fragment list (6 known Playwright fragments: "browser closed", "browser has been closed", "browser has disconnected", "target closed", "target page, context or browser has been closed", "connection closed") + `isAlreadyClosedError(err)` predicate handling both `Error` and non-Error throws (`String(err)` fallback); catch now re-throws when predicate is false | `df290e1e` (T10) |

T10 was pushed as a fast-forward (no rebuild) since it only adds a new
commit on top of `85f5b8d9` without altering prior history — single
CR review trigger, no force-push needed.

All findings across all three cycles RESOLVED. Branch force-pushed twice
(once after cycle 1, once after cycle 2) — each rebuild bundles
ALL outstanding CR fixes + commit-subject ≤50 amend + folded
prettier into a single push to avoid burning extra CR rate-limit
cycles.

### Post-merge protocol

Following `post-pr-checklist.md` C1-C10 once merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added guards and canary fixtures to enforce size limits on test helper functions (statements and lines), improving test quality checks.

* **Refactor**
  * Restructured multiple test suites and tooling for clearer helpers, modular orchestration, and safer teardown flows.

* **Tools**
  * Reworked capture and probe scripts for more modular browser/session handling and clearer artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
