### PR TITLE
feat(integration): Mode B HAR-replay simulator skeleton — Step 3a (DRAFT)

### DIFF
--- a/src/Tests/Integration/Simulator/HarLoader.ts
+++ b/src/Tests/Integration/Simulator/HarLoader.ts
@@ -1,0 +1,117 @@
+/**
+ * HAR 1.2 loader — reads a Playwright `recordHar` output file and
+ * validates it into a strongly-typed {@link IHarFile}.
+ *
+ * Why strict validation up front:
+ * - Downstream {@link StatefulRewriter} and {@link HarToMirrorManifest}
+ *   expect well-formed entries; failing fast at load time produces a
+ *   single clear error rather than a cascade of `cannot read property`
+ *   crashes later in the request stream.
+ * - The repo bans `@typescript-eslint/no-unsafe-assignment` and
+ *   `no-explicit-any`, so JSON.parse output is narrowed via assertion
+ *   functions before any property access.
+ *
+ * Public surface (factory):
+ * - {@link loadHarFile} — full HAR document.
+ * - {@link loadHarEntries} — convenience: just the entry array.
+ *
+ * @see ./HarTypes.ts — shape definitions.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import ScraperError from '../../../Scrapers/Base/ScraperError.js';
+import type { IHarEntry, IHarFile } from './HarTypes.js';
+
+/**
+ * Read a file and parse it as JSON, returning `unknown`.
+ *
+ * Intentionally returns `unknown` (not `any`) so downstream assertion
+ * functions are forced to narrow before property access.
+ *
+ * @param filePath - Absolute path to the HAR file.
+ * @returns Parsed JSON value (caller must validate shape).
+ */
+function readJsonFile(filePath: string): unknown {
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  return parsed;
+}
+
+/**
+ * Narrow `value` to a plain object (record). Throws on null/primitive.
+ *
+ * @param value - Candidate value.
+ * @param ctx - Context label used in the error message.
+ */
+function assertObject(value: unknown, ctx: string): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ScraperError(`HAR validation: ${ctx} is not an object`);
+  }
+}
+
+/**
+ * Narrow `value` to a readonly array.
+ *
+ * @param value - Candidate value.
+ * @param ctx - Context label used in the error message.
+ */
+function assertArray(value: unknown, ctx: string): asserts value is readonly unknown[] {
+  if (!Array.isArray(value)) throw new ScraperError(`HAR validation: ${ctx} is not an array`);
+}
+
+/**
+ * Validate one HAR entry has the request/response sub-objects the
+ * simulator depends on.
+ *
+ * Only the OUTER shape is checked here — request.method/url and
+ * response.status/content are validated lazily by {@link StatefulRewriter}
+ * when an entry is actually picked for replay.
+ *
+ * @param entry - Candidate entry object.
+ * @param index - Position in entries[] (for error messages).
+ */
+function assertEntryShape(entry: unknown, index: number): asserts entry is IHarEntry {
+  assertObject(entry, `entries[${String(index)}]`);
+  assertObject(entry.request, `entries[${String(index)}].request`);
+  assertObject(entry.response, `entries[${String(index)}].response`);
+}
+
+/**
+ * Validate the top-level HAR document has `log.entries[]`.
+ *
+ * @param data - Raw parsed JSON.
+ */
+function assertHarFile(data: unknown): asserts data is IHarFile {
+  assertObject(data, 'root');
+  assertObject(data.log, 'log');
+  assertArray(data.log.entries, 'log.entries');
+  data.log.entries.forEach((entry, index) => {
+    assertEntryShape(entry, index);
+  });
+}
+
+/**
+ * Load and validate a HAR file at `filePath`.
+ *
+ * @param filePath - Absolute path to a Playwright-recorded HAR JSON.
+ * @returns Typed HAR file.
+ */
+function loadHarFile(filePath: string): IHarFile {
+  const data = readJsonFile(filePath);
+  assertHarFile(data);
+  return data;
+}
+
+/**
+ * Convenience: load a HAR file and return just the entry array.
+ *
+ * @param filePath - Absolute path to a Playwright-recorded HAR JSON.
+ * @returns Frozen entries array.
+ */
+function loadHarEntries(filePath: string): readonly IHarEntry[] {
+  const file = loadHarFile(filePath);
+  return file.log.entries;
+}
+
+export { loadHarEntries, loadHarFile };

--- a/src/Tests/Integration/Simulator/HarToMirrorManifest.ts
+++ b/src/Tests/Integration/Simulator/HarToMirrorManifest.ts
@@ -1,0 +1,214 @@
+/**
+ * HAR → MirrorManifest converter (skeleton).
+ *
+ * <p>Bridges Playwright-recorded HAR files into rows that can be
+ * augmented by the operator into a full {@link IMirrorManifest},
+ * letting the existing Mode B {@link MirrorSimulator} replay HAR
+ * captures without a duplicate state machine.
+ *
+ * <p>What this module DOES (operator-independent):
+ *
+ * <ul>
+ *   <li>Read a HAR entry array.</li>
+ *   <li>Project each entry to an {@link IHarToManifestRow} bundle —
+ *       the same fields a manifest transition holds (method, URL,
+ *       status, contentType, headers, body) MINUS the manifest
+ *       semantics (phase, advanceTo, predicates, bodyFile path).</li>
+ *   <li>Validate HTTP method ∈ {@link MirrorMethod} set.</li>
+ * </ul>
+ *
+ * <p>What this module does NOT do (operator-owned):
+ *
+ * <ul>
+ *   <li>Decide which row belongs to which {@link IntegrationPhase} —
+ *       requires the phase-map sidecar captured during harvest.</li>
+ *   <li>Write body files to disk — that lives in a later harvester
+ *       tool once real HAR captures land.</li>
+ *   <li>Add postData / header / cookie predicates — those encode
+ *       OTP-challenge and session-cookie invariants that need
+ *       per-bank knowledge.</li>
+ * </ul>
+ *
+ * @see ../Mirror/MirrorManifest.ts — target shape.
+ * @see ../Mirror/MirrorSimulator.ts — consumer.
+ * @see ./HarTypes.ts — source shape.
+ */
+
+import { isSome, none, type Option, some } from '../../../Scrapers/Pipeline/Types/Option.js';
+import type { IMirrorResponse, MirrorMethod } from '../Mirror/MirrorManifest.js';
+import type { IHarContent, IHarEntry, IHarKeyValue, IHarResponse } from './HarTypes.js';
+
+/** Allowed HTTP methods in {@link MirrorMethod}. */
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const;
+
+/**
+ * Projected row — ready for an operator to augment into an
+ * {@link IMirrorTransition}.
+ */
+interface IHarToManifestRow {
+  readonly method: MirrorMethod;
+  readonly urlPattern: string;
+  readonly response: IMirrorResponse;
+  /** Inline body (utf8 text or base64), kept separately from response.bodyFile. */
+  readonly inlineBody: string;
+  readonly inlineBodyEncoding: 'utf8' | 'base64';
+}
+
+/**
+ * Test whether `value` is a known {@link MirrorMethod}.
+ *
+ * @param value - HTTP method string from HAR.
+ * @returns True when supported by the mirror simulator.
+ */
+function isAllowedMethod(value: string): value is MirrorMethod {
+  const upper = value.toUpperCase();
+  return (ALLOWED_METHODS as readonly string[]).includes(upper);
+}
+
+/**
+ * Canonicalize the URL the same way {@link StatefulRewriter} does
+ * by default: `scheme://host/pathname` (no search/fragment).
+ *
+ * @param url - Raw URL from HAR.
+ * @returns Canonical URL string.
+ */
+function canonicalUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Flatten HAR header key/value pairs into a case-insensitive
+ * `ReadonlyMap` (keys are lower-cased).
+ *
+ * Duplicate header names are joined with ", " (RFC 7230 §3.2.2),
+ * matching how Playwright's `route.fulfil` accepts headers.
+ *
+ * @param headers - HAR header array.
+ * @returns Frozen map keyed by lower-cased name.
+ */
+function flattenHeaders(headers: readonly IHarKeyValue[]): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  for (const { name, value } of headers) {
+    const key = name.toLowerCase();
+    const existing = map.get(key);
+    map.set(key, existing === undefined ? value : `${existing}, ${value}`);
+  }
+  return map;
+}
+
+/**
+ * Convert a header `ReadonlyMap` into a plain `Record<string,string>`
+ * (preserving the lower-cased keys) for {@link IMirrorResponse.headers}.
+ *
+ * @param map - Flattened header map.
+ * @returns Frozen record (plain object).
+ */
+function headersToRecord(map: ReadonlyMap<string, string>): Readonly<Record<string, string>> {
+  return Object.fromEntries(map);
+}
+
+/**
+ * Read the `Content-Type` response header, or fall back to
+ * `content.mimeType`, or `application/octet-stream`.
+ *
+ * @param headers - Flattened header map.
+ * @param content - HAR content (used for `mimeType` fallback).
+ * @returns Resolved content type.
+ */
+function resolveContentType(headers: ReadonlyMap<string, string>, content: IHarContent): string {
+  const explicit = headers.get('content-type');
+  if (explicit !== undefined) return explicit;
+  if (content.mimeType !== '') return content.mimeType;
+  return 'application/octet-stream';
+}
+
+/**
+ * Build the IMirrorResponse for a HAR response. The `bodyFile` is left
+ * empty — operator fills it after writing body to disk.
+ *
+ * @param harResponse - HAR response object.
+ * @returns Partial mirror response with empty `bodyFile`.
+ */
+function toMirrorResponse(harResponse: IHarResponse): IMirrorResponse {
+  const headers = flattenHeaders(harResponse.headers);
+  const contentType = resolveContentType(headers, harResponse.content);
+  const headerRecord = headersToRecord(headers);
+  return { status: harResponse.status, contentType, bodyFile: '', headers: headerRecord };
+}
+
+/**
+ * Build the inline body fields (text + encoding) for a HAR response.
+ *
+ * @param response - HAR response object.
+ * @returns Tuple of body text and encoding tag.
+ */
+function pickInlineBody(response: IHarResponse): { text: string; encoding: 'utf8' | 'base64' } {
+  const text = response.content.text ?? '';
+  const encoding = response.content.encoding === 'base64' ? 'base64' : 'utf8';
+  return { text, encoding };
+}
+
+/** Args bundle for {@link buildRow}. */
+interface IBuildRowArgs {
+  readonly method: MirrorMethod;
+  readonly urlPattern: string;
+  readonly response: IMirrorResponse;
+  readonly inline: { text: string; encoding: 'utf8' | 'base64' };
+}
+
+/**
+ * Assemble an {@link IHarToManifestRow} from its parts.
+ *
+ * @param args - Row parts.
+ * @returns Frozen row.
+ */
+function buildRow(args: IBuildRowArgs): IHarToManifestRow {
+  return {
+    method: args.method,
+    urlPattern: args.urlPattern,
+    response: args.response,
+    inlineBody: args.inline.text,
+    inlineBodyEncoding: args.inline.encoding,
+  };
+}
+
+/**
+ * Project one HAR entry to an {@link IHarToManifestRow}, returning
+ * None when the entry's method is unsupported.
+ *
+ * @param entry - HAR entry.
+ * @returns Some(row) on success; None when method unsupported.
+ */
+function toManifestRow(entry: IHarEntry): Option<IHarToManifestRow> {
+  const methodRaw = entry.request.method.toUpperCase();
+  if (!isAllowedMethod(methodRaw)) return none();
+  const inline = pickInlineBody(entry.response);
+  const urlPattern = canonicalUrl(entry.request.url);
+  const response = toMirrorResponse(entry.response);
+  const row = buildRow({ method: methodRaw, urlPattern, response, inline });
+  return some(row);
+}
+
+/**
+ * Convert a HAR entry array into manifest rows, dropping entries with
+ * unsupported HTTP methods.
+ *
+ * @param entries - HAR entry array.
+ * @returns Frozen rows array.
+ */
+function toManifestRows(entries: readonly IHarEntry[]): readonly IHarToManifestRow[] {
+  const rows: IHarToManifestRow[] = [];
+  for (const entry of entries) {
+    const projected = toManifestRow(entry);
+    if (isSome(projected)) rows.push(projected.value);
+  }
+  return rows;
+}
+
+export { ALLOWED_METHODS, canonicalUrl, flattenHeaders, toManifestRow, toManifestRows };
+export type { IHarToManifestRow };

--- a/src/Tests/Integration/Simulator/HarTypes.ts
+++ b/src/Tests/Integration/Simulator/HarTypes.ts
@@ -1,0 +1,83 @@
+/**
+ * HAR 1.2 type definitions — the subset Mode B simulator consumes.
+ *
+ * Source: <http://www.softwareishard.com/blog/har-12-spec/>
+ *
+ * Playwright's `recordHar` option emits HAR 1.2 JSON; this module
+ * captures only the fields the simulator needs (URL/method/status/
+ * headers/body + simple postData) and leaves out browser-specific
+ * fields (pages timings, cache, headersSize, etc.) that aren't relevant
+ * to replay semantics.
+ *
+ * Why a strict subset (not `any`):
+ * `@typescript-eslint/no-explicit-any` is `error` in the repo, and
+ * type-narrow parsing in {@link HarLoader} relies on these shapes.
+ *
+ * @see ./HarLoader.ts — parses + validates JSON to this shape.
+ * @see ./StatefulRewriter.ts — picks the next entry for a request.
+ */
+
+/** A single HAR name/value pair (used for headers, queryString, cookies). */
+interface IHarKeyValue {
+  readonly name: string;
+  readonly value: string;
+}
+
+/** HAR `request.postData` — request body when present. */
+interface IHarPostData {
+  readonly mimeType: string;
+  readonly text: string;
+}
+
+/** HAR `request` — only the fields the simulator matches against. */
+interface IHarRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: readonly IHarKeyValue[];
+  readonly queryString: readonly IHarKeyValue[];
+  readonly postData?: IHarPostData;
+}
+
+/** HAR `response.content` — body shape. */
+interface IHarContent {
+  readonly mimeType: string;
+  readonly text?: string;
+  /** Set to `'base64'` when `text` is base64-encoded binary. */
+  readonly encoding?: 'base64';
+}
+
+/** HAR `response` — only the fields the simulator replays. */
+interface IHarResponse {
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: readonly IHarKeyValue[];
+  readonly content: IHarContent;
+}
+
+/** HAR `log.entries[i]` — one request/response round-trip. */
+interface IHarEntry {
+  readonly request: IHarRequest;
+  readonly response: IHarResponse;
+}
+
+/** HAR `log` — collection of entries. */
+interface IHarLog {
+  readonly version: string;
+  readonly entries: readonly IHarEntry[];
+}
+
+/** Top-level HAR document — wraps `log`. */
+interface IHarFile {
+  readonly log: IHarLog;
+}
+
+export type {
+  IHarContent,
+  IHarEntry,
+  IHarFile,
+  IHarKeyValue,
+  IHarLog,
+  IHarPostData,
+  IHarRequest,
+  IHarResponse,
+};

--- a/src/Tests/Integration/Simulator/README.md
+++ b/src/Tests/Integration/Simulator/README.md
@@ -1,0 +1,96 @@
+# Mode B HAR-replay simulator — skeleton (Step 3a)
+
+This directory holds the **operator-independent skeleton** of the
+Phase 11 Mode B simulator: pure data structures and pure functions
+that read Playwright `recordHar` output and convert it into rows the
+existing [`MirrorSimulator`](../Mirror/MirrorSimulator.ts) can consume.
+
+## What is committed today
+
+| File                     | Purpose                                                        | Lines / fn cap |
+| ------------------------ | -------------------------------------------------------------- | -------------- |
+| `HarTypes.ts`            | HAR 1.2 type subset (no runtime code)                          | n/a            |
+| `HarLoader.ts`           | Read + validate Playwright-recorded HAR JSON                   | 10/10          |
+| `StatefulRewriter.ts`    | Sequence-aware `(method, canonical URL, hit#) → entry` matcher | 10/10          |
+| `HarToMirrorManifest.ts` | Project HAR entries → manifest rows (no FS IO)                 | 10/10          |
+
+All four are **fully unit-tested** with synthetic HAR JSON. They do
+not touch the network, the filesystem (except `HarLoader.readFileSync`),
+or Playwright. They are safe to ship before any real bank recording
+exists.
+
+## What is intentionally **deferred** (and why)
+
+The Step 3 spec at
+`C:\tmp\plans\israeli-bank-scrapers-fork\phase-11-full-coverage\status.md`
+originally listed six modules. The rubber-duck review during the Step 3
+design pass surfaced three blocking issues:
+
+1. **`HttpServer.ts` + `ProxyConfig.ts` with HTTPS cert generation**
+   was high-complexity and required either a new dependency
+   (`selfsigned`, `node-forge`, `pem`) or hand-rolled X.509 generation.
+   It also conflated origin-server semantics with forward-proxy
+   semantics. **Deferred** until a concrete failure case shows that
+   Playwright `context.route` / `page.route` interception is
+   insufficient.
+
+2. **`PhaseStateMachine.ts`** would duplicate the state machine the
+   existing `MirrorSimulator` already runs against `MirrorManifest`.
+   The honest path is to **reuse** that simulator rather than build a
+   second one; `HarToMirrorManifest.ts` is the bridge that lets HAR
+   recordings flow into the existing engine.
+
+3. **`SimulatorFactory.ts`** is premature until real HAR captures
+   exist and the phase-map sidecar format is finalized (HAR alone
+   does not encode the 11-phase chain — it needs a sibling file
+   mapping `entries[i]` → `IntegrationPhase`).
+
+These three modules will land in a follow-up PR once the first bank's
+HAR is recorded and we can iterate against real data.
+
+## Operator workflow (for when HAR captures land)
+
+1. Record HAR per `<bank> × <phase>` cell:
+   ```ts
+   const context = await browser.newContext({
+     recordHar: { path: 'mirrors/banks/<bank>/<NN>-<phase>.har' },
+   });
+   ```
+2. PII-redact via the existing `PiiRedactor`
+   (`src/Tests/Integration/Tools/PiiRedactor.ts`).
+3. Run `loadHarEntries(harPath)` + `toManifestRows(entries)` to get
+   the row skeleton.
+4. Augment each row with `phase`, optional `advanceTo`, and predicates
+   (postData / headers / cookies) — these encode the OTP nonce + session
+   cookie invariants the simulator enforces.
+5. Write body files to disk and fill each row's `response.bodyFile`.
+6. Emit the final `manifest.json` and commit to
+   `src/Tests/Integration/fixtures/banks/<bank>/manifest.json`.
+7. The existing `MirrorSimulator.installSimulator()` consumes the
+   manifest unchanged.
+
+## Why `StatefulRewriter` is committed today even though no HAR exists
+
+The sequence-aware "same URL → different response per N-th hit" logic
+is the trickiest invariant of the Mode B mirror, and the synthetic
+unit tests pin its semantics so that:
+
+- A bank visiting `/api/session` twice during init+post-login does NOT
+  silently serve the pre-login response after login.
+- A bank visiting a polled `/api/transactions` endpoint exhausts the
+  recorded responses in chronological order and reports `exhausted`
+  rather than looping back to entry #0.
+- Diagnostic counters (`missCount`, `exhaustedCount`) surface manifest
+  drift early.
+
+These invariants are independent of any specific bank's data, so
+locking them in via unit tests now prevents a regression later when
+the real-bank flow lands.
+
+## Out-of-scope (handled elsewhere)
+
+- **Phase state machine** → `../Mirror/MirrorSimulator.ts`.
+- **OTP challenge nonces** → `../Mirror/MirrorOtpChallenge.ts`.
+- **Escape classification** → `../Mirror/MirrorEscapeClassifier.ts`.
+- **PII redaction** → `../Tools/PiiRedactor.ts`.
+- **Per-bank coverage matrix** → `../Tools/CheckBankIntegrationCoverage.ts`.

--- a/src/Tests/Integration/Simulator/StatefulRewriter.ts
+++ b/src/Tests/Integration/Simulator/StatefulRewriter.ts
@@ -1,0 +1,283 @@
+/**
+ * Stateful HAR replay rewriter — picks the right HAR entry for an
+ * incoming request based on (method, canonical URL, sequence count).
+ *
+ * Why "stateful":
+ * In SPA-style banking flows the same URL is hit multiple times
+ * during the session (e.g. `/api/session` on init AND after login),
+ * and HAR records the responses chronologically. A naive first-match
+ * rewriter would always serve response #0, breaking the login flow.
+ * This rewriter advances a per-key counter so call #N gets entry #N.
+ *
+ * URL canonicalization:
+ * Defaults to "method + scheme://host/path" (strips query + fragment),
+ * which is the most forgiving for stateful sequencing. Callers can
+ * override via `urlCanonicalizer` when query params carry meaningful
+ * identity (e.g. `?accountId=...`).
+ *
+ * Public surface (factory):
+ * - {@link createStatefulRewriter} — returns {@link IStatefulRewriter}.
+ *
+ * Returned handle:
+ * - `pick(request)` — Option-wrapped entry (None if no match / out of
+ *   sequence).
+ * - `snapshot()` — current per-key counts (for test assertions).
+ *
+ * @see ./HarTypes.ts — entry shape.
+ * @see ./HarLoader.ts — produces the entries[] consumed here.
+ */
+
+import { isSome, none, type Option, some } from '../../../Scrapers/Pipeline/Types/Option.js';
+import type { IHarEntry } from './HarTypes.js';
+
+/** Request descriptor used for matching. */
+interface IRewriterRequest {
+  readonly method: string;
+  readonly url: string;
+}
+
+/** A canonicalizer maps a raw URL to its identity key. */
+type UrlCanonicalizer = (url: string) => string;
+
+/** Spec for {@link createStatefulRewriter}. */
+interface IRewriterSpec {
+  readonly entries: readonly IHarEntry[];
+  readonly urlCanonicalizer?: UrlCanonicalizer;
+}
+
+/** Frozen snapshot of internal counters (for test assertions). */
+interface IRewriterSnapshot {
+  readonly hits: ReadonlyMap<string, number>;
+  readonly missCount: number;
+  readonly exhaustedCount: number;
+}
+
+/** Public handle returned by {@link createStatefulRewriter}. */
+interface IStatefulRewriter {
+  pick(request: IRewriterRequest): Option<IHarEntry>;
+  snapshot(): IRewriterSnapshot;
+}
+
+/** Internal mutable state — held in factory closure. */
+interface IRewriterState {
+  readonly entryIndex: ReadonlyMap<string, readonly IHarEntry[]>;
+  readonly hits: Map<string, number>;
+  missCount: number;
+  exhaustedCount: number;
+}
+
+/**
+ * Default canonicalizer: `METHOD scheme://host/pathname` (no search/hash).
+ *
+ * Falls back to the raw URL when {@link URL} cannot parse it (e.g.
+ * Playwright `data:`/`blob:` schemes), keeping the rewriter robust.
+ *
+ * @param url - Raw URL from HAR or request.
+ * @returns Canonical key (without query/fragment).
+ */
+function defaultUrlKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Build a `method canonicalUrl` composite key.
+ *
+ * @param method - HTTP method (case-insensitive — upper-cased here).
+ * @param canonicalUrl - Result of the URL canonicalizer.
+ * @returns Composite key for the entry index.
+ */
+function compositeKey(method: string, canonicalUrl: string): string {
+  return `${method.toUpperCase()} ${canonicalUrl}`;
+}
+
+/**
+ * Append `entry` to the existing bucket for `key` (or create a fresh
+ * bucket) and return the resulting list, leaving `index` updated.
+ *
+ * @param index - Mutable index map.
+ * @param key - Composite key.
+ * @param entry - HAR entry to append.
+ * @returns The bucket post-append (length ≥ 1).
+ */
+function appendToBucket(
+  index: Map<string, IHarEntry[]>,
+  key: string,
+  entry: IHarEntry,
+): readonly IHarEntry[] {
+  const bucket = index.get(key) ?? [];
+  bucket.push(entry);
+  index.set(key, bucket);
+  return bucket;
+}
+
+/** Args bundle for {@link buildEntryIndex}. */
+interface IBuildIndexArgs {
+  readonly entries: readonly IHarEntry[];
+  readonly canonicalize: UrlCanonicalizer;
+}
+
+/**
+ * Index entries by composite key, preserving chronological order
+ * within each bucket.
+ *
+ * @param args - Source HAR entries + URL canonicalizer.
+ * @returns Frozen Map of key → entries[].
+ */
+function buildEntryIndex(args: IBuildIndexArgs): ReadonlyMap<string, readonly IHarEntry[]> {
+  const index = new Map<string, IHarEntry[]>();
+  for (const entry of args.entries) {
+    const canonical = args.canonicalize(entry.request.url);
+    const key = compositeKey(entry.request.method, canonical);
+    appendToBucket(index, key, entry);
+  }
+  return index;
+}
+
+/**
+ * Increment the per-key hit counter and return the resulting count.
+ *
+ * @param state - Mutable rewriter state.
+ * @param key - Composite key.
+ * @returns New hit count (1-based on first hit).
+ */
+function bumpHit(state: IRewriterState, key: string): number {
+  const next = (state.hits.get(key) ?? 0) + 1;
+  state.hits.set(key, next);
+  return next;
+}
+
+/**
+ * Spec for {@link selectFromBucket}.
+ */
+interface ISelectBucketArgs {
+  readonly state: IRewriterState;
+  readonly bucket: readonly IHarEntry[];
+  readonly hitNumber: number;
+}
+
+/**
+ * Pick the entry for the Nth hit of a bucket, or None if exhausted.
+ *
+ * @param args - State + bucket + 1-based hit number.
+ * @returns Some(entry) when in-range; None when exhausted.
+ */
+function selectFromBucket(args: ISelectBucketArgs): Option<IHarEntry> {
+  const zeroIndex = args.hitNumber - 1;
+  if (zeroIndex >= args.bucket.length) {
+    args.state.exhaustedCount = args.state.exhaustedCount + 1;
+    return none();
+  }
+  return some(args.bucket[zeroIndex]);
+}
+
+/**
+ * Spec for {@link resolveRequest}.
+ */
+interface IResolveArgs {
+  readonly state: IRewriterState;
+  readonly canonicalize: UrlCanonicalizer;
+  readonly request: IRewriterRequest;
+}
+
+/**
+ * Record a miss for `key` and return None.
+ *
+ * @param state - Mutable rewriter state.
+ * @returns Always None.
+ */
+function recordMiss(state: IRewriterState): Option<IHarEntry> {
+  state.missCount = state.missCount + 1;
+  return none();
+}
+
+/**
+ * Pick the next entry for `request`. Updates internal counters.
+ *
+ * @param args - Mutable state + canonicalizer + request descriptor.
+ * @returns Some(entry) on match; None on miss/exhausted.
+ */
+function resolveRequest(args: IResolveArgs): Option<IHarEntry> {
+  const canonical = args.canonicalize(args.request.url);
+  const key = compositeKey(args.request.method, canonical);
+  const bucket = args.state.entryIndex.get(key);
+  if (!bucket) return recordMiss(args.state);
+  const hitNumber = bumpHit(args.state, key);
+  return selectFromBucket({ state: args.state, bucket, hitNumber });
+}
+
+/**
+ * Freeze the mutable counters into an immutable snapshot.
+ *
+ * @param state - Internal state.
+ * @returns Snapshot suitable for test assertions.
+ */
+function snapshotState(state: IRewriterState): IRewriterSnapshot {
+  const hits = new Map(state.hits);
+  return { hits, missCount: state.missCount, exhaustedCount: state.exhaustedCount };
+}
+
+/**
+ * Build the initial mutable state for the rewriter.
+ *
+ * @param spec - Rewriter spec.
+ * @param canonicalize - URL canonicalizer.
+ * @returns Fresh mutable state.
+ */
+function buildInitialState(spec: IRewriterSpec, canonicalize: UrlCanonicalizer): IRewriterState {
+  return {
+    entryIndex: buildEntryIndex({ entries: spec.entries, canonicalize }),
+    hits: new Map(),
+    missCount: 0,
+    exhaustedCount: 0,
+  };
+}
+
+/**
+ * Build the `pick` closure bound to `state` + `canonicalize`.
+ *
+ * @param state - Mutable rewriter state.
+ * @param canonicalize - URL canonicalizer.
+ * @returns Picker fn that consumes one request per call.
+ */
+function createPickFn(
+  state: IRewriterState,
+  canonicalize: UrlCanonicalizer,
+): IStatefulRewriter['pick'] {
+  return request => resolveRequest({ state, canonicalize, request });
+}
+
+/**
+ * Build the `snapshot` closure bound to `state`.
+ *
+ * @param state - Mutable rewriter state.
+ * @returns Zero-arg snapshot function.
+ */
+function createSnapshotFn(state: IRewriterState): IStatefulRewriter['snapshot'] {
+  return () => snapshotState(state);
+}
+
+/**
+ * Create a sequence-aware HAR replay rewriter.
+ *
+ * @param spec - Entries + optional URL canonicalizer.
+ * @returns Handle exposing `pick` + `snapshot`.
+ */
+function createStatefulRewriter(spec: IRewriterSpec): IStatefulRewriter {
+  const canonicalize = spec.urlCanonicalizer ?? defaultUrlKey;
+  const state = buildInitialState(spec, canonicalize);
+  return { pick: createPickFn(state, canonicalize), snapshot: createSnapshotFn(state) };
+}
+
+export { createStatefulRewriter, defaultUrlKey, isSome };
+export type {
+  IRewriterRequest,
+  IRewriterSnapshot,
+  IRewriterSpec,
+  IStatefulRewriter,
+  UrlCanonicalizer,
+};

--- a/src/Tests/Integration/mirrors/banks/README.md
+++ b/src/Tests/Integration/mirrors/banks/README.md
@@ -1,0 +1,23 @@
+# Mode B HAR fixtures — recording root
+
+This directory stores per-bank Playwright HAR recordings + PII-redacted
+sidecar JSON used by the Mode B mirror simulator.
+
+```
+mirrors/banks/
+  <bank>/
+    01-init.har
+    02-pre-login.har
+    03-login.har
+    04-otp-trigger.har
+    05-otp-fill.har
+    06-auth-discovery.har
+    07-account-resolve.har
+    08-dashboard.har
+    09-scrape.har
+    10-terminate.har
+    phase-map.json       # entries[i] → IntegrationPhase
+```
+
+**No HAR captures are committed yet.** See
+`../Simulator/README.md` for the operator workflow that fills this tree.

--- a/src/Tests/Unit/Integration/Simulator/HarLoader.test.ts
+++ b/src/Tests/Unit/Integration/Simulator/HarLoader.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for HarLoader.
+ *
+ * Validates that:
+ * - well-formed Playwright HAR files load into a typed {@link IHarFile};
+ * - missing `log` / non-array `entries` / non-object root all throw a
+ *   single readable {@link ScraperError} message;
+ * - per-entry shape (missing `request`/`response`) is caught.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import ScraperError from '../../../../Scrapers/Base/ScraperError.js';
+import { loadHarEntries, loadHarFile } from '../../../Integration/Simulator/HarLoader.js';
+
+/** Minimal valid HAR JSON used as a baseline. */
+const VALID_HAR = {
+  log: {
+    version: '1.2',
+    creator: { name: 'jest', version: '1.0' },
+    entries: [
+      {
+        request: { method: 'GET', url: 'https://bank.example/api', headers: [], queryString: [] },
+        response: {
+          status: 200,
+          statusText: 'OK',
+          headers: [],
+          content: { mimeType: 'text/html' },
+        },
+      },
+    ],
+  },
+} as const;
+
+/** Handle for one isolated test workspace. */
+interface ITempHar {
+  readonly path: string;
+  readonly cleanup: () => boolean;
+}
+
+/**
+ * Build a cleanup callback that recursively removes `dir`.
+ *
+ * @param dir - Directory to remove.
+ * @returns Callback returning true after deletion.
+ */
+function makeCleanup(dir: string): () => boolean {
+  return (): boolean => {
+    rmSync(dir, { recursive: true, force: true });
+    return true;
+  };
+}
+
+/**
+ * Create a temp .har file containing `raw`.
+ *
+ * @param raw - JSON body (will be `JSON.stringify`-ed).
+ * @returns Path + cleanup callback.
+ */
+function makeTempHar(raw: unknown): ITempHar {
+  const sysTemp = tmpdir();
+  const prefix = join(sysTemp, 'har-loader-test-');
+  const dir = mkdtempSync(prefix);
+  const path = join(dir, 'capture.har');
+  const body = JSON.stringify(raw);
+  writeFileSync(path, body, 'utf8');
+  return { path, cleanup: makeCleanup(dir) };
+}
+
+describe('HarLoader', () => {
+  describe('loadHarFile (happy path)', () => {
+    it('parses + returns the typed IHarFile', () => {
+      const t = makeTempHar(VALID_HAR);
+      try {
+        const file = loadHarFile(t.path);
+        const firstEntry = file.log.entries[0];
+        expect(file.log.entries.length).toBe(1);
+        expect(firstEntry.request.method).toBe('GET');
+        expect(firstEntry.response.status).toBe(200);
+      } finally {
+        t.cleanup();
+      }
+    });
+  });
+
+  describe('loadHarEntries (convenience)', () => {
+    it('returns just the entries array', () => {
+      const t = makeTempHar(VALID_HAR);
+      try {
+        const entries = loadHarEntries(t.path);
+        const firstUrl = entries[0].request.url;
+        expect(entries.length).toBe(1);
+        expect(firstUrl).toBe('https://bank.example/api');
+      } finally {
+        t.cleanup();
+      }
+    });
+  });
+
+  describe('validation errors', () => {
+    it('throws ScraperError on non-object root', () => {
+      const t = makeTempHar('not-an-object');
+      try {
+        expect(() => loadHarFile(t.path)).toThrow(ScraperError);
+        expect(() => loadHarFile(t.path)).toThrow(/root is not an object/);
+      } finally {
+        t.cleanup();
+      }
+    });
+
+    it('throws ScraperError on missing log', () => {
+      const t = makeTempHar({ noLog: true });
+      try {
+        expect(() => loadHarFile(t.path)).toThrow(/log is not an object/);
+      } finally {
+        t.cleanup();
+      }
+    });
+
+    it('throws ScraperError on non-array entries', () => {
+      const t = makeTempHar({ log: { entries: 'oops' } });
+      try {
+        expect(() => loadHarFile(t.path)).toThrow(/log\.entries is not an array/);
+      } finally {
+        t.cleanup();
+      }
+    });
+
+    it('throws ScraperError on entry missing request', () => {
+      const bad = { log: { entries: [{ response: {} }] } };
+      const t = makeTempHar(bad);
+      try {
+        expect(() => loadHarFile(t.path)).toThrow(/entries\[0\]\.request is not an object/);
+      } finally {
+        t.cleanup();
+      }
+    });
+
+    it('throws ScraperError on entry missing response', () => {
+      const bad = { log: { entries: [{ request: {} }] } };
+      const t = makeTempHar(bad);
+      try {
+        expect(() => loadHarFile(t.path)).toThrow(/entries\[0\]\.response is not an object/);
+      } finally {
+        t.cleanup();
+      }
+    });
+  });
+});

--- a/src/Tests/Unit/Integration/Simulator/HarToMirrorManifest.test.ts
+++ b/src/Tests/Unit/Integration/Simulator/HarToMirrorManifest.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for HarToMirrorManifest.
+ *
+ * Pins the bridge contract:
+ *
+ * - Each well-formed HAR entry projects to exactly one row.
+ * - Unsupported HTTP methods (e.g. `CONNECT`) are dropped silently.
+ * - URLs are canonicalized (query + fragment stripped).
+ * - Duplicate response headers are joined with ", ".
+ * - `Content-Type` resolves header → mimeType → octet-stream fallback.
+ * - Base64-encoded bodies surface `inlineBodyEncoding: 'base64'`.
+ * - `bodyFile` is intentionally left empty (operator fills it after
+ *   writing body to disk).
+ */
+
+import ScraperError from '../../../../Scrapers/Base/ScraperError.js';
+import { isSome } from '../../../../Scrapers/Pipeline/Types/Option.js';
+import {
+  canonicalUrl,
+  flattenHeaders,
+  toManifestRow,
+  toManifestRows,
+} from '../../../Integration/Simulator/HarToMirrorManifest.js';
+import type { IHarEntry } from '../../../Integration/Simulator/HarTypes.js';
+
+/** Spec for {@link buildEntry}. */
+interface IBuildEntrySpec {
+  readonly method: string;
+  readonly url: string;
+  readonly body?: string;
+  readonly encoding?: 'base64';
+  readonly mimeType?: string;
+  readonly contentType?: string;
+  readonly status?: number;
+  readonly extraHeaders?: readonly { name: string; value: string }[];
+}
+
+/**
+ * Build the response headers array for a synthetic HAR entry.
+ *
+ * @param spec - Entry spec.
+ * @returns Headers array (may be empty).
+ */
+function buildResponseHeaders(spec: IBuildEntrySpec): readonly { name: string; value: string }[] {
+  const ct =
+    spec.contentType === undefined ? [] : [{ name: 'Content-Type', value: spec.contentType }];
+  const extra = spec.extraHeaders ?? [];
+  return [...ct, ...extra];
+}
+
+/**
+ * Build a synthetic HAR entry.
+ *
+ * @param spec - Method / URL / body / encoding / contentType / extra headers.
+ * @returns Minimal HAR entry.
+ */
+function buildEntry(spec: IBuildEntrySpec): IHarEntry {
+  const headers = buildResponseHeaders(spec);
+  const content = { mimeType: spec.mimeType ?? '', text: spec.body, encoding: spec.encoding };
+  const status = spec.status ?? 200;
+  return {
+    request: { method: spec.method, url: spec.url, headers: [], queryString: [] },
+    response: { status, statusText: 'OK', headers, content },
+  };
+}
+
+/**
+ * Unwrap an {@link Option} or fail the test with a stable error.
+ *
+ * @param opt - Option value (`{ has, value? }` discriminated union).
+ * @param opt.has - True iff `value` is set.
+ * @param opt.value - Wrapped value (only inspected when `has` is true).
+ * @returns The wrapped value.
+ */
+function unwrapSomeOrFail<T>(opt: { has: boolean; value?: T }): T {
+  if (!opt.has || opt.value === undefined) throw new ScraperError('expected Some, got None');
+  return opt.value;
+}
+
+describe('HarToMirrorManifest', () => {
+  describe('canonicalUrl', () => {
+    it('strips query + fragment', () => {
+      const result = canonicalUrl('https://b.example/api?x=1#z');
+      expect(result).toBe('https://b.example/api');
+    });
+
+    it('falls back to raw string when URL parse fails', () => {
+      const result = canonicalUrl('::bad::');
+      expect(result).toBe('::bad::');
+    });
+  });
+
+  describe('flattenHeaders', () => {
+    it('lower-cases header names', () => {
+      const map = flattenHeaders([{ name: 'X-Custom', value: 'v' }]);
+      const lower = map.get('x-custom');
+      const original = map.get('X-Custom');
+      expect(lower).toBe('v');
+      expect(original).toBeUndefined();
+    });
+
+    it('joins duplicate header values with comma-space', () => {
+      const map = flattenHeaders([
+        { name: 'Set-Cookie', value: 'a=1' },
+        { name: 'set-cookie', value: 'b=2' },
+      ]);
+      const joined = map.get('set-cookie');
+      expect(joined).toBe('a=1, b=2');
+    });
+  });
+
+  describe('toManifestRow — happy path', () => {
+    it('projects GET with explicit Content-Type', () => {
+      const entry = buildEntry({
+        method: 'GET',
+        url: 'https://b.example/api?x=1',
+        body: '{"ok":true}',
+        contentType: 'application/json',
+      });
+      const opt = toManifestRow(entry);
+      const row = unwrapSomeOrFail(opt);
+      expect(row.method).toBe('GET');
+      expect(row.urlPattern).toBe('https://b.example/api');
+      expect(row.response.contentType).toBe('application/json');
+      expect(row.response.bodyFile).toBe('');
+      expect(row.inlineBody).toBe('{"ok":true}');
+      expect(row.inlineBodyEncoding).toBe('utf8');
+    });
+
+    it('uppercases lowercase method', () => {
+      const entry = buildEntry({ method: 'post', url: 'https://b.example/x' });
+      const opt = toManifestRow(entry);
+      const row = unwrapSomeOrFail(opt);
+      expect(row.method).toBe('POST');
+    });
+
+    it('falls back to content.mimeType when no header', () => {
+      const entry = buildEntry({ method: 'GET', url: 'https://b.example/x', mimeType: 'text/css' });
+      const opt = toManifestRow(entry);
+      const row = unwrapSomeOrFail(opt);
+      expect(row.response.contentType).toBe('text/css');
+    });
+
+    it('falls back to application/octet-stream when nothing known', () => {
+      const entry = buildEntry({ method: 'GET', url: 'https://b.example/x' });
+      const opt = toManifestRow(entry);
+      const row = unwrapSomeOrFail(opt);
+      expect(row.response.contentType).toBe('application/octet-stream');
+    });
+
+    it('marks base64 bodies', () => {
+      const entry = buildEntry({
+        method: 'GET',
+        url: 'https://b.example/img',
+        body: 'BASE64DATA',
+        encoding: 'base64',
+        contentType: 'image/png',
+      });
+      const opt = toManifestRow(entry);
+      const row = unwrapSomeOrFail(opt);
+      expect(row.inlineBodyEncoding).toBe('base64');
+      expect(row.inlineBody).toBe('BASE64DATA');
+    });
+  });
+
+  describe('toManifestRow — rejection', () => {
+    it('drops unsupported method (CONNECT)', () => {
+      const entry = buildEntry({ method: 'CONNECT', url: 'https://b.example/' });
+      const row = toManifestRow(entry);
+      const hasMatch = isSome(row);
+      expect(hasMatch).toBe(false);
+    });
+  });
+
+  describe('toManifestRows', () => {
+    it('keeps supported entries, drops unsupported', () => {
+      const supported = buildEntry({ method: 'GET', url: 'https://b.example/a' });
+      const unsupported = buildEntry({ method: 'CONNECT', url: 'https://b.example/proxy' });
+      const rows = toManifestRows([supported, unsupported]);
+      const firstMethod = rows[0].method;
+      expect(rows.length).toBe(1);
+      expect(firstMethod).toBe('GET');
+    });
+
+    it('preserves chronological order', () => {
+      const first = buildEntry({ method: 'GET', url: 'https://b.example/one' });
+      const second = buildEntry({ method: 'POST', url: 'https://b.example/two' });
+      const rows = toManifestRows([first, second]);
+      const urls = rows.map(r => r.urlPattern);
+      expect(urls).toEqual(['https://b.example/one', 'https://b.example/two']);
+    });
+  });
+});

--- a/src/Tests/Unit/Integration/Simulator/StatefulRewriter.test.ts
+++ b/src/Tests/Unit/Integration/Simulator/StatefulRewriter.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for StatefulRewriter.
+ *
+ * Pins the sequence-aware semantics:
+ *
+ * - Same `(method, canonical-url)` hit twice → returns entries in
+ *   chronological order (1st hit = entries[0], 2nd hit = entries[1]).
+ * - Exhausted bucket → None + bumps `exhaustedCount`.
+ * - Unknown URL → None + bumps `missCount` (does NOT bump `exhaustedCount`).
+ * - Default URL canonicalizer strips `?query` and `#fragment`.
+ * - Custom canonicalizer is honoured.
+ */
+
+import ScraperError from '../../../../Scrapers/Base/ScraperError.js';
+import { isSome } from '../../../../Scrapers/Pipeline/Types/Option.js';
+import type { IHarEntry } from '../../../Integration/Simulator/HarTypes.js';
+import {
+  createStatefulRewriter,
+  defaultUrlKey,
+} from '../../../Integration/Simulator/StatefulRewriter.js';
+
+/**
+ * Build a synthetic 200 OK HAR response wrapping `bodyTag`.
+ *
+ * @param bodyTag - Body text used as the response's identifying marker.
+ * @returns Minimal valid HAR response.
+ */
+function makeResponse(bodyTag: string): IHarEntry['response'] {
+  return {
+    status: 200,
+    statusText: 'OK',
+    headers: [],
+    content: { mimeType: 'text/plain', text: bodyTag },
+  };
+}
+
+/**
+ * Build a synthetic HAR entry with the given identifying response body.
+ *
+ * @param method - HTTP method.
+ * @param url - Raw URL (search/fragment OK).
+ * @param bodyTag - Tag stored in `response.content.text` for assertions.
+ * @returns Minimal valid HAR entry.
+ */
+function makeEntry(method: string, url: string, bodyTag: string): IHarEntry {
+  return {
+    request: { method, url, headers: [], queryString: [] },
+    response: makeResponse(bodyTag),
+  };
+}
+
+/**
+ * Unwrap an {@link Option} or fail the test with a stable error.
+ *
+ * @param opt - Option value (`{ has, value? }` discriminated union).
+ * @param opt.has - True iff `value` is set.
+ * @param opt.value - Wrapped value (only inspected when `has` is true).
+ * @returns The wrapped value.
+ */
+function unwrapSomeOrFail<T>(opt: { has: boolean; value?: T }): T {
+  if (!opt.has || opt.value === undefined) throw new ScraperError('expected Some, got None');
+  return opt.value;
+}
+
+/**
+ * Canonicalizer that maps every URL to the same key (test double).
+ *
+ * @returns Constant string used as the bucket key for all requests.
+ */
+function fixedKeyCanonicalizer(): string {
+  return 'fixed-key';
+}
+
+describe('StatefulRewriter', () => {
+  describe('defaultUrlKey', () => {
+    it('strips query + fragment', () => {
+      const key = defaultUrlKey('https://bank.example/api/x?session=abc#part');
+      expect(key).toBe('https://bank.example/api/x');
+    });
+
+    it('falls back to raw url on parse failure', () => {
+      const key = defaultUrlKey('not://a parseable url');
+      expect(key).toBe('not://a parseable url');
+    });
+  });
+
+  describe('pick — sequence ordering', () => {
+    it('returns entries in chronological order for same URL', () => {
+      const a = makeEntry('GET', 'https://b.example/s', 'first');
+      const b = makeEntry('GET', 'https://b.example/s', 'second');
+      const rewriter = createStatefulRewriter({ entries: [a, b] });
+      const hit1 = rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const hit2 = rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const e1 = unwrapSomeOrFail(hit1);
+      const e2 = unwrapSomeOrFail(hit2);
+      expect(e1.response.content.text).toBe('first');
+      expect(e2.response.content.text).toBe('second');
+    });
+
+    it('returns None and bumps exhaustedCount after bucket runs out', () => {
+      const a = makeEntry('GET', 'https://b.example/s', 'only');
+      const rewriter = createStatefulRewriter({ entries: [a] });
+      rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const exhausted = rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const snap = rewriter.snapshot();
+      const isExhaustedNone = isSome(exhausted);
+      expect(isExhaustedNone).toBe(false);
+      expect(snap.exhaustedCount).toBe(1);
+      expect(snap.missCount).toBe(0);
+    });
+  });
+
+  describe('pick — miss handling', () => {
+    it('returns None and bumps missCount on unknown URL', () => {
+      const a = makeEntry('GET', 'https://b.example/s', 'tag');
+      const rewriter = createStatefulRewriter({ entries: [a] });
+      const result = rewriter.pick({ method: 'GET', url: 'https://b.example/UNKNOWN' });
+      const snap = rewriter.snapshot();
+      const hasMatch = isSome(result);
+      expect(hasMatch).toBe(false);
+      expect(snap.missCount).toBe(1);
+      expect(snap.exhaustedCount).toBe(0);
+    });
+
+    it('does NOT match cross-method (POST → GET)', () => {
+      const a = makeEntry('POST', 'https://b.example/s', 'post');
+      const rewriter = createStatefulRewriter({ entries: [a] });
+      const wrong = rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const snap = rewriter.snapshot();
+      const hasMatch = isSome(wrong);
+      expect(hasMatch).toBe(false);
+      expect(snap.missCount).toBe(1);
+    });
+  });
+
+  describe('canonicalization', () => {
+    it('matches across differing query strings by default', () => {
+      const a = makeEntry('GET', 'https://b.example/s?session=alice', 'one');
+      const rewriter = createStatefulRewriter({ entries: [a] });
+      const hit = rewriter.pick({ method: 'GET', url: 'https://b.example/s?session=bob' });
+      const snap = rewriter.snapshot();
+      const hasMatch = isSome(hit);
+      expect(hasMatch).toBe(true);
+      expect(snap.missCount).toBe(0);
+    });
+
+    it('uses a custom canonicalizer when provided', () => {
+      const a = makeEntry('GET', 'https://b.example/s?x=1', 'one');
+      const rewriter = createStatefulRewriter({
+        entries: [a],
+        urlCanonicalizer: fixedKeyCanonicalizer,
+      });
+      const hit = rewriter.pick({ method: 'GET', url: 'https://totally-different.example/y' });
+      const hasMatch = isSome(hit);
+      expect(hasMatch).toBe(true);
+    });
+  });
+
+  describe('snapshot', () => {
+    it('reports per-key hit counts', () => {
+      const a = makeEntry('GET', 'https://b.example/s', 'tag');
+      const b = makeEntry('POST', 'https://b.example/p', 'tag2');
+      const rewriter = createStatefulRewriter({ entries: [a, b] });
+      rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      rewriter.pick({ method: 'POST', url: 'https://b.example/p' });
+      const snap = rewriter.snapshot();
+      const getHits = snap.hits.get('GET https://b.example/s');
+      const postHits = snap.hits.get('POST https://b.example/p');
+      expect(getHits).toBe(1);
+      expect(postHits).toBe(1);
+    });
+
+    it('hits map is a defensive copy (mutating it does not change rewriter state)', () => {
+      const a = makeEntry('GET', 'https://b.example/s', 'tag');
+      const rewriter = createStatefulRewriter({ entries: [a] });
+      rewriter.pick({ method: 'GET', url: 'https://b.example/s' });
+      const snapBefore = rewriter.snapshot();
+      const mutable = snapBefore.hits as Map<string, number>;
+      mutable.set('GET https://b.example/s', 999);
+      const snapAfter = rewriter.snapshot();
+      const afterCount = snapAfter.hits.get('GET https://b.example/s');
+      expect(afterCount).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Status

**DRAFT** — operator-independent skeleton only. Real HAR captures + per-bank manifests + Mode B post-login tests are deferred per the rubber-duck scope cut below.

## Depends on

- PR-#TBD-2 (Mode A foundation) — bridges into the `MirrorSimulator` shipped there

## What

Mode B HAR-replay simulator SKELETON under `src/Tests/Integration/Simulator/`. Four pure modules that turn a captured HAR + per-bank phase map into manifests the existing `MirrorSimulator` (from PR-#TBD-2) consumes.

## Why a skeleton (rubber-duck-driven scope reduction, 6 → 4 modules)

Original Step 3 spec listed six modules: `HttpServer` + `HarLoader` + `PhaseStateMachine` + `StatefulRewriter` + `SimulatorFactory` + `ProxyConfig`. A pre-implementation rubber-duck critique surfaced three blocking concerns:

1. **HTTPS-proxy server** would require either a new dep (`selfsigned`/`node-forge`/`pem`) or hand-rolled X.509 — both add CI flakiness risk for unclear benefit. Playwright `context.route` interception is likely sufficient against captured HARs without a full reverse proxy.

2. **`PhaseStateMachine.ts`** would duplicate the state machine that PR-#TBD-2's `MirrorSimulator` already runs against `MirrorManifest`. Building a one-way bridge (HAR → MirrorManifest) lets the canonical engine stay canonical.

3. **`SimulatorFactory.ts`** is premature without ≥1 real HAR + a finalised phase-map sidecar format. Deferred until real captures expose the right factory shape.

Reduced to four pure modules + tests + documentation. See `src/Tests/Integration/Simulator/README.md` for the full scope-honesty doc + operator workflow.

## What's in

- `Simulator/HarTypes.ts` — HAR 1.2 type subset (no runtime; `queryString` required; `encoding?: 'base64'` only)
- `Simulator/HarLoader.ts` — strict JSON validator (`readJsonFile` → `assertHarFile` → `IHarFile`); all throws via `ScraperError`
- `Simulator/StatefulRewriter.ts` — sequence-aware `(method, canonical-URL, hit#)` picker with snapshot counters (missCount / exhaustedCount)
- `Simulator/HarToMirrorManifest.ts` — pure projector turning HAR entries into MirrorManifest row skeletons; operator fills `phase`/`advanceTo`/`predicates`/`bodyFile`
- `Simulator/README.md` — scope honesty + operator workflow + deferred-work doc
- `mirrors/banks/README.md` — per-bank HAR layout convention
- 29 new unit tests in `Tests/Unit/Integration/Simulator/`

## Operator workflow (when HAR captures land)

1. Record HAR via Playwright `recordHar` per `<bank> × <phase>` cell
2. PII-redact via the existing `PiiRedactor`
3. `loadHarEntries(harPath)` + `toManifestRows(entries)` → row skeleton
4. Augment each row with `phase`/`advanceTo`/`predicates` (knowledge the harvester captures at recording time)
5. Write body files to disk; fill each row's `response.bodyFile`
6. Commit final `manifest.json`; existing `MirrorSimulator` consumes it unchanged

## What's deferred (operator-blocked, follow-up PRs)

- **Real-bank HAR captures** — need `.env` + trusted IP + OTP devices (now reportedly all set; harvest unblocked once PR-A2.2 lands)
- **Per-bank `MirrorManifest` JSON** with full `phase`/`advanceTo`/`predicates`/`bodyFile` rows
- **Mode B integration tests** driving production scrapers through captured HARs
- **`HttpServer` / `SimulatorFactory` / `ProxyConfig` / `PhaseStateMachine`** — deferred per rubber-duck rationale above

## Diff stats

- 9 files changed
- +1345 / -0 lines
- Zero touches to existing production or test code

## Husky 22-gate ladder

Full ladder GREEN at commit `d4780694` (no `--no-verify`):
- tsc / eslint / biome / prettier exit 0
- §19.10 10-line cap enforced on all new files (via `PHASE_10_INTEGRATION_FILES` glob)
- All canaries fire / bank-coverage 11/11 OK
- test:pipeline + test:mock + test:e2e:mock green
- Mode A 31p / 5s in 100s for 11 banks
- Mode B mirror 6p / 5s in 141s for 11 banks
- 29 new simulator unit tests in 175/175 integration suite

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
