### PR TITLE
fix(metadata): restore sergienko4 in metadata files after filter-repo over-scrub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for everything
-* @[REDACTED-USER]
+* @sergienko4

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-ko_fi: [REDACTED-USER]
-github: [REDACTED-USER]
+ko_fi: sergienko4
+github: sergienko4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: monday
     open-pull-requests-limit: 10
     reviewers:
-      - [REDACTED-USER]
+      - sergienko4
     labels:
       - dependencies
     groups:

--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -45,7 +45,7 @@
 # into AutoMapperFacade/AutoMapperTypes.ts as part of the 11-sub-module
 # split. They are CROSS-MODULE INTERNALS — shared types + constants
 # used by BfsFieldSearch, AccountExtractor, ContainerPicker, TxnMapper,
-# etc. — not part of the user-facing @[REDACTED-USER]/israeli-bank-scrapers
+# etc. — not part of the user-facing @sergienko4/israeli-bank-scrapers
 # public surface. They are not re-exported from lib/index.{cjs,mjs}.
 
 # Reason: ApiRecord — internal alias `Record<string, unknown>` for API response shapes (used by AccountExtractor + BfsFieldSearch + TxnMapper). Not a stable public type.
@@ -66,7 +66,7 @@ UntypedValue
 # — the per-strategy classify/redact registry contract, brand types,
 # sentinel constants, and helpers consumed only by Facade.ts and the
 # per-category siblings. Not part of the user-facing
-# @[REDACTED-USER]/israeli-bank-scrapers public surface and not re-exported
+# @sergienko4/israeli-bank-scrapers public surface and not re-exported
 # from lib/index.{cjs,mjs}. (The user-facing `redact()` entry point
 # is documented in docs/ and so is NOT in this allowlist.)
 
@@ -321,13 +321,13 @@ NETWORK_FETCH_TIMEOUT_MS
 JsonRecord
 
 # --- Phase 3 / commit 13 (CR PR #286 finding F7 — OTP click timeouts) ---
-# Reason: OTP_FALLBACK_CLICK_TIMEOUT_MS — Mediator/Otp/OtpDetectorConfig.ts named constant (5000 ms) used exclusively by OtpDetector.tryFallbackClick and its unit-test suite. Extracted from an inline literal per CR PR #286 to keep the fallback + force-click timeouts together and prevent drift; not part of the @[REDACTED-USER]/israeli-bank-scrapers public surface.
+# Reason: OTP_FALLBACK_CLICK_TIMEOUT_MS — Mediator/Otp/OtpDetectorConfig.ts named constant (5000 ms) used exclusively by OtpDetector.tryFallbackClick and its unit-test suite. Extracted from an inline literal per CR PR #286 to keep the fallback + force-click timeouts together and prevent drift; not part of the @sergienko4/israeli-bank-scrapers public surface.
 OTP_FALLBACK_CLICK_TIMEOUT_MS
-# Reason: OTP_FORCE_CLICK_TIMEOUT_MS — Mediator/Otp/OtpDetectorConfig.ts named constant (3000 ms) used exclusively by OtpDetector.tryForceClick and its unit-test suite. Extracted from an inline literal per CR PR #286 to keep the fallback + force-click timeouts together and prevent drift; not part of the @[REDACTED-USER]/israeli-bank-scrapers public surface.
+# Reason: OTP_FORCE_CLICK_TIMEOUT_MS — Mediator/Otp/OtpDetectorConfig.ts named constant (3000 ms) used exclusively by OtpDetector.tryForceClick and its unit-test suite. Extracted from an inline literal per CR PR #286 to keep the fallback + force-click timeouts together and prevent drift; not part of the @sergienko4/israeli-bank-scrapers public surface.
 OTP_FORCE_CLICK_TIMEOUT_MS
 
 # --- Phase 2a / C15 (PipelineContextSlotKeys — extracted from PipelineContextFactory.ts) ---
-# Reason: PhaseStateSlotKey — internal string-literal union 'login' | 'dashboard' | 'scrape' | 'api' used by PipelineContextFactory.ts to type the four top-level phase-state result slots. Pure type-plumbing; not part of the @[REDACTED-USER]/israeli-bank-scrapers public surface.
+# Reason: PhaseStateSlotKey — internal string-literal union 'login' | 'dashboard' | 'scrape' | 'api' used by PipelineContextFactory.ts to type the four top-level phase-state result slots. Pure type-plumbing; not part of the @sergienko4/israeli-bank-scrapers public surface.
 PhaseStateSlotKey
 # Reason: DiscoverySlotKey — internal string-literal union of the six discovery result-slot names (preLoginDiscovery, loginFieldDiscovery, scrapeDiscovery, accountDiscovery, txnEndpoint, dashboardTxnHarvest) used by PipelineContextFactory.ts. Pure type-plumbing; not part of the public API.
 DiscoverySlotKey
@@ -339,7 +339,7 @@ BalanceSlotKey
 ResultSlotKey
 
 # --- Phase 2c-strict / Dashboard split (DashboardPhaseActions / TxnParser) ---
-# Reason: IDashboardTargets — internal target-resolver bundle used by DashboardPhaseActions.sequential.ts + .targets.ts + .action.ts siblings after the 1991-line monolith was split to satisfy the 150-line file cap. Pure cross-sibling type plumbing; not part of the @[REDACTED-USER]/israeli-bank-scrapers public surface.
+# Reason: IDashboardTargets — internal target-resolver bundle used by DashboardPhaseActions.sequential.ts + .targets.ts + .action.ts siblings after the 1991-line monolith was split to satisfy the 150-line file cap. Pure cross-sibling type plumbing; not part of the @sergienko4/israeli-bank-scrapers public surface.
 IDashboardTargets
 # Reason: JsonScopeValue — internal JSON-value alias used by the TxnParser.scope.ts / .accountId.ts / .harvest.ts siblings after TxnParser.ts was split to satisfy the per-file LoC budget. Same architectural role as TxnParser.ts (DASHBOARD-side harvest scope); pure cross-sibling type plumbing, not part of the public API.
 JsonScopeValue
@@ -349,5 +349,5 @@ JsonScopeValue
 IDiscoverFieldsArgs
 
 # --- Phase 2 / CR fix (EndpointUrlHelpers — WK constant for pending/clearance-requests URL) ---
-# Reason: PIPELINE_WELL_KNOWN_PENDING — internal WellKnown registry constant in ScrapeWK.ts that names the apiPrefix/pathFragment/actionName triple for the pending/clearance-requests endpoint on the shared card-family backbone (CAL/Isracard/Amex/MAX). Mirrors the shape of pre-existing PIPELINE_WELL_KNOWN_BILLING/_API/_QUERY_KEYS/_HEADERS constants which were grandfathered into the docs-coverage gate by pre-existing on main; this addition is the same kind (Pipeline-internal WK registry plumbing consumed only by EndpointUrlHelpers.resolvePendingUrl). Not part of the @[REDACTED-USER]/israeli-bank-scrapers public surface — Pipeline is internal to the scrapers, not exported via src/index.ts.
+# Reason: PIPELINE_WELL_KNOWN_PENDING — internal WellKnown registry constant in ScrapeWK.ts that names the apiPrefix/pathFragment/actionName triple for the pending/clearance-requests endpoint on the shared card-family backbone (CAL/Isracard/Amex/MAX). Mirrors the shape of pre-existing PIPELINE_WELL_KNOWN_BILLING/_API/_QUERY_KEYS/_HEADERS constants which were grandfathered into the docs-coverage gate by pre-existing on main; this addition is the same kind (Pipeline-internal WK registry plumbing consumed only by EndpointUrlHelpers.resolvePendingUrl). Not part of the @sergienko4/israeli-bank-scrapers public surface — Pipeline is internal to the scrapers, not exported via src/index.ts.
 PIPELINE_WELL_KNOWN_PENDING

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,7 +161,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --no-progress
-            --exclude '[REDACTED-USER].github.io/israeli-bank-scrapers/'
+            --exclude 'sergienko4.github.io/israeli-bank-scrapers/'
             --exclude 'npmjs.com/package/'
             'README.md' 'docs/**/*.md'
           fail: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,143 +1,143 @@
 # Changelog
 
-## [8.4.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.3.2...v8.4.0) (2026-05-28)
+## [8.4.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.3.2...v8.4.0) (2026-05-28)
 
 
 ### Features
 
-* **paybox:** onboard PayBox via api-direct unified primitives ([#261](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/261)) ([c911add](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/c911add65254943e701c50b5f5f1079abb3b2fbc))
+* **paybox:** onboard PayBox via api-direct unified primitives ([#261](https://github.com/sergienko4/israeli-bank-scrapers/issues/261)) ([c911add](https://github.com/sergienko4/israeli-bank-scrapers/commit/c911add65254943e701c50b5f5f1079abb3b2fbc))
 
 
 ### Bug Fixes
 
-* **balance-resolve:** v6 single-phase ownership + mkdocs docs site ([#264](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/264)) ([b0ea82b](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/b0ea82b318c00f52d620dd71d56e2604ae008cdd))
-* **ci:** drop deprecated --exclude-mail from Lychee args ([#270](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/270)) ([4e25ab3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/4e25ab333e5cb360fb71776fcbfc4e33256715b6))
+* **balance-resolve:** v6 single-phase ownership + mkdocs docs site ([#264](https://github.com/sergienko4/israeli-bank-scrapers/issues/264)) ([b0ea82b](https://github.com/sergienko4/israeli-bank-scrapers/commit/b0ea82b318c00f52d620dd71d56e2604ae008cdd))
+* **ci:** drop deprecated --exclude-mail from Lychee args ([#270](https://github.com/sergienko4/israeli-bank-scrapers/issues/270)) ([4e25ab3](https://github.com/sergienko4/israeli-bank-scrapers/commit/4e25ab333e5cb360fb71776fcbfc4e33256715b6))
 
-## [8.3.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.3.1...v8.3.2) (2026-05-21)
-
-
-### Bug Fixes
-
-* **ci:** grant contents:write to auto-merge job ([#255](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/255)) ([2a079c0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/2a079c061d6f3fedc5dbb1698a0552e692e36ce4))
-* resolve 21 security & quality findings + recurrence guards ([#248](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/248)) ([bf53b90](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/bf53b906e94e0e9ff43fbc1fe811b255d16ce3c5))
-
-## [8.3.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.3.0...v8.3.1) (2026-05-20)
+## [8.3.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.3.1...v8.3.2) (2026-05-21)
 
 
 ### Bug Fixes
 
-* **onezero:** Camoufox-backed identity transport + version flow ([#243](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/243)) ([c033572](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/c03357296c6b582e267893b8dca2411c87fed6a1))
+* **ci:** grant contents:write to auto-merge job ([#255](https://github.com/sergienko4/israeli-bank-scrapers/issues/255)) ([2a079c0](https://github.com/sergienko4/israeli-bank-scrapers/commit/2a079c061d6f3fedc5dbb1698a0552e692e36ce4))
+* resolve 21 security & quality findings + recurrence guards ([#248](https://github.com/sergienko4/israeli-bank-scrapers/issues/248)) ([bf53b90](https://github.com/sergienko4/israeli-bank-scrapers/commit/bf53b906e94e0e9ff43fbc1fe811b255d16ce3c5))
 
-## [8.3.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.2.1...v8.3.0) (2026-05-19)
+## [8.3.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.3.0...v8.3.1) (2026-05-20)
+
+
+### Bug Fixes
+
+* **onezero:** Camoufox-backed identity transport + version flow ([#243](https://github.com/sergienko4/israeli-bank-scrapers/issues/243)) ([c033572](https://github.com/sergienko4/israeli-bank-scrapers/commit/c03357296c6b582e267893b8dca2411c87fed6a1))
+
+## [8.3.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.2.1...v8.3.0) (2026-05-19)
 
 
 ### Features
 
-* pipeline architecture — Strategy, Builder, Mediator, Result Patterns ([#175](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/175)) ([4d1addd](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/4d1addd23a5f7dec8dd7672bb7e711c7b7f4e553))
-* **pipeline:** architecture v2 — real-bank E2E green + PII redaction ([#206](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/206)) ([60b4913](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/60b49133adeaf085f4a0aef59509e04c2f5ae427))
-* **pipeline:** cross-bank factory + OTP-FILL seal + HOME fix ([#218](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/218)) ([9a62261](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/9a622619909c82077259f6c1061ba87fc25f89f5))
-* **pipeline:** introduce AUTH-DISCOVERY phase + 100% phase isolation ([#216](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/216)) ([915b130](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/915b1306a3b06080a2668c645b699e327b41fde6))
-* **pipeline:** M2 — phase isolation + scope-bound LOGIN.POST + cross-bank factory ([#217](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/217)) ([e0d32f4](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/e0d32f4c60896ff25c93fbe12effe3e740c6cb93))
-* **pipeline:** M4 OTP-TRIGGER seal + dom-ready-everywhere architecture (8 PRs) ([#221](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/221)) ([8791375](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/8791375175d6e90287c29211408b72b6ff100ecb))
-* **pipeline:** seal per-phase ownership — ACCOUNT-RESOLVE / DASHBOARD / TXN ([#211](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/211)) ([5d62681](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/5d62681e9172e670181c62b413a68218b59e7822))
-* qodo failover review (fires when CodeRabbit rate-limits) ([#231](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/231)) ([109953e](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/109953e71ea27db7c907fecd5af35f3719bee431))
-* **test:** Phase H — complete cross-bank test architecture ([#232](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/232)) ([6062de7](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/6062de7a1c2a3ee714d4d42dabdf46fadd1b31fe))
-* **test:** Telegram OTP delivery + scorecard fix + pre-commit hook parallel/cache ([#215](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/215)) ([bb0f447](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/bb0f4475b925b5ba34237018464e1756513ef038))
-* unified Pipeline architecture (Step 1-2 — types, executor, builder) ([#171](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/171)) ([01a05d9](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/01a05d9e3190860e8e6e9e7b6e42542638dc9229))
+* pipeline architecture — Strategy, Builder, Mediator, Result Patterns ([#175](https://github.com/sergienko4/israeli-bank-scrapers/issues/175)) ([4d1addd](https://github.com/sergienko4/israeli-bank-scrapers/commit/4d1addd23a5f7dec8dd7672bb7e711c7b7f4e553))
+* **pipeline:** architecture v2 — real-bank E2E green + PII redaction ([#206](https://github.com/sergienko4/israeli-bank-scrapers/issues/206)) ([60b4913](https://github.com/sergienko4/israeli-bank-scrapers/commit/60b49133adeaf085f4a0aef59509e04c2f5ae427))
+* **pipeline:** cross-bank factory + OTP-FILL seal + HOME fix ([#218](https://github.com/sergienko4/israeli-bank-scrapers/issues/218)) ([9a62261](https://github.com/sergienko4/israeli-bank-scrapers/commit/9a622619909c82077259f6c1061ba87fc25f89f5))
+* **pipeline:** introduce AUTH-DISCOVERY phase + 100% phase isolation ([#216](https://github.com/sergienko4/israeli-bank-scrapers/issues/216)) ([915b130](https://github.com/sergienko4/israeli-bank-scrapers/commit/915b1306a3b06080a2668c645b699e327b41fde6))
+* **pipeline:** M2 — phase isolation + scope-bound LOGIN.POST + cross-bank factory ([#217](https://github.com/sergienko4/israeli-bank-scrapers/issues/217)) ([e0d32f4](https://github.com/sergienko4/israeli-bank-scrapers/commit/e0d32f4c60896ff25c93fbe12effe3e740c6cb93))
+* **pipeline:** M4 OTP-TRIGGER seal + dom-ready-everywhere architecture (8 PRs) ([#221](https://github.com/sergienko4/israeli-bank-scrapers/issues/221)) ([8791375](https://github.com/sergienko4/israeli-bank-scrapers/commit/8791375175d6e90287c29211408b72b6ff100ecb))
+* **pipeline:** seal per-phase ownership — ACCOUNT-RESOLVE / DASHBOARD / TXN ([#211](https://github.com/sergienko4/israeli-bank-scrapers/issues/211)) ([5d62681](https://github.com/sergienko4/israeli-bank-scrapers/commit/5d62681e9172e670181c62b413a68218b59e7822))
+* qodo failover review (fires when CodeRabbit rate-limits) ([#231](https://github.com/sergienko4/israeli-bank-scrapers/issues/231)) ([109953e](https://github.com/sergienko4/israeli-bank-scrapers/commit/109953e71ea27db7c907fecd5af35f3719bee431))
+* **test:** Phase H — complete cross-bank test architecture ([#232](https://github.com/sergienko4/israeli-bank-scrapers/issues/232)) ([6062de7](https://github.com/sergienko4/israeli-bank-scrapers/commit/6062de7a1c2a3ee714d4d42dabdf46fadd1b31fe))
+* **test:** Telegram OTP delivery + scorecard fix + pre-commit hook parallel/cache ([#215](https://github.com/sergienko4/israeli-bank-scrapers/issues/215)) ([bb0f447](https://github.com/sergienko4/israeli-bank-scrapers/commit/bb0f4475b925b5ba34237018464e1756513ef038))
+* unified Pipeline architecture (Step 1-2 — types, executor, builder) ([#171](https://github.com/sergienko4/israeli-bank-scrapers/issues/171)) ([01a05d9](https://github.com/sergienko4/israeli-bank-scrapers/commit/01a05d9e3190860e8e6e9e7b6e42542638dc9229))
 
 
 ### Bug Fixes
 
-* M4.F4 audit label + Docker CI-mirror scaffold ([#225](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/225)) ([052118a](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/052118a8c0e659eb130b19891967a2243b12699f))
-* **scrape+ci:** cross-bank billing-cycle + dedup + CI hardening ([#227](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/227)) ([cbd588d](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/cbd588d313492dbaf737092b21907817cfd4a500))
-* **scrape+ci:** release-blocker data-integrity ([cbd588d](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/cbd588d313492dbaf737092b21907817cfd4a500))
-* **security:** redact bank errorMessage in logs + ESLint guard (CodeQL [#28](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/28)) ([#233](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/233)) ([3bdd6ac](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/3bdd6ac74856b6530f3d354cf7011aa98ef3cb0f))
-* **telegram:** non-destructive getUpdates offset=0 ([#226](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/226)) ([915773c](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/915773c4e76d2fb20b958774fa3586ceaacac6af))
+* M4.F4 audit label + Docker CI-mirror scaffold ([#225](https://github.com/sergienko4/israeli-bank-scrapers/issues/225)) ([052118a](https://github.com/sergienko4/israeli-bank-scrapers/commit/052118a8c0e659eb130b19891967a2243b12699f))
+* **scrape+ci:** cross-bank billing-cycle + dedup + CI hardening ([#227](https://github.com/sergienko4/israeli-bank-scrapers/issues/227)) ([cbd588d](https://github.com/sergienko4/israeli-bank-scrapers/commit/cbd588d313492dbaf737092b21907817cfd4a500))
+* **scrape+ci:** release-blocker data-integrity ([cbd588d](https://github.com/sergienko4/israeli-bank-scrapers/commit/cbd588d313492dbaf737092b21907817cfd4a500))
+* **security:** redact bank errorMessage in logs + ESLint guard (CodeQL [#28](https://github.com/sergienko4/israeli-bank-scrapers/issues/28)) ([#233](https://github.com/sergienko4/israeli-bank-scrapers/issues/233)) ([3bdd6ac](https://github.com/sergienko4/israeli-bank-scrapers/commit/3bdd6ac74856b6530f3d354cf7011aa98ef3cb0f))
+* **telegram:** non-destructive getUpdates offset=0 ([#226](https://github.com/sergienko4/israeli-bank-scrapers/issues/226)) ([915773c](https://github.com/sergienko4/israeli-bank-scrapers/commit/915773c4e76d2fb20b958774fa3586ceaacac6af))
 
 
 ### Performance Improvements
 
-* **pipeline:** TIMING mission - cut wait ceilings + fail-loud refinements ([#220](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/220)) ([991ad98](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/991ad9873abd9536fb638b521ff6249ce210628f))
+* **pipeline:** TIMING mission - cut wait ceilings + fail-loud refinements ([#220](https://github.com/sergienko4/israeli-bank-scrapers/issues/220)) ([991ad98](https://github.com/sergienko4/israeli-bank-scrapers/commit/991ad9873abd9536fb638b521ff6249ce210628f))
 
-## [8.2.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.2.0...v8.2.1) (2026-03-17)
+## [8.2.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.2.0...v8.2.1) (2026-03-17)
 
 
 ### Bug Fixes
 
-* replace CSS/ID selectors with visible Hebrew text ([#168](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/168)) ([dc87d2b](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/dc87d2bbac1f226b143f618a3d155dfe0187b239))
+* replace CSS/ID selectors with visible Hebrew text ([#168](https://github.com/sergienko4/israeli-bank-scrapers/issues/168)) ([dc87d2b](https://github.com/sergienko4/israeli-bank-scrapers/commit/dc87d2bbac1f226b143f618a3d155dfe0187b239))
 
-## [8.2.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.1.0...v8.2.0) (2026-03-16)
+## [8.2.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.1.0...v8.2.0) (2026-03-16)
 
 
 ### Features
 
-* add SonarCloud static analysis workflow ([#160](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/160)) ([3bf3c43](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/3bf3c43e69af745e8d86d54c5ebb6eeec31d44db))
+* add SonarCloud static analysis workflow ([#160](https://github.com/sergienko4/israeli-bank-scrapers/issues/160)) ([3bf3c43](https://github.com/sergienko4/israeli-bank-scrapers/commit/3bf3c43e69af745e8d86d54c5ebb6eeec31d44db))
 
 
 ### Bug Fixes
 
-* replace Max CSS ID selectors with visible Hebrew text ([#163](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/163)) ([ad2e14a](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/ad2e14a786fc71d874cc954ee02de404bca36e71))
+* replace Max CSS ID selectors with visible Hebrew text ([#163](https://github.com/sergienko4/israeli-bank-scrapers/issues/163)) ([ad2e14a](https://github.com/sergienko4/israeli-bank-scrapers/commit/ad2e14a786fc71d874cc954ee02de404bca36e71))
 
-## [8.1.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.6...v8.1.0) (2026-03-14)
+## [8.1.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.6...v8.1.0) (2026-03-14)
 
 
 ### Features
 
-* add integration test framework with 18 tests for 6 scrapers ([#158](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/158)) ([a6a4dfe](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a6a4dfe451cf4e8b894568c8d4affbaedc728b26))
+* add integration test framework with 18 tests for 6 scrapers ([#158](https://github.com/sergienko4/israeli-bank-scrapers/issues/158)) ([a6a4dfe](https://github.com/sergienko4/israeli-bank-scrapers/commit/a6a4dfe451cf4e8b894568c8d4affbaedc728b26))
 
-## [8.0.6](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.5...v8.0.6) (2026-03-14)
-
-
-### Bug Fixes
-
-* harden CI/CD — timeouts, reliability, consolidate 10 jobs into 2 ([#154](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/154)) ([cb6d573](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/cb6d5739cb8315c2c0194a12cb5880ec0e15f3d8))
-
-## [8.0.5](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.4...v8.0.5) (2026-03-13)
+## [8.0.6](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.5...v8.0.6) (2026-03-14)
 
 
 ### Bug Fixes
 
-* eliminate silent errors and improve log readability ([#148](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/148)) ([b1581cb](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/b1581cbb14bff93ce0ef2a7b4068e1950c5cbeb4))
-* handle Max tree-version homepage login flow ([#150](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/150)) ([aaac1cb](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/aaac1cb27ca9ad5c8d180b96f676dd3c0c879534))
-* move Node 24 env var to top-level in release-please workflow ([#147](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/147)) ([a091831](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a09183170f2ef1ce7805967b251a35b55a013792))
-* opt into Node.js 24 for all CI workflows ([#145](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/145)) ([b96a0ad](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/b96a0ad632be485241b567c5dbd91e0db2f73bf1))
-* switch to allow-licenses allowlist + fix flatted vulnerability ([#151](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/151)) ([fbceb9d](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/fbceb9dba92e180738d93a887bc1795b5490ef61))
+* harden CI/CD — timeouts, reliability, consolidate 10 jobs into 2 ([#154](https://github.com/sergienko4/israeli-bank-scrapers/issues/154)) ([cb6d573](https://github.com/sergienko4/israeli-bank-scrapers/commit/cb6d5739cb8315c2c0194a12cb5880ec0e15f3d8))
 
-## [8.0.4](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.3...v8.0.4) (2026-03-12)
+## [8.0.5](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.4...v8.0.5) (2026-03-13)
 
 
 ### Bug Fixes
 
-* add bank name to all scraper log lines for CI readability ([#143](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/143)) ([2f4fb87](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/2f4fb87a8374fd6f1d207c5f64efb31c341a0d46))
-* opt into Node.js 24 for release-please action ([#140](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/140)) ([f03e3a5](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/f03e3a5ae4ac7ec76cba3fd1153b6459632185b0))
-* switch VisaCal API calls from native fetch to browser-context fetch ([#144](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/144)) ([a18f40a](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a18f40ac79aa3148c76fdf60aa248ff26ba29c82))
+* eliminate silent errors and improve log readability ([#148](https://github.com/sergienko4/israeli-bank-scrapers/issues/148)) ([b1581cb](https://github.com/sergienko4/israeli-bank-scrapers/commit/b1581cbb14bff93ce0ef2a7b4068e1950c5cbeb4))
+* handle Max tree-version homepage login flow ([#150](https://github.com/sergienko4/israeli-bank-scrapers/issues/150)) ([aaac1cb](https://github.com/sergienko4/israeli-bank-scrapers/commit/aaac1cb27ca9ad5c8d180b96f676dd3c0c879534))
+* move Node 24 env var to top-level in release-please workflow ([#147](https://github.com/sergienko4/israeli-bank-scrapers/issues/147)) ([a091831](https://github.com/sergienko4/israeli-bank-scrapers/commit/a09183170f2ef1ce7805967b251a35b55a013792))
+* opt into Node.js 24 for all CI workflows ([#145](https://github.com/sergienko4/israeli-bank-scrapers/issues/145)) ([b96a0ad](https://github.com/sergienko4/israeli-bank-scrapers/commit/b96a0ad632be485241b567c5dbd91e0db2f73bf1))
+* switch to allow-licenses allowlist + fix flatted vulnerability ([#151](https://github.com/sergienko4/israeli-bank-scrapers/issues/151)) ([fbceb9d](https://github.com/sergienko4/israeli-bank-scrapers/commit/fbceb9dba92e180738d93a887bc1795b5490ef61))
 
-## [8.0.3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.2...v8.0.3) (2026-03-12)
-
-
-### Bug Fixes
-
-* add OTP confirm flow for Beinleumi group banks ([#136](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/136)) ([a01866e](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a01866e913a47ed96e2a461f1a2b2c20df4a7b41))
-
-## [8.0.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.1...v8.0.2) (2026-03-11)
+## [8.0.4](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.3...v8.0.4) (2026-03-12)
 
 
 ### Bug Fixes
 
-* opt into Node.js 24 for GitHub Pages actions ([#132](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/132)) ([d222c8a](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/d222c8aac35dda4240e91538557e5bb7ca169f74))
-* restrict GITHUB_TOKEN permissions per OSSF Scorecard ([#134](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/134)) ([35b9f0b](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/35b9f0bbbc70b8c9c632dfa7aa71de55199f3620))
+* add bank name to all scraper log lines for CI readability ([#143](https://github.com/sergienko4/israeli-bank-scrapers/issues/143)) ([2f4fb87](https://github.com/sergienko4/israeli-bank-scrapers/commit/2f4fb87a8374fd6f1d207c5f64efb31c341a0d46))
+* opt into Node.js 24 for release-please action ([#140](https://github.com/sergienko4/israeli-bank-scrapers/issues/140)) ([f03e3a5](https://github.com/sergienko4/israeli-bank-scrapers/commit/f03e3a5ae4ac7ec76cba3fd1153b6459632185b0))
+* switch VisaCal API calls from native fetch to browser-context fetch ([#144](https://github.com/sergienko4/israeli-bank-scrapers/issues/144)) ([a18f40a](https://github.com/sergienko4/israeli-bank-scrapers/commit/a18f40ac79aa3148c76fdf60aa248ff26ba29c82))
 
-## [8.0.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v8.0.0...v8.0.1) (2026-03-11)
+## [8.0.3](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.2...v8.0.3) (2026-03-12)
 
 
 ### Bug Fixes
 
-* add CodeQL security analysis workflow ([#128](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/128)) ([66e59e8](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/66e59e84b702a57f7687204466ee00e8a5c3230e))
-* move CodeQL to standalone workflow + skip hook for non-code changes ([#130](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/130)) ([84c6415](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/84c6415102c09a8fabc0a3bfc02328b3d3ce356e))
-* rewrite README with balanced layout, doctoc TOC, and all-contributors ([#127](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/127)) ([56be12c](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/56be12ccc6dcb1546b7a35bb5281653a3814653e))
-* skip Camoufox fetch when cached, avoid GitHub API rate limits ([#131](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/131)) ([ed1745d](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/ed1745db9e29791d263a6f3cbe87cc125280d440))
+* add OTP confirm flow for Beinleumi group banks ([#136](https://github.com/sergienko4/israeli-bank-scrapers/issues/136)) ([a01866e](https://github.com/sergienko4/israeli-bank-scrapers/commit/a01866e913a47ed96e2a461f1a2b2c20df4a7b41))
 
-## [8.0.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.10.0...v8.0.0) (2026-03-10)
+## [8.0.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.1...v8.0.2) (2026-03-11)
+
+
+### Bug Fixes
+
+* opt into Node.js 24 for GitHub Pages actions ([#132](https://github.com/sergienko4/israeli-bank-scrapers/issues/132)) ([d222c8a](https://github.com/sergienko4/israeli-bank-scrapers/commit/d222c8aac35dda4240e91538557e5bb7ca169f74))
+* restrict GITHUB_TOKEN permissions per OSSF Scorecard ([#134](https://github.com/sergienko4/israeli-bank-scrapers/issues/134)) ([35b9f0b](https://github.com/sergienko4/israeli-bank-scrapers/commit/35b9f0bbbc70b8c9c632dfa7aa71de55199f3620))
+
+## [8.0.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v8.0.0...v8.0.1) (2026-03-11)
+
+
+### Bug Fixes
+
+* add CodeQL security analysis workflow ([#128](https://github.com/sergienko4/israeli-bank-scrapers/issues/128)) ([66e59e8](https://github.com/sergienko4/israeli-bank-scrapers/commit/66e59e84b702a57f7687204466ee00e8a5c3230e))
+* move CodeQL to standalone workflow + skip hook for non-code changes ([#130](https://github.com/sergienko4/israeli-bank-scrapers/issues/130)) ([84c6415](https://github.com/sergienko4/israeli-bank-scrapers/commit/84c6415102c09a8fabc0a3bfc02328b3d3ce356e))
+* rewrite README with balanced layout, doctoc TOC, and all-contributors ([#127](https://github.com/sergienko4/israeli-bank-scrapers/issues/127)) ([56be12c](https://github.com/sergienko4/israeli-bank-scrapers/commit/56be12ccc6dcb1546b7a35bb5281653a3814653e))
+* skip Camoufox fetch when cached, avoid GitHub API rate limits ([#131](https://github.com/sergienko4/israeli-bank-scrapers/issues/131)) ([ed1745d](https://github.com/sergienko4/israeli-bank-scrapers/commit/ed1745db9e29791d263a6f3cbe87cc125280d440))
+
+## [8.0.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.10.0...v8.0.0) (2026-03-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -146,146 +146,146 @@
 
 ### Features
 
-* strict ESLint config with JSDoc, I-prefix, architectural bans ([#119](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/119)) ([becfecf](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/becfecfead80edf1cc9fb8b5f27737843e8691b3))
-* textContent selector + form-anchor + Max single-flow refactor ([#124](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/124)) ([f8bbfff](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/f8bbfff27de362e588f82c95dc39dfa7d8419902))
+* strict ESLint config with JSDoc, I-prefix, architectural bans ([#119](https://github.com/sergienko4/israeli-bank-scrapers/issues/119)) ([becfecf](https://github.com/sergienko4/israeli-bank-scrapers/commit/becfecfead80edf1cc9fb8b5f27737843e8691b3))
+* textContent selector + form-anchor + Max single-flow refactor ([#124](https://github.com/sergienko4/israeli-bank-scrapers/issues/124)) ([f8bbfff](https://github.com/sergienko4/israeli-bank-scrapers/commit/f8bbfff27de362e588f82c95dc39dfa7d8419902))
 
 
 ### Bug Fixes
 
-* add backward-compatible type aliases for v7.x consumers ([#121](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/121)) ([842a8a4](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/842a8a438bb544563d120f71a31535769cb354b9))
-* add diagnostic logging to Max postAction + increase timeout to 60s ([#125](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/125)) ([442efd6](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/442efd6778b6ebfcd174651612db2188e2587359))
+* add backward-compatible type aliases for v7.x consumers ([#121](https://github.com/sergienko4/israeli-bank-scrapers/issues/121)) ([842a8a4](https://github.com/sergienko4/israeli-bank-scrapers/commit/842a8a438bb544563d120f71a31535769cb354b9))
+* add diagnostic logging to Max postAction + increase timeout to 60s ([#125](https://github.com/sergienko4/israeli-bank-scrapers/issues/125)) ([442efd6](https://github.com/sergienko4/israeli-bank-scrapers/commit/442efd6778b6ebfcd174651612db2188e2587359))
 
-## [7.10.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.9.0...v7.10.0) (2026-03-08)
+## [7.10.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.9.0...v7.10.0) (2026-03-08)
 
 
 ### Features
 
-* add login chain logging with PII-safe result summary ([#110](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/110)) ([2ef55ba](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/2ef55ba34c106c67a017338a7d10beb230c4fab4))
-* enhance SelectorResolver with label-text-first field resolution ([#113](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/113)) ([7ad2ccd](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/7ad2ccd2010ec1e5b133a557dc3f34dc73588877))
-* remove all CSS selectors from login fields — visible text first ([#115](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/115)) ([476cf8e](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/476cf8e87f8a2cee58dfffab0832b932a7fe56c3))
+* add login chain logging with PII-safe result summary ([#110](https://github.com/sergienko4/israeli-bank-scrapers/issues/110)) ([2ef55ba](https://github.com/sergienko4/israeli-bank-scrapers/commit/2ef55ba34c106c67a017338a7d10beb230c4fab4))
+* enhance SelectorResolver with label-text-first field resolution ([#113](https://github.com/sergienko4/israeli-bank-scrapers/issues/113)) ([7ad2ccd](https://github.com/sergienko4/israeli-bank-scrapers/commit/7ad2ccd2010ec1e5b133a557dc3f34dc73588877))
+* remove all CSS selectors from login fields — visible text first ([#115](https://github.com/sergienko4/israeli-bank-scrapers/issues/115)) ([476cf8e](https://github.com/sergienko4/israeli-bank-scrapers/commit/476cf8e87f8a2cee58dfffab0832b932a7fe56c3))
 
 
 ### Bug Fixes
 
-* pre-commit hook runs full lint (same as CI) ([#112](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/112)) ([4397af7](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/4397af7e5feb8f3d74b8cc99a64a61877fff8d9a))
+* pre-commit hook runs full lint (same as CI) ([#112](https://github.com/sergienko4/israeli-bank-scrapers/issues/112)) ([4397af7](https://github.com/sergienko4/israeli-bank-scrapers/commit/4397af7e5feb8f3d74b8cc99a64a61877fff8d9a))
 
-## [7.9.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.8.1...v7.9.0) (2026-03-08)
+## [7.9.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.8.1...v7.9.0) (2026-03-08)
 
 
 ### Features
 
-* replace playwright-extra+stealth with @hieutran094/camoufox-js ([#107](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/107)) ([f5a340c](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/f5a340cce03eebc79a9acd70698b03e82dbbf51a))
+* replace playwright-extra+stealth with @hieutran094/camoufox-js ([#107](https://github.com/sergienko4/israeli-bank-scrapers/issues/107)) ([f5a340c](https://github.com/sergienko4/israeli-bank-scrapers/commit/f5a340cce03eebc79a9acd70698b03e82dbbf51a))
 
-## [7.8.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.8.0...v7.8.1) (2026-03-04)
+## [7.8.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.8.0...v7.8.1) (2026-03-04)
 
 
 ### Bug Fixes
 
-* handle Max second-login ID verification step (Flow B) ([#102](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/102)) ([0995ff3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/0995ff315dcd13fb692885f29c4c13cf8e82684d))
+* handle Max second-login ID verification step (Flow B) ([#102](https://github.com/sergienko4/israeli-bank-scrapers/issues/102)) ([0995ff3](https://github.com/sergienko4/israeli-bank-scrapers/commit/0995ff315dcd13fb692885f29c4c13cf8e82684d))
 
-## [7.8.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.7.0...v7.8.0) (2026-03-03)
-
-
-### Features
-
-* ESLint strict + SelectorResolver dashboard + VisaCal & Beinleumi fixes ([#96](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/96)) ([e367712](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/e3677124f6fbd678f709671fdf9feac64bbe1fda))
-
-## [7.7.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.6.0...v7.7.0) (2026-03-03)
+## [7.8.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.7.0...v7.8.0) (2026-03-03)
 
 
 ### Features
 
-* ESLint 10 + stealth plugin + VisaCal login fix + pino logger ([#92](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/92)) ([5c7afc6](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/5c7afc633c4d9ee7cc4dd647f115c258bbcb4d74))
+* ESLint strict + SelectorResolver dashboard + VisaCal & Beinleumi fixes ([#96](https://github.com/sergienko4/israeli-bank-scrapers/issues/96)) ([e367712](https://github.com/sergienko4/israeli-bank-scrapers/commit/e3677124f6fbd678f709671fdf9feac64bbe1fda))
 
-## [7.6.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.5.1...v7.6.0) (2026-03-02)
+## [7.7.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.6.0...v7.7.0) (2026-03-03)
 
 
 ### Features
 
-* **ci:** expand pre-commit to 8-gate validation matching CI pipeline ([#82](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/82)) ([c715912](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/c7159120f31fe731717013e26d637d064e7df13a))
+* ESLint 10 + stealth plugin + VisaCal login fix + pino logger ([#92](https://github.com/sergienko4/israeli-bank-scrapers/issues/92)) ([5c7afc6](https://github.com/sergienko4/israeli-bank-scrapers/commit/5c7afc633c4d9ee7cc4dd647f115c258bbcb4d74))
+
+## [7.6.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.5.1...v7.6.0) (2026-03-02)
+
+
+### Features
+
+* **ci:** expand pre-commit to 8-gate validation matching CI pipeline ([#82](https://github.com/sergienko4/israeli-bank-scrapers/issues/82)) ([c715912](https://github.com/sergienko4/israeli-bank-scrapers/commit/c7159120f31fe731717013e26d637d064e7df13a))
 
 
 ### Bug Fixes
 
-* **esm:** change OneZero moment import to bare specifier ([#81](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/81)) ([a44b219](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a44b219c001862fb50467691ba62f81c67894cf7))
+* **esm:** change OneZero moment import to bare specifier ([#81](https://github.com/sergienko4/israeli-bank-scrapers/issues/81)) ([a44b219](https://github.com/sergienko4/israeli-bank-scrapers/commit/a44b219c001862fb50467691ba62f81c67894cf7))
 
-## [7.5.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.5.0...v7.5.1) (2026-03-02)
+## [7.5.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.5.0...v7.5.1) (2026-03-02)
 
 
 ### Bug Fixes
 
-* **ci:** replace Babel with tsup in release-please publish workflow ([#79](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/79)) ([41b82d8](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/41b82d8dee93d574fb3adc74ea3441e984016943))
+* **ci:** replace Babel with tsup in release-please publish workflow ([#79](https://github.com/sergienko4/israeli-bank-scrapers/issues/79)) ([41b82d8](https://github.com/sergienko4/israeli-bank-scrapers/commit/41b82d8dee93d574fb3adc74ea3441e984016943))
 
-## [7.5.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.4.0...v7.5.0) (2026-03-02)
+## [7.5.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.4.0...v7.5.0) (2026-03-02)
 
 
 ### Features
 
-* **toolchain:** zero-compromise ESLint + strict types + tsup ESM build ([#76](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/76)) ([aaa6751](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/aaa6751dae2dc8b4d1fc56895d01a84ee8b05783))
+* **toolchain:** zero-compromise ESLint + strict types + tsup ESM build ([#76](https://github.com/sergienko4/israeli-bank-scrapers/issues/76)) ([aaa6751](https://github.com/sergienko4/israeli-bank-scrapers/commit/aaa6751dae2dc8b4d1fc56895d01a84ee8b05783))
 
-## [7.4.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.3.1...v7.4.0) (2026-03-01)
-
-
-### Features
-
-* **eslint+naming:** PascalCase file/folder convention, strict naming rules, generic login fix + Max domain fix ([#74](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/74)) ([aecce66](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/aecce667f5257212f0d37943b025f13a969bb5e3))
-
-## [7.3.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.3.0...v7.3.1) (2026-02-28)
-
-
-### Bug Fixes
-
-* **discount:** return success with 0 txns when API has no records in range ([#72](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/72)) ([20579fd](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/20579fd9c564d7a003fd42adb9a9b92df45d8b1d))
-
-## [7.3.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.2.0...v7.3.0) (2026-02-28)
+## [7.4.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.3.1...v7.4.0) (2026-03-01)
 
 
 ### Features
 
-* **e2e:** add Beinleumi OTP-screen CI test ([#67](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/67)) ([ba67f00](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/ba67f0075e2db9a7128f72a39096bedcdeb6604e))
+* **eslint+naming:** PascalCase file/folder convention, strict naming rules, generic login fix + Max domain fix ([#74](https://github.com/sergienko4/israeli-bank-scrapers/issues/74)) ([aecce66](https://github.com/sergienko4/israeli-bank-scrapers/commit/aecce667f5257212f0d37943b025f13a969bb5e3))
 
-## [7.2.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.1.0...v7.2.0) (2026-02-28)
+## [7.3.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.3.0...v7.3.1) (2026-02-28)
+
+
+### Bug Fixes
+
+* **discount:** return success with 0 txns when API has no records in range ([#72](https://github.com/sergienko4/israeli-bank-scrapers/issues/72)) ([20579fd](https://github.com/sergienko4/israeli-bank-scrapers/commit/20579fd9c564d7a003fd42adb9a9b92df45d8b1d))
+
+## [7.3.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.2.0...v7.3.0) (2026-02-28)
 
 
 ### Features
 
-* add TypeDoc auto-docs published to GitHub Pages ([#68](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/68)) ([173ddfc](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/173ddfcf6d24be8c8d65f1d6300d2bbf6c15cb43))
+* **e2e:** add Beinleumi OTP-screen CI test ([#67](https://github.com/sergienko4/israeli-bank-scrapers/issues/67)) ([ba67f00](https://github.com/sergienko4/israeli-bank-scrapers/commit/ba67f0075e2db9a7128f72a39096bedcdeb6604e))
 
-## [7.1.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.0.3...v7.1.0) (2026-02-28)
+## [7.2.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.1.0...v7.2.0) (2026-02-28)
 
 
 ### Features
 
-* resilient login field detection — 4-round selector fallback + bank registry ([#63](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/63)) ([d67a59f](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/d67a59f0b44af42c10f610778049ead24e9c6b07))
+* add TypeDoc auto-docs published to GitHub Pages ([#68](https://github.com/sergienko4/israeli-bank-scrapers/issues/68)) ([173ddfc](https://github.com/sergienko4/israeli-bank-scrapers/commit/173ddfcf6d24be8c8d65f1d6300d2bbf6c15cb43))
+
+## [7.1.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.0.3...v7.1.0) (2026-02-28)
+
+
+### Features
+
+* resilient login field detection — 4-round selector fallback + bank registry ([#63](https://github.com/sergienko4/israeli-bank-scrapers/issues/63)) ([d67a59f](https://github.com/sergienko4/israeli-bank-scrapers/commit/d67a59f0b44af42c10f610778049ead24e9c6b07))
 
 
 ### Bug Fixes
 
-* **e2e:** replace broken Beinleumi MATAF test with Massad ([#65](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/65)) ([947f8f3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/947f8f3ba7af17814853196d84a50d5740955dc8))
-* **visa-cal:** increase getCards session storage timeout 10s → 30s ([#66](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/66)) ([a8fc4e5](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a8fc4e572c363dcf9ee99e2f70c894aca9d8efe1))
+* **e2e:** replace broken Beinleumi MATAF test with Massad ([#65](https://github.com/sergienko4/israeli-bank-scrapers/issues/65)) ([947f8f3](https://github.com/sergienko4/israeli-bank-scrapers/commit/947f8f3ba7af17814853196d84a50d5740955dc8))
+* **visa-cal:** increase getCards session storage timeout 10s → 30s ([#66](https://github.com/sergienko4/israeli-bank-scrapers/issues/66)) ([a8fc4e5](https://github.com/sergienko4/israeli-bank-scrapers/commit/a8fc4e572c363dcf9ee99e2f70c894aca9d8efe1))
 
-## [7.0.3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.0.2...v7.0.3) (2026-02-27)
-
-
-### Bug Fixes
-
-* surface network errors in fetchPostWithinPage and fix Amex login diagnostics ([#61](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/61)) ([4da69dd](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/4da69dd4a5738a0cb4d76813c2dce709cabbb4a3))
-
-## [7.0.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.0.1...v7.0.2) (2026-02-26)
+## [7.0.3](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.0.2...v7.0.3) (2026-02-27)
 
 
 ### Bug Fixes
 
-* throw error browser version mismatches Playwright's expected Chromium ([#59](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/59)) ([a15b018](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/a15b01843f7e4c31612069bf7b38432473d700e2))
+* surface network errors in fetchPostWithinPage and fix Amex login diagnostics ([#61](https://github.com/sergienko4/israeli-bank-scrapers/issues/61)) ([4da69dd](https://github.com/sergienko4/israeli-bank-scrapers/commit/4da69dd4a5738a0cb4d76813c2dce709cabbb4a3))
 
-## [7.0.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v7.0.0...v7.0.1) (2026-02-26)
+## [7.0.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.0.1...v7.0.2) (2026-02-26)
 
 
 ### Bug Fixes
 
-* add 403 retry with 15s delay for WAF-blocked datacenter IPs ([#57](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/57)) ([98eadd7](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/98eadd70d318a66574cb4a3328d10a4e1ee66ba7))
+* throw error browser version mismatches Playwright's expected Chromium ([#59](https://github.com/sergienko4/israeli-bank-scrapers/issues/59)) ([a15b018](https://github.com/sergienko4/israeli-bank-scrapers/commit/a15b01843f7e4c31612069bf7b38432473d700e2))
 
-## [7.0.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.9.2...v7.0.0) (2026-02-26)
+## [7.0.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v7.0.0...v7.0.1) (2026-02-26)
+
+
+### Bug Fixes
+
+* add 403 retry with 15s delay for WAF-blocked datacenter IPs ([#57](https://github.com/sergienko4/israeli-bank-scrapers/issues/57)) ([98eadd7](https://github.com/sergienko4/israeli-bank-scrapers/commit/98eadd70d318a66574cb4a3328d10a4e1ee66ba7))
+
+## [7.0.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.9.2...v7.0.0) (2026-02-26)
 
 
 ### ⚠ BREAKING CHANGES
@@ -294,103 +294,103 @@
 
 ### Features
 
-* migrate from Puppeteer to Playwright ([#54](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/54)) ([4974e0f](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/4974e0f1e49fd4545ac01249df0f23ef2dafd93f))
+* migrate from Puppeteer to Playwright ([#54](https://github.com/sergienko4/israeli-bank-scrapers/issues/54)) ([4974e0f](https://github.com/sergienko4/israeli-bank-scrapers/commit/4974e0f1e49fd4545ac01249df0f23ef2dafd93f))
 
-## [6.9.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.9.1...v6.9.2) (2026-02-26)
-
-
-### Bug Fixes
-
-* CodeQL incomplete-sanitization in max.ts + enable Discount in CI ([#52](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/52)) ([dccf481](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/dccf481df80b1569d4175fe6bcbf0abcd4d37b6c))
-
-## [6.9.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.9.0...v6.9.1) (2026-02-26)
+## [6.9.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.9.1...v6.9.2) (2026-02-26)
 
 
 ### Bug Fixes
 
-* bypass Cloudflare WAF for Amex/Isracard with retry + manual stealth ([dd3a6a1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/dd3a6a18f50757517000f2341d4ea892e23bb752))
-* bypass Cloudflare WAF for Amex/Isracard with retry + manual stealth ([#49](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/49)) ([dd3a6a1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/dd3a6a18f50757517000f2341d4ea892e23bb752))
+* CodeQL incomplete-sanitization in max.ts + enable Discount in CI ([#52](https://github.com/sergienko4/israeli-bank-scrapers/issues/52)) ([dccf481](https://github.com/sergienko4/israeli-bank-scrapers/commit/dccf481df80b1569d4175fe6bcbf0abcd4d37b6c))
 
-## [6.9.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.8.2...v6.9.0) (2026-02-25)
+## [6.9.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.9.0...v6.9.1) (2026-02-26)
+
+
+### Bug Fixes
+
+* bypass Cloudflare WAF for Amex/Isracard with retry + manual stealth ([dd3a6a1](https://github.com/sergienko4/israeli-bank-scrapers/commit/dd3a6a18f50757517000f2341d4ea892e23bb752))
+* bypass Cloudflare WAF for Amex/Isracard with retry + manual stealth ([#49](https://github.com/sergienko4/israeli-bank-scrapers/issues/49)) ([dd3a6a1](https://github.com/sergienko4/israeli-bank-scrapers/commit/dd3a6a18f50757517000f2341d4ea892e23bb752))
+
+## [6.9.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.8.2...v6.9.0) (2026-02-25)
 
 
 ### Features
 
-* integrate puppeteer-extra-plugin-stealth for enhanced anti-detection ([#47](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/47)) ([fadb0dc](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/fadb0dc7362aaf3a9c85955a82d0c813e2ec9425))
+* integrate puppeteer-extra-plugin-stealth for enhanced anti-detection ([#47](https://github.com/sergienko4/israeli-bank-scrapers/issues/47)) ([fadb0dc](https://github.com/sergienko4/israeli-bank-scrapers/commit/fadb0dc7362aaf3a9c85955a82d0c813e2ec9425))
 
-## [6.8.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.8.1...v6.8.2) (2026-02-25)
-
-
-### Bug Fixes
-
-* resolve Jest 30 test-exclude crash on Node 22 ([#45](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/45)) ([e146bf2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/e146bf2529f015c9010050127b829d35dd4b217c))
-
-## [6.8.1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.8.0...v6.8.1) (2026-02-25)
+## [6.8.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.8.1...v6.8.2) (2026-02-25)
 
 
 ### Bug Fixes
 
-* replace node-fetch with native fetch() API ([#41](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/41)) ([9e12cef](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/9e12cefd260c5890d0ea35c0f995160badf07fd6))
+* resolve Jest 30 test-exclude crash on Node 22 ([#45](https://github.com/sergienko4/israeli-bank-scrapers/issues/45)) ([e146bf2](https://github.com/sergienko4/israeli-bank-scrapers/commit/e146bf2529f015c9010050127b829d35dd4b217c))
 
-## [6.8.0](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.8...v6.8.0) (2026-02-24)
+## [6.8.1](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.8.0...v6.8.1) (2026-02-25)
+
+
+### Bug Fixes
+
+* replace node-fetch with native fetch() API ([#41](https://github.com/sergienko4/israeli-bank-scrapers/issues/41)) ([9e12cef](https://github.com/sergienko4/israeli-bank-scrapers/commit/9e12cefd260c5890d0ea35c0f995160badf07fd6))
+
+## [6.8.0](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.8...v6.8.0) (2026-02-24)
 
 
 ### Features
 
-* apply anti-detection to ALL scrapers via base class ([#32](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/32)) ([d8e9e5e](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/d8e9e5e2f04e9cb22c9980e76fbaeab88df2317e))
+* apply anti-detection to ALL scrapers via base class ([#32](https://github.com/sergienko4/israeli-bank-scrapers/issues/32)) ([d8e9e5e](https://github.com/sergienko4/israeli-bank-scrapers/commit/d8e9e5e2f04e9cb22c9980e76fbaeab88df2317e))
 
-## [6.7.8](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.7...v6.7.8) (2026-02-24)
-
-
-### Bug Fixes
-
-* ratchet coverage thresholds to prevent regression ([#29](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/29)) ([ed824c8](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/ed824c837e3d780921e242dd7ab2c35f9132e840))
-
-## [6.7.7](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.6...v6.7.7) (2026-02-24)
+## [6.7.8](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.7...v6.7.8) (2026-02-24)
 
 
 ### Bug Fixes
 
-* **ci:** use PAT for release-please to trigger CI on PRs ([#22](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/22)) ([664c323](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/664c32367531607c4bf17367fe57b471de2d4157))
+* ratchet coverage thresholds to prevent regression ([#29](https://github.com/sergienko4/israeli-bank-scrapers/issues/29)) ([ed824c8](https://github.com/sergienko4/israeli-bank-scrapers/commit/ed824c837e3d780921e242dd7ab2c35f9132e840))
+
+## [6.7.7](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.6...v6.7.7) (2026-02-24)
+
+
+### Bug Fixes
+
+* **ci:** use PAT for release-please to trigger CI on PRs ([#22](https://github.com/sergienko4/israeli-bank-scrapers/issues/22)) ([664c323](https://github.com/sergienko4/israeli-bank-scrapers/commit/664c32367531607c4bf17367fe57b471de2d4157))
 
 
 ### Documentation
 
-* update documentation to match current CI/CD setup ([#23](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/23)) ([e248f5f](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/e248f5f0c0cf903a623780469ace58aa21b7659c))
+* update documentation to match current CI/CD setup ([#23](https://github.com/sergienko4/israeli-bank-scrapers/issues/23)) ([e248f5f](https://github.com/sergienko4/israeli-bank-scrapers/commit/e248f5f0c0cf903a623780469ace58aa21b7659c))
 
-## [6.7.6](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.5...v6.7.6) (2026-02-24)
-
-
-### Code Refactoring
-
-* **ci:** improve workflow quality from review ([#19](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues/19)) ([8084b1c](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/8084b1c054e213b2b6fa3e28b6a60123f97a178f))
-
-## [6.7.5](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.4...v6.7.5) (2026-02-24)
-
-
-### Bug Fixes
-
-* **ci:** install npm 11+ for Trusted Publishing OIDC support ([0a22fc1](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/0a22fc1f7509a08055a0bb36f5280a2ac5a2a653))
-* update Node to 22.14.0 for npm Trusted Publishing support ([37625ba](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/37625ba2ea040259d61a7d85fb4abc7b8c1534b6))
-
-## [6.7.4](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.3...v6.7.4) (2026-02-24)
-
-
-### Bug Fixes
-
-* **ci:** add NPM_TOKEN for CI publishing ([dc3552f](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/dc3552f36193ab01962e052b542f4547e470721a))
-* **ci:** trigger publish on GitHub Release (not tag push) ([ab00b4b](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/ab00b4b9d6acd8982f9ed7ede36c2bdde78e6aae))
-
-## [6.7.3](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.2...v6.7.3) (2026-02-24)
+## [6.7.6](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.5...v6.7.6) (2026-02-24)
 
 
 ### Code Refactoring
 
-* improve code quality from review ([1687e57](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/1687e57f71156d85f836957e6ebf3984892d7e30))
+* **ci:** improve workflow quality from review ([#19](https://github.com/sergienko4/israeli-bank-scrapers/issues/19)) ([8084b1c](https://github.com/sergienko4/israeli-bank-scrapers/commit/8084b1c054e213b2b6fa3e28b6a60123f97a178f))
 
-## [6.7.2](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/compare/v6.7.1...v6.7.2) (2026-02-24)
+## [6.7.5](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.4...v6.7.5) (2026-02-24)
 
 
 ### Bug Fixes
 
-* bypass Amex/Isracard WAF with anti-detection headers ([1cc4875](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commit/1cc4875f5a54b224d11ddf6bc8c61da619380606))
+* **ci:** install npm 11+ for Trusted Publishing OIDC support ([0a22fc1](https://github.com/sergienko4/israeli-bank-scrapers/commit/0a22fc1f7509a08055a0bb36f5280a2ac5a2a653))
+* update Node to 22.14.0 for npm Trusted Publishing support ([37625ba](https://github.com/sergienko4/israeli-bank-scrapers/commit/37625ba2ea040259d61a7d85fb4abc7b8c1534b6))
+
+## [6.7.4](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.3...v6.7.4) (2026-02-24)
+
+
+### Bug Fixes
+
+* **ci:** add NPM_TOKEN for CI publishing ([dc3552f](https://github.com/sergienko4/israeli-bank-scrapers/commit/dc3552f36193ab01962e052b542f4547e470721a))
+* **ci:** trigger publish on GitHub Release (not tag push) ([ab00b4b](https://github.com/sergienko4/israeli-bank-scrapers/commit/ab00b4b9d6acd8982f9ed7ede36c2bdde78e6aae))
+
+## [6.7.3](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.2...v6.7.3) (2026-02-24)
+
+
+### Code Refactoring
+
+* improve code quality from review ([1687e57](https://github.com/sergienko4/israeli-bank-scrapers/commit/1687e57f71156d85f836957e6ebf3984892d7e30))
+
+## [6.7.2](https://github.com/sergienko4/israeli-bank-scrapers/compare/v6.7.1...v6.7.2) (2026-02-24)
+
+
+### Bug Fixes
+
+* bypass Amex/Isracard WAF with anti-detection headers ([1cc4875](https://github.com/sergienko4/israeli-bank-scrapers/commit/1cc4875f5a54b224d11ddf6bc8c61da619380606))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Fork of [eshaham/israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers) with WAF bypass via Playwright.
 
-Published as `@[REDACTED-USER]/israeli-bank-scrapers` on npm.
+Published as `@sergienko4/israeli-bank-scrapers` on npm.
 
 ## Code Quality
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,5 +7,5 @@ By participating in this project, you agree to abide by its terms.
 ## Reporting
 
 If you experience or witness unacceptable behavior, please report it by opening
-a [GitHub issue](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues) or
+a [GitHub issue](https://github.com/sergienko4/israeli-bank-scrapers/issues) or
 contacting the maintainer directly via their GitHub profile.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to @[REDACTED-USER]/israeli-bank-scrapers
+Contributing to @sergienko4/israeli-bank-scrapers
 ========
 
 Hey people, first of all, thanks for taking the time to help improving this project :beers:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-[![npm version](https://img.shields.io/npm/v/@[REDACTED-USER]/israeli-bank-scrapers?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/@[REDACTED-USER]/israeli-bank-scrapers)
-[![CI](https://img.shields.io/github/actions/workflow/status/[REDACTED-USER]/israeli-bank-scrapers/pr.yml?style=for-the-badge&logo=github&label=CI)](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/actions)
+[![npm version](https://img.shields.io/npm/v/@sergienko4/israeli-bank-scrapers?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/@sergienko4/israeli-bank-scrapers)
+[![CI](https://img.shields.io/github/actions/workflow/status/sergienko4/israeli-bank-scrapers/pr.yml?style=for-the-badge&logo=github&label=CI)](https://github.com/sergienko4/israeli-bank-scrapers/actions)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org)
-[![License](https://img.shields.io/github/license/[REDACTED-USER]/israeli-bank-scrapers?style=for-the-badge)](./LICENSE)
-[![API Docs](https://img.shields.io/badge/API_Docs-TypeDoc-blue?style=for-the-badge&logo=typescript&logoColor=white)](https://[REDACTED-USER].github.io/israeli-bank-scrapers/api/)
-[![npm downloads](https://img.shields.io/npm/dm/@[REDACTED-USER]/israeli-bank-scrapers?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/@[REDACTED-USER]/israeli-bank-scrapers)
-[![SonarCloud](https://img.shields.io/sonar/quality_gate/[REDACTED-USER]_israeli-bank-scrapers?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/overall?id=[REDACTED-USER]_israeli-bank-scrapers)
-[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/[REDACTED-USER]/israeli-bank-scrapers?style=for-the-badge&label=OSSF)](https://securityscorecards.dev/viewer/?uri=github.com/[REDACTED-USER]/israeli-bank-scrapers)
+[![License](https://img.shields.io/github/license/sergienko4/israeli-bank-scrapers?style=for-the-badge)](./LICENSE)
+[![API Docs](https://img.shields.io/badge/API_Docs-TypeDoc-blue?style=for-the-badge&logo=typescript&logoColor=white)](https://sergienko4.github.io/israeli-bank-scrapers/api/)
+[![npm downloads](https://img.shields.io/npm/dm/@sergienko4/israeli-bank-scrapers?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/@sergienko4/israeli-bank-scrapers)
+[![SonarCloud](https://img.shields.io/sonar/quality_gate/sergienko4_israeli-bank-scrapers?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/overall?id=sergienko4_israeli-bank-scrapers)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sergienko4/israeli-bank-scrapers?style=for-the-badge&label=OSSF)](https://securityscorecards.dev/viewer/?uri=github.com/sergienko4/israeli-bank-scrapers)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A5%2022.14-green?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org/)
 
 # Israeli Bank Scrapers
@@ -23,7 +23,7 @@ Scrape transactions from **19 Israeli banks and credit card companies** with bui
 Maintained fork of [eshaham/israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers), rewritten on a typed phase-based pipeline using [Camoufox](https://github.com/daijro/camoufox) (Firefox anti-detect), Playwright, and TypeScript 6.0 strict mode.
 
 ```sh
-npm install @[REDACTED-USER]/israeli-bank-scrapers
+npm install @sergienko4/israeli-bank-scrapers
 ```
 
 ## Architecture at a glance
@@ -54,7 +54,7 @@ flowchart LR
 
 12 phases for browser banks, 2 phases for api-direct banks, **one result shape**. Each phase owns its mediator zone and its own state — phases never reach into each other's data. See [Architecture](#architecture) for the contract that keeps the wiring honest.
 
-> **📚 Full documentation:** [User Guide & Architecture (mkdocs)](https://[REDACTED-USER].github.io/israeli-bank-scrapers/) · [API Reference (TypeDoc)](https://[REDACTED-USER].github.io/israeli-bank-scrapers/api/) · [Changelog](./CHANGELOG.md) · [Contributing](./CONTRIBUTING.md)
+> **📚 Full documentation:** [User Guide & Architecture (mkdocs)](https://sergienko4.github.io/israeli-bank-scrapers/) · [API Reference (TypeDoc)](https://sergienko4.github.io/israeli-bank-scrapers/api/) · [Changelog](./CHANGELOG.md) · [Contributing](./CONTRIBUTING.md)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -92,7 +92,7 @@ flowchart LR
 Three steps to get transactions from Bank Hapoalim:
 
 ```typescript
-import { CompanyTypes, createScraper } from '@[REDACTED-USER]/israeli-bank-scrapers';
+import { CompanyTypes, createScraper } from '@sergienko4/israeli-bank-scrapers';
 
 const scraper = createScraper({
   companyId: CompanyTypes.Hapoalim,
@@ -147,7 +147,7 @@ Per-phase navigation timeout is controlled by the `defaultTimeout` scraper **opt
 ## Usage
 
 ```typescript
-import { CompanyTypes, createScraper } from '@[REDACTED-USER]/israeli-bank-scrapers';
+import { CompanyTypes, createScraper } from '@sergienko4/israeli-bank-scrapers';
 
 const scraper = createScraper({
   companyId: CompanyTypes.Amex,
@@ -588,7 +588,7 @@ createScraper({
 
 ```diff
 - npm install israeli-bank-scrapers
-+ npm install @[REDACTED-USER]/israeli-bank-scrapers
++ npm install @sergienko4/israeli-bank-scrapers
 ```
 
 Same `createScraper` + `companyId` + `credentials` API. Both `import` and `require()` work. Types now use `I` prefix (`IScraper`, `IScraperScrapingResult`) — old names still work as aliases.
@@ -636,25 +636,25 @@ Thanks to the original [israeli-bank-scrapers](https://github.com/eshaham/israel
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/[REDACTED-USER]"><img src="https://avatars.githubusercontent.com/u/16467411?v=4?s=80" width="80px;" alt="[REDACTED-USER] Eugune"/><br /><sub><b>[REDACTED-USER] Eugune</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=[REDACTED-USER]" title="Code">💻</a> <a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=[REDACTED-USER]" title="Documentation">📖</a> <a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=[REDACTED-USER]" title="Tests">⚠️</a> <a href="#maintenance-[REDACTED-USER]" title="Maintenance">🚧</a> <a href="#infra-[REDACTED-USER]" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://elad.shaham.net/"><img src="https://avatars.githubusercontent.com/u/7040645?v=4?s=80" width="80px;" alt="Elad Shaham"/><br /><sub><b>Elad Shaham</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=eshaham" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sebikaplun"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="sebikaplun"/><br /><sub><b>sebikaplun</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=sebikaplun" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/esakal"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="esakal"/><br /><sub><b>esakal</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=esakal" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ezzatq"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="ezzatq"/><br /><sub><b>ezzatq</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=ezzatq" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/kfirarad"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="kfirarad"/><br /><sub><b>kfirarad</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=kfirarad" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/baruchiro"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="baruchiro"/><br /><sub><b>baruchiro</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=baruchiro" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sergienko4"><img src="https://avatars.githubusercontent.com/u/16467411?v=4?s=80" width="80px;" alt="sergienko4 Eugune"/><br /><sub><b>sergienko4 Eugune</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=sergienko4" title="Code">💻</a> <a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=sergienko4" title="Documentation">📖</a> <a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=sergienko4" title="Tests">⚠️</a> <a href="#maintenance-sergienko4" title="Maintenance">🚧</a> <a href="#infra-sergienko4" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://elad.shaham.net/"><img src="https://avatars.githubusercontent.com/u/7040645?v=4?s=80" width="80px;" alt="Elad Shaham"/><br /><sub><b>Elad Shaham</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=eshaham" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/sebikaplun"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="sebikaplun"/><br /><sub><b>sebikaplun</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=sebikaplun" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/esakal"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="esakal"/><br /><sub><b>esakal</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=esakal" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ezzatq"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="ezzatq"/><br /><sub><b>ezzatq</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=ezzatq" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/kfirarad"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="kfirarad"/><br /><sub><b>kfirarad</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=kfirarad" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/baruchiro"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="baruchiro"/><br /><sub><b>baruchiro</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=baruchiro" title="Code">💻</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/matanelgabsi"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="matanelgabsi"/><br /><sub><b>matanelgabsi</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=matanelgabsi" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/dratler"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="dratler"/><br /><sub><b>dratler</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=dratler" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/dudiventura"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="dudiventura"/><br /><sub><b>dudiventura</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=dudiventura" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gczobel"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="gczobel"/><br /><sub><b>gczobel</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=gczobel" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/orzarchi"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="orzarchi"/><br /><sub><b>orzarchi</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=orzarchi" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/erezd"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="erezd"/><br /><sub><b>erezd</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=erezd" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/erikash"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="erikash"/><br /><sub><b>erikash</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=erikash" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/matanelgabsi"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="matanelgabsi"/><br /><sub><b>matanelgabsi</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=matanelgabsi" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/dratler"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="dratler"/><br /><sub><b>dratler</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=dratler" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/dudiventura"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="dudiventura"/><br /><sub><b>dudiventura</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=dudiventura" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gczobel"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="gczobel"/><br /><sub><b>gczobel</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=gczobel" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/orzarchi"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="orzarchi"/><br /><sub><b>orzarchi</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=orzarchi" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/erezd"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="erezd"/><br /><sub><b>erezd</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=erezd" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/erikash"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="erikash"/><br /><sub><b>erikash</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=erikash" title="Code">💻</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/daniel-hauser"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="daniel-hauser"/><br /><sub><b>daniel-hauser</b></sub></a><br /><a href="https://github.com/[REDACTED-USER]/israeli-bank-scrapers/commits?author=daniel-hauser" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/daniel-hauser"><img src="https://avatars.githubusercontent.com/u/0?v=4?s=80" width="80px;" alt="daniel-hauser"/><br /><sub><b>daniel-hauser</b></sub></a><br /><a href="https://github.com/sergienko4/israeli-bank-scrapers/commits?author=daniel-hauser" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>
@@ -666,22 +666,22 @@ Thanks to the original [israeli-bank-scrapers](https://github.com/eshaham/israel
 
 ## Links
 
-- [API Documentation (TypeDoc)](https://[REDACTED-USER].github.io/israeli-bank-scrapers/api/)
-- [Changelog](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/CHANGELOG.md)
-- [Contributing](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/CODE_OF_CONDUCT.md)
-- [Security Policy](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/SECURITY.md)
+- [API Documentation (TypeDoc)](https://sergienko4.github.io/israeli-bank-scrapers/api/)
+- [Changelog](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/CHANGELOG.md)
+- [Contributing](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/CODE_OF_CONDUCT.md)
+- [Security Policy](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/SECURITY.md)
 
 ## Known Projects
 
-- [israeli-bank-scrapers-to-actual-budget](https://github.com/[REDACTED-USER]/israeli-bank-scrapers-to-actual-budget) — Sync to Actual Budget
+- [israeli-bank-scrapers-to-actual-budget](https://github.com/sergienko4/israeli-bank-scrapers-to-actual-budget) — Sync to Actual Budget
 - [Caspion](https://github.com/brafdlog/caspion) — Auto-send to budget apps
 - [Moneyman](https://github.com/daniel-hauser/moneyman) — Save via GitHub Actions
 - [Firefly III Importer](https://github.com/itairaz1/israeli-bank-firefly-importer) — Import to Firefly III
 
 ## License
 
-MIT. Maintained by [@[REDACTED-USER]](https://github.com/[REDACTED-USER]). Based on [eshaham/israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers).
+MIT. Maintained by [@sergienko4](https://github.com/sergienko4). Based on [eshaham/israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ If you discover a security vulnerability in this project, please report it respo
 Instead, please use one of the following methods:
 
 1. **GitHub Security Advisories (preferred):** Navigate to the
-   [Security Advisories](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/security/advisories/new)
+   [Security Advisories](https://github.com/sergienko4/israeli-bank-scrapers/security/advisories/new)
    page and create a new advisory.
 
 2. **Email:** Send details to the repository maintainer via the email

--- a/docs/architecture/balance-resolve.md
+++ b/docs/architecture/balance-resolve.md
@@ -50,7 +50,7 @@ Reads `scrape.accountIdentities` + `scrape.balanceFetchTemplate`. **Default-deny
 | GET + `urlPathInterpolation` | One entry per unique BA, `<ID>` replaced in URL path |
 | Bulk (no key) | One entry with `bankAccountUniqueId: '__BULK__'` covering every card |
 
-Source: [`BalanceFetchPlanner.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceFetchPlanner.ts).
+Source: [`BalanceFetchPlanner.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceFetchPlanner.ts).
 
 ### `.action` — fetch + extract
 
@@ -61,7 +61,7 @@ Source: [`BalanceFetchPlanner.ts`](https://github.com/[REDACTED-USER]/israeli-ba
     - Per-card-record banks (Visa Cal — `result.bigNumbers[].cards[]`, Amex/Isracard — `data.cardsList[].cardChargeNext.billingSumSekel`) — find the card by `cardUniqueId` or one of the display-id fields (`last4Digits`, `cardSuffix`, `cardLast4`, `shortCardNumber`, `card4Number`), then run the bulk extractor on its sub-record.
     - Bulk endpoints — `responses.get('__BULK__')` services every card via the same body.
 
-Source: [`BalanceResolveActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.ts) (`executeBalanceResolveAction`).
+Source: [`BalanceResolveActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.ts) (`executeBalanceResolveAction`).
 
 ### `.post` — partition + universal-miss gate
 
@@ -73,7 +73,7 @@ Source: [`BalanceResolveActions.ts`](https://github.com/[REDACTED-USER]/israeli-
 
 ### `.final` — emit `balanceResolution`
 
-Builds `Map<accountNumber, number>` (legitimate `0` preserved; `'MISS'` → `0`). Writes to `ctx.balanceResolution` which [`PipelineResult`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts) reads when assembling the final accounts array.
+Builds `Map<accountNumber, number>` (legitimate `0` preserved; `'MISS'` → `0`). Writes to `ctx.balanceResolution` which [`PipelineResult`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts) reads when assembling the final accounts array.
 
 ## Observability
 
@@ -94,9 +94,9 @@ Three ESLint canaries lock the boundary at commit time:
 
 | Canary | What it rejects |
 |---|---|
-| [`balance-resolve-isolation.canary.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/balance-resolve-isolation.canary.ts) | BALANCE-RESOLVE code reaching outside its own folder |
-| [`no-balance-in-scrape.canary.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/no-balance-in-scrape.canary.ts) | SCRAPE-zone code importing balance extractor / planner |
-| [`balance-fetch-only-in-balance-resolve.canary.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/balance-fetch-only-in-balance-resolve.canary.ts) | `BalanceFetchPlanner` imported anywhere outside `BalanceResolve/` |
+| [`balance-resolve-isolation.canary.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/balance-resolve-isolation.canary.ts) | BALANCE-RESOLVE code reaching outside its own folder |
+| [`no-balance-in-scrape.canary.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/no-balance-in-scrape.canary.ts) | SCRAPE-zone code importing balance extractor / planner |
+| [`balance-fetch-only-in-balance-resolve.canary.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/balance-fetch-only-in-balance-resolve.canary.ts) | `BalanceFetchPlanner` imported anywhere outside `BalanceResolve/` |
 
 A PR that violates any of the three fails the **`canaries`** gate of the pre-commit hook (and the build CI gate).
 
@@ -104,9 +104,9 @@ A PR that violates any of the three fails the **`canaries`** gate of the pre-com
 
 | File | Tests |
 |---|---|
-| [`BalanceResolveActionsV6.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts) | Happy path: PRE → ACTION → POST → FINAL per shape (single, per-BA, bulk) |
-| [`BalanceFetchPlanner.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceFetchPlanner.test.ts) | Planner dedup, default-deny, malformed URL |
-| [`BalanceResolveActionsCoverage.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsCoverage.test.ts) | Edge branches: null/array/primitive POST body, malformed JSON, extractor-false fall-through |
-| [`BalanceResolveCrossBank.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts) | Per-shape cross-bank smoke (Hapoalim / Visa Cal / Amex) |
-| [`BalanceResolvePhase.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Phases/BalanceResolvePhase.test.ts) | Phase orchestrator delegates to the right action |
-| [`BalanceExtractor.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceExtractor.test.ts) | BFS+ILS depth-5 extractor against every bank shape |
+| [`BalanceResolveActionsV6.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts) | Happy path: PRE → ACTION → POST → FINAL per shape (single, per-BA, bulk) |
+| [`BalanceFetchPlanner.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceFetchPlanner.test.ts) | Planner dedup, default-deny, malformed URL |
+| [`BalanceResolveActionsCoverage.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsCoverage.test.ts) | Edge branches: null/array/primitive POST body, malformed JSON, extractor-false fall-through |
+| [`BalanceResolveCrossBank.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBank.test.ts) | Per-shape cross-bank smoke (Hapoalim / Visa Cal / Amex) |
+| [`BalanceResolvePhase.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Phases/BalanceResolvePhase.test.ts) | Phase orchestrator delegates to the right action |
+| [`BalanceExtractor.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceExtractor.test.ts) | BFS+ILS depth-5 extractor against every bank shape |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -42,7 +42,7 @@ flowchart TB
 
 | File | Role |
 |---|---|
-| [`src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts) | Declarative `PHASE_CHAIN` slot definitions |
-| [`src/Scrapers/Pipeline/Core/PipelineRegistry.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineRegistry.ts) | Maps `CompanyTypes → PipelineFactory` |
-| [`src/Scrapers/Pipeline/Types/PipelineContext.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/PipelineContext.ts) | All shared types + `Option<T>` slots |
-| [`src/Scrapers/Pipeline/Types/Procedure.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/Procedure.ts) | The `Procedure<T>` result-pattern primitive |
+| [`src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts) | Declarative `PHASE_CHAIN` slot definitions |
+| [`src/Scrapers/Pipeline/Core/PipelineRegistry.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineRegistry.ts) | Maps `CompanyTypes → PipelineFactory` |
+| [`src/Scrapers/Pipeline/Types/PipelineContext.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/PipelineContext.ts) | All shared types + `Option<T>` slots |
+| [`src/Scrapers/Pipeline/Types/Procedure.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/Procedure.ts) | The `Procedure<T>` result-pattern primitive |

--- a/docs/architecture/layers.md
+++ b/docs/architecture/layers.md
@@ -63,4 +63,4 @@ The architecture validator (`lint:architecture`) runs on every commit and reject
 - Imports from layer 1 (Public API) into any legacy implementation
 - Cross-mediator imports within layer 3 (BALANCE-RESOLVE cannot reach into SCRAPE state directly)
 
-Source: [`src/Tests/Tools/lint-and-validate.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Tools/lint-and-validate.ts) + the 3 architecture canaries under `src/Scrapers/Pipeline/EslintCanaries/`.
+Source: [`src/Tests/Tools/lint-and-validate.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Tools/lint-and-validate.ts) + the 3 architecture canaries under `src/Scrapers/Pipeline/EslintCanaries/`.

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -56,7 +56,7 @@ type Procedure<T> =
 | `toLegacy(p)` | Convert to the public `IScraperScrapingResult` shape |
 | `assertOk(p)` | Test-only — `expect(p.success).toBe(true)` + type narrowing |
 
-See [`Procedure.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/Procedure.ts).
+See [`Procedure.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/Procedure.ts).
 
 ## IPipelineContext — the shared state slot table
 
@@ -78,7 +78,7 @@ Key slots (v8.4+):
 | `balanceValidation` | BALANCE-RESOLVE.post | `{ resolvedIds, missedIds, totalAccounts }` |
 | `balanceResolution` | BALANCE-RESOLVE.final | Final `Map<accountNumber, number>` → `PipelineResult` |
 
-The two paths converge on `balanceResolution` — that's the single source of truth read by [`PipelineResult.combineWithBalance`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts).
+The two paths converge on `balanceResolution` — that's the single source of truth read by [`PipelineResult.combineWithBalance`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts).
 
 ## Interceptors — cross-cutting, no data
 
@@ -87,11 +87,11 @@ The two paths converge on `balanceResolution` — that's the single source of tr
 | **PopupInterceptor** | HOME / ACCOUNT-RESOLVE / DASHBOARD | Dismiss modal overlays by visible text |
 | **NetworkDiscovery** | (whole run) | Index every HTTP request/response post-auth, redact body+URL before write, feed endpoints to SCRAPE + BALANCE-RESOLVE |
 
-Source: [`src/Scrapers/Pipeline/Interceptors/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors).
+Source: [`src/Scrapers/Pipeline/Interceptors/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors).
 
 ## Source pointers
 
-- [`PipelineAssembly.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts) — `PHASE_CHAIN` slot declarations
-- [`PipelineExecutor.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Executor/PipelineExecutor.ts) — drives the slots in order
-- [`BasePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/BasePhase.ts) — `pre`/`action`/`post`/`final` contract every phase implements
-- [`PipelineContextFactory.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts) — builds the initial context per run
+- [`PipelineAssembly.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts) — `PHASE_CHAIN` slot declarations
+- [`PipelineExecutor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Executor/PipelineExecutor.ts) — drives the slots in order
+- [`BasePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/BasePhase.ts) — `pre`/`action`/`post`/`final` contract every phase implements
+- [`PipelineContextFactory.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts) — builds the initial context per run

--- a/docs/architecture/waf-interceptor.md
+++ b/docs/architecture/waf-interceptor.md
@@ -11,7 +11,7 @@ The interceptor centralises the recipe in one place: detect the challenge frame,
 
 ## Architecture
 
-Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge):
+Single cluster under [`src/Scrapers/Pipeline/Interceptors/WafChallenge/`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge):
 
 | File | Purpose |
 |---|---|
@@ -147,10 +147,10 @@ No PII flows through these events — only the `kind` enum (`hcaptcha-checkbox` 
 
 | File | Role |
 |---|---|
-| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
-| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
-| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
-| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |
+| [`Interceptors/WafChallenge/WafChallengeInterceptor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeInterceptor.ts) | Factory entry point |
+| [`Core/Builder/PipelineBuilderHelpers.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/Builder/PipelineBuilderHelpers.ts) | Wires interceptor FIRST in `buildBrowserBaseInterceptors()` |
+| [`Interceptors/WafChallenge/WafChallengeDetector.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/WafChallengeDetector.ts) | Frame URL classifier |
+| [`Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/WafChallenge/HCaptchaCheckboxSolver.ts) | Solve recipe |
 
 ## Camoufox launcher knob surface
 

--- a/docs/banks/amex.md
+++ b/docs/banks/amex.md
@@ -7,12 +7,12 @@
 | Credentials | `id`, `card6Digits`, `password` |
 | OTP | — |
 | Phase chain | INIT → HOME → **PRE-LOGIN** → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Amex/AmexPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Amex/AmexPipeline.ts) |
+| Source | [`Banks/Amex/AmexPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Amex/AmexPipeline.ts) |
 
 ## Quick example
 
 ```typescript
-import { CompanyTypes, createScraper } from '@[REDACTED-USER]/israeli-bank-scrapers';
+import { CompanyTypes, createScraper } from '@sergienko4/israeli-bank-scrapers';
 
 const scraper = createScraper({
   companyId: CompanyTypes.Amex,

--- a/docs/banks/behatsdaa.md
+++ b/docs/banks/behatsdaa.md
@@ -9,7 +9,7 @@
 | Credentials | `id`, `password` |
 | OTP | — |
 | Registry | `SCRAPER_REGISTRY_AMEX_TO_ISRACARD` |
-| Source | [`src/Scrapers/Behatsdaa/BehatsdaaScraper.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Behatsdaa/BehatsdaaScraper.ts) |
+| Source | [`src/Scrapers/Behatsdaa/BehatsdaaScraper.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Behatsdaa/BehatsdaaScraper.ts) |
 
 ## Quick example
 

--- a/docs/banks/beinleumi.md
+++ b/docs/banks/beinleumi.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` (plus `otpCodeRetriever` callback in options) |
 | OTP | Required |
 | Phase chain | INIT → HOME → LOGIN → **OTP-TRIGGER → OTP-FILL** → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Beinleumi/BeinleumiPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Beinleumi/BeinleumiPipeline.ts) |
+| Source | [`Banks/Beinleumi/BeinleumiPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Beinleumi/BeinleumiPipeline.ts) |
 
 ## Quick example
 
@@ -27,4 +27,4 @@ const result = await scraper.scrape({
 ## Known quirks
 
 - Beinleumi is the parent of the Beinleumi group: same login flow used by Massad, Otsar Hahayal, Pagi.
-- Balance endpoint shape: `(withdrawable + current)` per account — see [`beinleumi/balance-resolve/last-good.json`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/beinleumi/balance-resolve/last-good.json) for the captured response shape.
+- Balance endpoint shape: `(withdrawable + current)` per account — see [`beinleumi/balance-resolve/last-good.json`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/beinleumi/balance-resolve/last-good.json) for the captured response shape.

--- a/docs/banks/discount.md
+++ b/docs/banks/discount.md
@@ -7,7 +7,7 @@
 | Credentials | `id`, `password`, `num` |
 | OTP | — |
 | Phase chain | INIT → HOME → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Discount/DiscountPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Discount/DiscountPipeline.ts) |
+| Source | [`Banks/Discount/DiscountPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Discount/DiscountPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/hapoalim.md
+++ b/docs/banks/hapoalim.md
@@ -7,7 +7,7 @@
 | Credentials | `userCode`, `password` (plus `otpCodeRetriever` callback in options) |
 | OTP | **Conditional** — only on unrecognised devices |
 | Phase chain | INIT → HOME → LOGIN → (OTP-FILL conditional) → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Hapoalim/HapoalimPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts) |
+| Source | [`Banks/Hapoalim/HapoalimPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/index.md
+++ b/docs/banks/index.md
@@ -55,7 +55,7 @@
 | Mizrahi Bank | `Mizrahi` | `username`, `password` | — |
 | Bank Yahav | `Yahav` | `username`, `nationalID`, `password` | — |
 
-Source: [`src/Definitions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Definitions.ts).
+Source: [`src/Definitions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Definitions.ts).
 
 ## How to pick the right page
 
@@ -64,4 +64,4 @@ Source: [`src/Definitions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-s
 | ... just want to scrape with code that works today | The per-bank page for credential fields, then [Quick Start](../quick-start.md) |
 | ... want to know which engine your bank uses (browser vs API) | The per-bank page's "Engine" line |
 | ... hit `INVALID_OTP` or `INVALID_PASSWORD` | The per-bank "Known quirks" section + [Phases → LOGIN](../phases/login.md) / [OTP-FILL](../phases/otp-fill.md) |
-| ... see `WAF_BLOCKED` | The per-bank page (in case of bank-specific quirks) + [Error Types → WAF](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#error-types) |
+| ... see `WAF_BLOCKED` | The per-bank page (in case of bank-specific quirks) + [Error Types → WAF](https://github.com/sergienko4/israeli-bank-scrapers#error-types) |

--- a/docs/banks/isracard.md
+++ b/docs/banks/isracard.md
@@ -7,7 +7,7 @@
 | Credentials | `id`, `card6Digits`, `password` |
 | OTP | — |
 | Phase chain | INIT → HOME → **PRE-LOGIN** → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Isracard/IsracardPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Isracard/IsracardPipeline.ts) |
+| Source | [`Banks/Isracard/IsracardPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Isracard/IsracardPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/leumi.md
+++ b/docs/banks/leumi.md
@@ -9,7 +9,7 @@
 | Credentials | `username`, `password` |
 | OTP | — |
 | Registry | `SCRAPER_REGISTRY_LEUMI_TO_YAHAV` |
-| Source | [`src/Scrapers/Leumi/LeumiScraper.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Leumi/LeumiScraper.ts) |
+| Source | [`src/Scrapers/Leumi/LeumiScraper.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Leumi/LeumiScraper.ts) |
 
 ## Quick example
 

--- a/docs/banks/massad.md
+++ b/docs/banks/massad.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` (plus `otpCodeRetriever` callback in options) |
 | OTP | Required |
 | Phase chain | INIT → HOME → LOGIN → **OTP-TRIGGER → OTP-FILL** → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Massad/MassadPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Massad/MassadPipeline.ts) |
+| Source | [`Banks/Massad/MassadPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Massad/MassadPipeline.ts) |
 
 ## Known quirks
 

--- a/docs/banks/max.md
+++ b/docs/banks/max.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` |
 | OTP | — |
 | Phase chain | INIT → HOME → **PRE-LOGIN** → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Max/MaxPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Max/MaxPipeline.ts) |
+| Source | [`Banks/Max/MaxPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Max/MaxPipeline.ts) |
 
 ## Known quirks
 

--- a/docs/banks/mercantile.md
+++ b/docs/banks/mercantile.md
@@ -7,7 +7,7 @@
 | Credentials | `id`, `password`, `num` |
 | OTP | — |
 | Phase chain | INIT → HOME → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Mercantile/MercantilePipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Mercantile/MercantilePipeline.ts) |
+| Source | [`Banks/Mercantile/MercantilePipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Mercantile/MercantilePipeline.ts) |
 
 ## Known quirks
 

--- a/docs/banks/mizrahi.md
+++ b/docs/banks/mizrahi.md
@@ -9,7 +9,7 @@
 | Credentials | `username`, `password` |
 | OTP | — |
 | Registry | `SCRAPER_REGISTRY_LEUMI_TO_YAHAV` |
-| Source | [`src/Scrapers/Mizrahi/MizrahiScraper.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Mizrahi/MizrahiScraper.ts) |
+| Source | [`src/Scrapers/Mizrahi/MizrahiScraper.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Mizrahi/MizrahiScraper.ts) |
 
 ## Quick example
 

--- a/docs/banks/onezero.md
+++ b/docs/banks/onezero.md
@@ -8,7 +8,7 @@
 | OTP | Required (or `otpLongTermToken` from a previous run) |
 | Phase chain | [API-DIRECT-CALL](../phases/api-direct-call.md) → [API-DIRECT-SCRAPE](../phases/api-direct-scrape.md) |
 | Phone format | `international-plus` (`+972000000000`) |
-| Source | [`Banks/OneZero/OneZeroPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OneZero/OneZeroPipeline.ts) |
+| Source | [`Banks/OneZero/OneZeroPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OneZero/OneZeroPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/otsar-hahayal.md
+++ b/docs/banks/otsar-hahayal.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` (plus `otpCodeRetriever` callback in options) |
 | OTP | Required |
 | Phase chain | INIT → HOME → LOGIN → **OTP-TRIGGER → OTP-FILL** → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/OtsarHahayal/OtsarHahayalPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OtsarHahayal/OtsarHahayalPipeline.ts) |
+| Source | [`Banks/OtsarHahayal/OtsarHahayalPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OtsarHahayal/OtsarHahayalPipeline.ts) |
 
 ## Known quirks
 

--- a/docs/banks/pagi.md
+++ b/docs/banks/pagi.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` (plus `otpCodeRetriever` callback in options) |
 | OTP | Required |
 | Phase chain | INIT → HOME → LOGIN → **OTP-TRIGGER → OTP-FILL** → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/Pagi/PagiPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pagi/PagiPipeline.ts) |
+| Source | [`Banks/Pagi/PagiPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pagi/PagiPipeline.ts) |
 
 ## Known quirks
 

--- a/docs/banks/paybox.md
+++ b/docs/banks/paybox.md
@@ -8,7 +8,7 @@
 | OTP | Required (cached long-term token supported) |
 | Phase chain | [API-DIRECT-CALL](../phases/api-direct-call.md) → [API-DIRECT-SCRAPE](../phases/api-direct-scrape.md) |
 | Phone format | `international-dash` (`972-000000000`) |
-| Source | [`Banks/PayBox/PayBoxPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/PayBox/PayBoxPipeline.ts) |
+| Source | [`Banks/PayBox/PayBoxPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/PayBox/PayBoxPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/pepper.md
+++ b/docs/banks/pepper.md
@@ -8,7 +8,7 @@
 | OTP | Required |
 | Phase chain | [API-DIRECT-CALL](../phases/api-direct-call.md) → [API-DIRECT-SCRAPE](../phases/api-direct-scrape.md) |
 | Phone format | `international-flat` (`972000000000`) |
-| Source | [`Banks/Pepper/PepperPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pepper/PepperPipeline.ts) |
+| Source | [`Banks/Pepper/PepperPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pepper/PepperPipeline.ts) |
 
 ## Quick example
 

--- a/docs/banks/visacal.md
+++ b/docs/banks/visacal.md
@@ -7,7 +7,7 @@
 | Credentials | `username`, `password` |
 | OTP | — |
 | Phase chain | INIT → HOME → **PRE-LOGIN** → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE |
-| Source | [`Banks/VisaCal/VisaCalPipeline.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/VisaCal/VisaCalPipeline.ts) |
+| Source | [`Banks/VisaCal/VisaCalPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/VisaCal/VisaCalPipeline.ts) |
 
 ## Known quirks
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -10,7 +10,7 @@
 | [Test surfaces](testing.md) | Which test suite to write for what |
 | [Code style & lint](lint.md) | Project rules: SOLID, max-depth, no CSS selectors, etc. |
 
-See also: [CONTRIBUTING.md](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/CONTRIBUTING.md) at the repo root for the full PR checklist + Code of Conduct.
+See also: [CONTRIBUTING.md](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/CONTRIBUTING.md) at the repo root for the full PR checklist + Code of Conduct.
 
 ## Quick start (contributor)
 

--- a/docs/contributing/lint.md
+++ b/docs/contributing/lint.md
@@ -2,7 +2,7 @@
 
 The pre-commit hook runs ESLint + Biome + Prettier + the architecture validator + canaries + guideline-coverage on every commit. Skipping any of them is not an option.
 
-> **Quality caps** (per-function LoC, file size, complexity, parameter count) live in [CLEAN_CODE.md](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/CLEAN_CODE.md). That file is the single source of truth — do NOT restate the numbers here. The `lint:guideline-coverage` gate asserts `eslint.config.mjs` actually enforces those caps for every Pipeline cluster.
+> **Quality caps** (per-function LoC, file size, complexity, parameter count) live in [CLEAN_CODE.md](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/CLEAN_CODE.md). That file is the single source of truth — do NOT restate the numbers here. The `lint:guideline-coverage` gate asserts `eslint.config.mjs` actually enforces those caps for every Pipeline cluster.
 
 ## Project-specific rules (beyond defaults)
 
@@ -62,7 +62,7 @@ const isSuccess = isOk(result);
 expect(isSuccess).toBe(true);
 ```
 
-Test files have the [`assertOk`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Helpers/AssertProcedure.ts) helper for this exact pattern.
+Test files have the [`assertOk`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Helpers/AssertProcedure.ts) helper for this exact pattern.
 
 ## Auto-fix vs hand-fix
 

--- a/docs/contributing/new-bank.md
+++ b/docs/contributing/new-bank.md
@@ -6,7 +6,7 @@ Pipeline-first — every new bank lives under `src/Scrapers/Pipeline/Banks/<Name
 
 ### 1. Add the enum entry
 
-Edit [`src/Definitions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Definitions.ts):
+Edit [`src/Definitions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Definitions.ts):
 
 ```typescript
 export enum CompanyTypes {
@@ -74,7 +74,7 @@ export function buildNewBankPipeline(options: ScraperOptions): Procedure<IPipeli
 
 ### 5. Register the builder
 
-Edit [`src/Scrapers/Pipeline/Core/PipelineRegistry.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineRegistry.ts):
+Edit [`src/Scrapers/Pipeline/Core/PipelineRegistry.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineRegistry.ts):
 
 ```typescript
 import { buildNewBankPipeline } from '../Banks/NewBank/NewBankPipeline.js';
@@ -93,7 +93,7 @@ Create `src/Tests/E2eMocked/<NewBank>/<NewBank>.e2e-mocked.test.ts` that:
 2. Constructs the scraper.
 3. Asserts `result.success === true` + expected account count + sample txn.
 
-The existing [`Amex.e2e-mocked.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/E2eMocked/Amex.e2e-mocked.test.ts) is the template.
+The existing [`Amex.e2e-mocked.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/E2eMocked/Amex.e2e-mocked.test.ts) is the template.
 
 ### 7. Verify
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -52,7 +52,7 @@ Five test suites, picked by **what you're testing**.
 
 Captured under `src/Tests/E2eMocked/<Bank>/fixtures/` and `Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/<bank>/`. Always **pre-redacted** via `PiiRedactor` at capture time — committing a fixture should never leak real PII.
 
-If you need to add fixtures, use the [`SnapshotInterceptor`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/SnapshotFrameCapture.ts) which writes redacted JSON for every captured response, then move the relevant slice into the fixture dir.
+If you need to add fixtures, use the [`SnapshotInterceptor`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors/SnapshotFrameCapture.ts) which writes redacted JSON for every captured response, then move the relevant slice into the fixture dir.
 
 ## Where the gates run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,12 @@ hide:
 Scrape transactions from **19 Israeli banks and credit card companies** with built-in **Cloudflare WAF bypass** and **end-to-end PII redaction**.
 
 ```sh
-npm install @[REDACTED-USER]/israeli-bank-scrapers
+npm install @sergienko4/israeli-bank-scrapers
 ```
 
 [Quick Start :material-rocket-launch:](quick-start.md){ .md-button .md-button--primary }
 [Architecture overview :material-sitemap:](architecture/index.md){ .md-button }
-[API Reference :material-code-braces:](https://[REDACTED-USER].github.io/israeli-bank-scrapers/api/){ .md-button }
+[API Reference :material-code-braces:](https://sergienko4.github.io/israeli-bank-scrapers/api/){ .md-button }
 
 ---
 
@@ -67,7 +67,7 @@ flowchart LR
     - Unified api-direct primitives across OneZero, Pepper, PayBox (signer config DU, `JsonValueTemplate`, carry derivations).
 - **v8.3.0** — Pipeline architecture v2 (Strategy / Builder / Mediator / Result patterns, phase isolation, PII redaction).
 
-See [README → Version history](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#version-history) for the full timeline.
+See [README → Version history](https://github.com/sergienko4/israeli-bank-scrapers#version-history) for the full timeline.
 
 ## Migration notice
 

--- a/docs/observability/forensic-audit.md
+++ b/docs/observability/forensic-audit.md
@@ -2,7 +2,7 @@
 
 Every scrape path (browser + api-direct) emits a **per-account audit line** during `.post`. The line is the primary debug surface for "did the scrape actually pull transactions for this account?".
 
-| Source | [`src/Scrapers/Pipeline/Mediator/Scrape/ForensicAuditAction.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Scrape/ForensicAuditAction.ts) |
+| Source | [`src/Scrapers/Pipeline/Mediator/Scrape/ForensicAuditAction.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Scrape/ForensicAuditAction.ts) |
 |---|---|
 
 ## What it looks like in `pipeline.log`

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -32,4 +32,4 @@ flowchart LR
 | **Runtime** (`PiiRedactor.ts`) | Inside Pino's `redact.censor` callback — every record runs through it before *any* transport writes | Account / card / Israeli ID / phone numbers, customer names, merchant strings, transaction amounts, auth tokens, OTP codes, URLs with PII query keys, HTML text + value attributes |
 | **Commit-time** (ESLint AST + `lint-and-validate.ts`) | Every pre-commit and CI run | Code that tries to bypass the runtime: PII identifiers interpolated into `LOG.*` template literals, full payload objects passed under `result|accounts|transactions|...` keys |
 
-If you spot something leaking past both layers, [open an issue](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues) — it's a load-bearing bug, not cosmetic.
+If you spot something leaking past both layers, [open an issue](https://github.com/sergienko4/israeli-bank-scrapers/issues) — it's a load-bearing bug, not cosmetic.

--- a/docs/observability/redaction.md
+++ b/docs/observability/redaction.md
@@ -2,7 +2,7 @@
 
 `PiiRedactor.ts` is the single source of truth. Pino runs it as the `redact.censor` callback so every record is redacted *before* any transport writes.
 
-| Source | [`src/Scrapers/Pipeline/Types/PiiRedactor.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/PiiRedactor.ts) |
+| Source | [`src/Scrapers/Pipeline/Types/PiiRedactor.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/PiiRedactor.ts) |
 |---|---|
 
 ## What gets redacted vs what survives
@@ -73,7 +73,7 @@ ESLint AST selectors reject pull requests that try to bypass the runtime layer. 
 - `LOG.<level>({ result, ... })` / `{ accounts }` / `{ transactions }` — passing whole payloads
 - `console.log` (any) — bypasses Pino entirely
 
-Source: the [`pii-template-literal`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-template-literal.canary.ts), [`pii-error-message`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-error-message.canary.ts), and [`pii-payload-key`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-payload-key.canary.ts) canary fixtures + the `PII-Log` rule in `lint-and-validate.ts`.
+Source: the [`pii-template-literal`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-template-literal.canary.ts), [`pii-error-message`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-error-message.canary.ts), and [`pii-payload-key`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/EslintCanaries/pii-payload-key.canary.ts) canary fixtures + the `PII-Log` rule in `lint-and-validate.ts`.
 
 If your new code emits a log that triggers the canary at commit time, the right fix is to extract the safe identifier first:
 

--- a/docs/phases/account-resolve.md
+++ b/docs/phases/account-resolve.md
@@ -6,7 +6,7 @@ Discover the list of accounts/cards the user has access to and the billing-cycle
 |---|---|
 | **Always-on?** | Yes (`ifBrowser`) |
 | **Owner slot** | `accountDiscovery: Option<IAccountDiscovery>` |
-| **Source** | [`AccountResolvePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/AccountResolve/AccountResolvePhase.ts) + [`AccountResolveActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.ts) |
+| **Source** | [`AccountResolvePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/AccountResolve/AccountResolvePhase.ts) + [`AccountResolveActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/api-direct-call.md
+++ b/docs/phases/api-direct-call.md
@@ -6,7 +6,7 @@ Login + OTP via JSON API. Replaces INIT → HOME → PRE-LOGIN → LOGIN → OTP
 |---|---|
 | **Always-on?** | api-direct banks only |
 | **Owner slots** | `apiMediator`, `login`, `api` |
-| **Source** | [`ApiDirectCallPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectCall/ApiDirectCallPhase.ts) + [`ApiDirectCallActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/ApiDirectCall/ApiDirectCallActions.ts) + [`Flow/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow) |
+| **Source** | [`ApiDirectCallPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectCall/ApiDirectCallPhase.ts) + [`ApiDirectCallActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/ApiDirectCall/ApiDirectCallActions.ts) + [`Flow/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow) |
 
 ## Unified api-direct primitives
 

--- a/docs/phases/api-direct-scrape.md
+++ b/docs/phases/api-direct-scrape.md
@@ -6,7 +6,7 @@ Shape-driven JSON/GraphQL walk that replaces SCRAPE + BALANCE-RESOLVE for api-di
 |---|---|
 | **Always-on?** | api-direct banks only |
 | **Owner slots** | `scrape`, `balanceResolution` |
-| **Source** | [`ApiDirectScrapePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapePhase.ts) + [`ApiDirectScrapeSteps.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeSteps.ts) |
+| **Source** | [`ApiDirectScrapePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapePhase.ts) + [`ApiDirectScrapeSteps.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeSteps.ts) |
 
 ## Sub-step contract
 
@@ -38,8 +38,8 @@ Each api-direct bank declares its own `IApiDirectScrapeShape`:
 
 | Bank | TXN query | Balance query | Source |
 |---|---|---|---|
-| OneZero | `GET_ACCOUNT_TRANSACTIONS` GraphQL | `GET_ACCOUNT_BALANCE` GraphQL | [`Banks/OneZero/scrape/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OneZero/scrape) |
-| Pepper | REST `/transactions` | REST `/balance` | [`Banks/Pepper/scrape/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pepper/scrape) |
-| PayBox | REST `/wallet/transactions` | REST `/wallet/balance` | [`Banks/PayBox/scrape/`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/PayBox/scrape) |
+| OneZero | `GET_ACCOUNT_TRANSACTIONS` GraphQL | `GET_ACCOUNT_BALANCE` GraphQL | [`Banks/OneZero/scrape/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/OneZero/scrape) |
+| Pepper | REST `/transactions` | REST `/balance` | [`Banks/Pepper/scrape/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Pepper/scrape) |
+| PayBox | REST `/wallet/transactions` | REST `/wallet/balance` | [`Banks/PayBox/scrape/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Banks/PayBox/scrape) |
 
 The shape interface (`balanceVars`, `balanceExtract`, `txnVars`, `txnExtract`) is uniform; only the per-bank closures differ.

--- a/docs/phases/auth-discovery.md
+++ b/docs/phases/auth-discovery.md
@@ -6,7 +6,7 @@ Capture the post-login auth token, API origin, cookies, and any session ids by o
 |---|---|
 | **Always-on?** | Yes (`ifBrowser`) |
 | **Owner slot** | `authDiscovery: Option<IAuthDiscovery>`, `api: Option<IApiFetchContext>` |
-| **Source** | [`AuthDiscoveryPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/AuthDiscovery/AuthDiscoveryPhase.ts) + [`AuthDiscovery.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery.ts) |
+| **Source** | [`AuthDiscoveryPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/AuthDiscovery/AuthDiscoveryPhase.ts) + [`AuthDiscovery.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/balance-resolve.md
+++ b/docs/phases/balance-resolve.md
@@ -10,7 +10,7 @@ This page is the **phase orchestrator reference**.
 |---|---|
 | **Always-on?** | Yes for browser banks (`ifBrowser`); api-direct banks emit the same `balanceResolution` via [API-DIRECT-SCRAPE.final](api-direct-scrape.md) instead |
 | **Owner slots** | `balanceFetchPlan`, `balanceResponsesByBankAccount`, `balanceExtracted`, `balanceValidation`, `balanceResolution` |
-| **Source** | [`BalanceResolvePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/BalanceResolve/BalanceResolvePhase.ts) (thin orchestrator) + [`BalanceResolveActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.ts) (all logic) |
+| **Source** | [`BalanceResolvePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/BalanceResolve/BalanceResolvePhase.ts) (thin orchestrator) + [`BalanceResolveActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.ts) (all logic) |
 
 ## Sub-step quick reference
 

--- a/docs/phases/dashboard.md
+++ b/docs/phases/dashboard.md
@@ -6,7 +6,7 @@ Pivot to the dashboard URL, prime the network capture pool by clicking a "show t
 |---|---|
 | **Always-on?** | Yes (`ifBrowser`) |
 | **Owner slots** | `dashboard: Option<IDashboardState>`, `txnEndpoint: Option<ITxnEndpoint>`, `dashboardTxnHarvest: Option<IDashboardTxnHarvest>` |
-| **Source** | [`DashboardPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Dashboard/DashboardPhase.ts) + [`DashboardPhaseActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts) |
+| **Source** | [`DashboardPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Dashboard/DashboardPhase.ts) + [`DashboardPhaseActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.ts) |
 
 ## Why a separate phase?
 

--- a/docs/phases/home.md
+++ b/docs/phases/home.md
@@ -6,7 +6,7 @@ Landing-page discovery — find the "Log in" affordance on the bank's home page 
 |---|---|
 | **Always-on?** | Yes (browser banks) |
 | **Owner slot** | `loginAreaReady: boolean`, `mediator.popupInterceptor` invocation |
-| **Source** | [`HomePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Home/HomePhase.ts), [`FindLoginAreaPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/PreLogin/FindLoginAreaPhase.ts) |
+| **Source** | [`HomePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Home/HomePhase.ts), [`FindLoginAreaPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/PreLogin/FindLoginAreaPhase.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/index.md
+++ b/docs/phases/index.md
@@ -2,7 +2,7 @@
 
 > **Who this is for:** developers wiring a new bank, debugging a phase failure, or auditing the typed contract between phases.
 
-Every phase implements [`BasePhase`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/BasePhase.ts) and owns four sub-step hooks: `pre`, `action`, `post`, `final`. The `PipelineExecutor` drives them in order and threads an immutable `IPipelineContext` snapshot between phases.
+Every phase implements [`BasePhase`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/BasePhase.ts) and owns four sub-step hooks: `pre`, `action`, `post`, `final`. The `PipelineExecutor` drives them in order and threads an immutable `IPipelineContext` snapshot between phases.
 
 ## Browser banks — 12 phases
 

--- a/docs/phases/init.md
+++ b/docs/phases/init.md
@@ -6,7 +6,7 @@ Launch the browser engine, build the initial `IPipelineContext`, navigate to the
 |---|---|
 | **Always-on?** | Yes (browser banks) |
 | **Owner slots** | `browser` (Playwright browser + context + page), `diagnostics.loginUrl`, `diagnostics.loginStartMs` |
-| **Source** | [`InitPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Init/InitPhase.ts) |
+| **Source** | [`InitPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Init/InitPhase.ts) |
 
 ## Sub-step contract
 
@@ -22,5 +22,5 @@ Launch the browser engine, build the initial `IPipelineContext`, navigate to the
 | Symptom | Likely cause |
 |---|---|
 | `TIMEOUT` | Bank URL unreachable; increase `defaultTimeout` |
-| `WAF_BLOCKED` | Cloudflare challenge at the landing page — see [README → WAF Troubleshooting](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#error-types) |
+| `WAF_BLOCKED` | Cloudflare challenge at the landing page — see [README → WAF Troubleshooting](https://github.com/sergienko4/israeli-bank-scrapers#error-types) |
 | `GENERIC` "companyId not registered" | The bank is legacy-only — falls back to `SCRAPER_REGISTRY` automatically; if you see this on a Pipeline-registered bank, the registry got out of sync |

--- a/docs/phases/login.md
+++ b/docs/phases/login.md
@@ -6,7 +6,7 @@ Resolve each credential field via the 7-strategy `SelectorResolver`, fill, submi
 |---|---|
 | **Always-on?** | Yes (`ifLoginAlways`) |
 | **Owner slot** | `login: Option<{ activeFrame, persistentOtpToken, urlBeforeSubmit }>` |
-| **Source** | [`LoginPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Login/LoginPhase.ts) + [`LoginPhaseActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts) |
+| **Source** | [`LoginPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Login/LoginPhase.ts) + [`LoginPhaseActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Login/LoginPhaseActions.ts) |
 
 ## 7-strategy SelectorResolver
 

--- a/docs/phases/otp-fill.md
+++ b/docs/phases/otp-fill.md
@@ -7,7 +7,7 @@ Invoke the user-provided `otpCodeRetriever` callback, fill the returned code int
 | **Always-on?** | No — opt-in via `ifOtpFill` predicate |
 | **Banks that use it** | All [OTP-TRIGGER](otp-trigger.md) banks + Hapoalim (conditional) |
 | **Owner slot** | `otpFill: Option<IOtpFill>` |
-| **Source** | [`OtpFillPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/OtpFill/OtpFillPhase.ts) + [`OtpFillPhaseActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/OtpFill/OtpFillPhaseActions.ts) |
+| **Source** | [`OtpFillPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/OtpFill/OtpFillPhase.ts) + [`OtpFillPhaseActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/OtpFill/OtpFillPhaseActions.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/otp-trigger.md
+++ b/docs/phases/otp-trigger.md
@@ -7,7 +7,7 @@ Ask the bank to dispatch the SMS/email OTP code. Runs only when the bank's `Logi
 | **Always-on?** | No — opt-in via `ifOtpFillAndTrigger` predicate |
 | **Banks that use it** | Beinleumi, Massad, Otsar Hahayal, Pagi (Beinleumi group) — and Hapoalim **conditionally** |
 | **Owner slot** | `otpTrigger: Option<IOtpTrigger>` |
-| **Source** | [`OtpTriggerPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/OtpTrigger/OtpTriggerPhase.ts) + [`OtpTriggerPhaseActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/OtpTrigger/OtpTriggerPhaseActions.ts) |
+| **Source** | [`OtpTriggerPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/OtpTrigger/OtpTriggerPhase.ts) + [`OtpTriggerPhaseActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/OtpTrigger/OtpTriggerPhaseActions.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/pre-login.md
+++ b/docs/phases/pre-login.md
@@ -7,7 +7,7 @@ Opt-in "show login" step for card banks that hide the password field behind a to
 | **Always-on?** | No — opt-in via `ifBrowserAndPreLogin` predicate |
 | **Banks that use it** | Amex, Isracard, Max, VisaCal |
 | **Owner slot** | `preLoginDiscovery: Option<IPreLoginDiscovery>` |
-| **Source** | [`FindLoginAreaPhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/PreLogin/FindLoginAreaPhase.ts) + [`PreLoginActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/PreLogin/PreLoginActions.ts) |
+| **Source** | [`FindLoginAreaPhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/PreLogin/FindLoginAreaPhase.ts) + [`PreLoginActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/PreLogin/PreLoginActions.ts) |
 
 ## Sub-step contract
 

--- a/docs/phases/scrape.md
+++ b/docs/phases/scrape.md
@@ -6,7 +6,7 @@ Per-account transaction walk. Emits the typed inputs that [BALANCE-RESOLVE](bala
 |---|---|
 | **Always-on?** | Yes (`ifAnyScraper`) |
 | **Owner slot** | `scrape: Option<{ accounts, accountIdentities, balanceFetchTemplate }>` |
-| **Source** | [`ScrapePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Scrape/ScrapePhase.ts) + [`ScrapePhaseActions.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhaseActions.ts) |
+| **Source** | [`ScrapePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Scrape/ScrapePhase.ts) + [`ScrapePhaseActions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhaseActions.ts) |
 
 ## Sub-step contract
 
@@ -38,7 +38,7 @@ See [Architecture → BALANCE-RESOLVE](../architecture/balance-resolve.md) for t
 | Accounts produced, all with `txns.length === 0`, AND `network.countSuccessfulResponses() > 0` | succeed (legitimate empty month) |
 | Accounts produced, all empty, AND `countSuccessfulResponses() === 0` | `Procedure fail` "scrape miss" |
 
-Test coverage: [`EmptyGateHeuristic.test.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/Scrape/EmptyGateHeuristic.test.ts).
+Test coverage: [`EmptyGateHeuristic.test.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Tests/Unit/Pipeline/Mediator/Scrape/EmptyGateHeuristic.test.ts).
 
 ## Forensic audit observability
 

--- a/docs/phases/terminate.md
+++ b/docs/phases/terminate.md
@@ -6,7 +6,7 @@ Close the browser, dispose interceptors, and produce the final `IScraperScraping
 |---|---|
 | **Always-on?** | Yes (`ifBrowser`) |
 | **Owner slot** | (none — clean-up phase) |
-| **Source** | [`TerminatePhase.ts`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Terminate/TerminatePhase.ts) |
+| **Source** | [`TerminatePhase.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Phases/Terminate/TerminatePhase.ts) |
 
 ## Sub-step contract
 
@@ -24,7 +24,7 @@ Close the browser, dispose interceptors, and produce the final `IScraperScraping
 | `pipeline.log` | Pino transport | ✅ via `PiiRedactor.censor` callback |
 | `network/*.json` | `NetworkDiscovery` capture writer | ✅ pre-write through `PiiRedactor` |
 | `screenshots/*.html` | `SafeScreenshot` DOM serializer | ✅ in-place text + value scrubs |
-| `screenshots/*.png` | `SafeScreenshot` raster | ❌ **not** OCR-redacted — see [Bug Reports](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#filing-a-bug-report) |
+| `screenshots/*.png` | `SafeScreenshot` raster | ❌ **not** OCR-redacted — see [Bug Reports](https://github.com/sergienko4/israeli-bank-scrapers#filing-a-bug-report) |
 
 ## Cleanup invariants
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,7 +5,7 @@ Get the first transaction from Bank Hapoalim in three steps.
 ## 1. Install
 
 ```sh
-npm install @[REDACTED-USER]/israeli-bank-scrapers
+npm install @sergienko4/israeli-bank-scrapers
 ```
 
 Requirements:
@@ -19,7 +19,7 @@ Requirements:
 ## 2. Scrape
 
 ```typescript
-import { CompanyTypes, createScraper } from '@[REDACTED-USER]/israeli-bank-scrapers';
+import { CompanyTypes, createScraper } from '@sergienko4/israeli-bank-scrapers';
 
 const scraper = createScraper({
   companyId: CompanyTypes.Hapoalim,
@@ -67,5 +67,5 @@ The `balance` field is populated by [BALANCE-RESOLVE.final](phases/balance-resol
 
 - Bank not Hapoalim? — pick yours in [Banks](banks/index.md); each page lists credentials + OTP behavior + known quirks.
 - Need OTP? — see [Phase → OTP-TRIGGER](phases/otp-trigger.md) and [OTP-FILL](phases/otp-fill.md).
-- WAF block? — [Error Types → WAF Troubleshooting](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#error-types) in the README.
-- Parallel scraping? — [README → Advanced Usage](https://github.com/[REDACTED-USER]/israeli-bank-scrapers#advanced-usage).
+- WAF block? — [Error Types → WAF Troubleshooting](https://github.com/sergienko4/israeli-bank-scrapers#error-types) in the README.
+- Parallel scraping? — [README → Advanced Usage](https://github.com/sergienko4/israeli-bank-scrapers#advanced-usage).

--- a/docs/workflow/branch-flow.md
+++ b/docs/workflow/branch-flow.md
@@ -34,7 +34,7 @@ Every commit subject must follow the Conventional Commits format:
 2. Make the change. Run `npm run test:unit` + `npm run lint` locally.
 3. Commit (the pre-commit hook runs the full 12 gates).
 4. Push + open the PR. CI re-runs the same gates.
-5. Wait for `@[REDACTED-USER]` (CODEOWNER) review.
+5. Wait for `@sergienko4` (CODEOWNER) review.
 6. Squash-merge once approved + CI green. Commit subject must still be Conventional.
 
 ## release-please cadence
@@ -44,7 +44,7 @@ Every commit subject must follow the Conventional Commits format:
     1. Bumps the version in `package.json`
     2. Updates `CHANGELOG.md`
     3. Tags the commit
-    4. Triggers the `npm-publish` workflow → publishes to npm as `@[REDACTED-USER]/israeli-bank-scrapers@<new-version>`
+    4. Triggers the `npm-publish` workflow → publishes to npm as `@sergienko4/israeli-bank-scrapers@<new-version>`
 
 You don't manually edit `CHANGELOG.md` or `package.json` for versions — release-please owns both.
 

--- a/docs/workflow/code-review-tooling.md
+++ b/docs/workflow/code-review-tooling.md
@@ -9,7 +9,7 @@ This repo runs two automated review tools on every PR:
 | **CodeRabbit** | Walkthrough comment + inline review threads + summary review | `.coderabbit.yaml` (root) — see [config rationale](#coderabbit-config-rationale) below |
 | **SonarCloud Scan** | New-issue list bound to the PR | `sonar-project.properties` + the `SonarCloud Scan` CI job |
 
-Both tools surface findings on PR-open and on every push. The C8 step of the [post-PR checklist](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/main/.github/PULL_REQUEST_TEMPLATE.md) requires the maintainer to **pull every open finding, verify against the current working tree, and either fix or document a disposition before requesting re-review**.
+Both tools surface findings on PR-open and on every push. The C8 step of the [post-PR checklist](https://github.com/sergienko4/israeli-bank-scrapers/blob/main/.github/PULL_REQUEST_TEMPLATE.md) requires the maintainer to **pull every open finding, verify against the current working tree, and either fix or document a disposition before requesting re-review**.
 
 The query commands below are the canonical way to do that pull — they do not depend on the GitHub web UI rendering finished by the time you check.
 
@@ -60,7 +60,7 @@ SonarCloud's web project is public, so its REST search API is reachable without 
 
 ```bash
 curl -sS "https://sonarcloud.io/api/issues/search?\
-componentKeys=[REDACTED-USER]_israeli-bank-scrapers&\
+componentKeys=sergienko4_israeli-bank-scrapers&\
 pullRequest={N}&\
 issueStatuses=OPEN,CONFIRMED&\
 sinceLeakPeriod=true&\
@@ -80,7 +80,7 @@ ps=100" | \
 
 ```bash
 curl -sS "https://sonarcloud.io/api/qualitygates/project_status?\
-projectKey=[REDACTED-USER]_israeli-bank-scrapers&\
+projectKey=sergienko4_israeli-bank-scrapers&\
 pullRequest={N}" | jq '.projectStatus.status'
 ```
 

--- a/docs/workflow/pre-commit.md
+++ b/docs/workflow/pre-commit.md
@@ -2,7 +2,7 @@
 
 Driven by [husky](https://typicode.github.io/husky/). Runs every quality gate in parallel before any commit lands locally.
 
-| Source | [`.husky/pre-commit`](https://github.com/[REDACTED-USER]/israeli-bank-scrapers/blob/{{BRANCH}}/.husky/pre-commit) |
+| Source | [`.husky/pre-commit`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/.husky/pre-commit) |
 |---|---|
 
 ## Phase 1 — Prettier autoformat

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
 site_name: Israeli Bank Scrapers
 site_description: Scrape transactions from 19 Israeli banks and credit card companies with built-in Cloudflare WAF bypass and end-to-end PII redaction.
-site_url: https://[REDACTED-USER].github.io/israeli-bank-scrapers/
-repo_url: https://github.com/[REDACTED-USER]/israeli-bank-scrapers
-repo_name: [REDACTED-USER]/israeli-bank-scrapers
+site_url: https://sergienko4.github.io/israeli-bank-scrapers/
+repo_url: https://github.com/sergienko4/israeli-bank-scrapers
+repo_name: sergienko4/israeli-bank-scrapers
 edit_uri: edit/main/docs/
 copyright: |
-  &copy; <a href="https://github.com/[REDACTED-USER]">[REDACTED-USER]</a> &middot; MIT &middot; based on <a href="https://github.com/eshaham/israeli-bank-scrapers">eshaham/israeli-bank-scrapers</a>
+  &copy; <a href="https://github.com/sergienko4">sergienko4</a> &middot; MIT &middot; based on <a href="https://github.com/eshaham/israeli-bank-scrapers">eshaham/israeli-bank-scrapers</a>
 
 docs_dir: docs
 site_dir: site
@@ -114,9 +114,9 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/[REDACTED-USER]/israeli-bank-scrapers
+      link: https://github.com/sergienko4/israeli-bank-scrapers
     - icon: fontawesome/brands/npm
-      link: https://www.npmjs.com/package/@[REDACTED-USER]/israeli-bank-scrapers
+      link: https://www.npmjs.com/package/@sergienko4/israeli-bank-scrapers
   status:
     new: New in v8.4
     deprecated: Legacy — scheduled for migration to Pipeline
@@ -189,4 +189,4 @@ nav:
       - Adding a new bank: contributing/new-bank.md
       - Test surfaces: contributing/testing.md
       - Code style & lint: contributing/lint.md
-  - API Reference: https://[REDACTED-USER].github.io/israeli-bank-scrapers/api/
+  - API Reference: https://sergienko4.github.io/israeli-bank-scrapers/api/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@[REDACTED-USER]/israeli-bank-scrapers",
+  "name": "@sergienko4/israeli-bank-scrapers",
   "version": "8.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@[REDACTED-USER]/israeli-bank-scrapers",
+      "name": "@sergienko4/israeli-bank-scrapers",
       "version": "8.4.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@[REDACTED-USER]/israeli-bank-scrapers",
+  "name": "@sergienko4/israeli-bank-scrapers",
   "version": "8.4.0",
   "description": "Scrape transactions from all 18 Israeli banks with Cloudflare WAF bypass (Camoufox + Playwright)",
   "engines": {
@@ -76,7 +76,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/[REDACTED-USER]/israeli-bank-scrapers.git"
+    "url": "git+https://github.com/sergienko4/israeli-bank-scrapers.git"
   },
   "keywords": [
     "israel",
@@ -95,9 +95,9 @@
   "author": "Elad Shaham",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/[REDACTED-USER]/israeli-bank-scrapers/issues"
+    "url": "https://github.com/sergienko4/israeli-bank-scrapers/issues"
   },
-  "homepage": "https://github.com/[REDACTED-USER]/israeli-bank-scrapers#readme",
+  "homepage": "https://github.com/sergienko4/israeli-bank-scrapers#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@eslint/js": "^10.0.1",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,7 @@
 {
   "entryPoints": ["src/index.ts", "src/transactions.ts", "src/scrapers/interface.ts", "src/definitions.ts", "src/scrapers/errors.ts"],
   "out": "typedoc-build",
-  "name": "@[REDACTED-USER]/israeli-bank-scrapers",
+  "name": "@sergienko4/israeli-bank-scrapers",
   "readme": "README.md",
   "includeVersion": true,
   "excludePrivate": true,
@@ -10,8 +10,8 @@
   "excludeExternals": true,
   "searchInComments": true,
   "navigationLinks": {
-    "GitHub": "https://github.com/[REDACTED-USER]/israeli-bank-scrapers",
-    "npm": "https://www.npmjs.com/package/@[REDACTED-USER]/israeli-bank-scrapers"
+    "GitHub": "https://github.com/sergienko4/israeli-bank-scrapers",
+    "npm": "https://www.npmjs.com/package/@sergienko4/israeli-bank-scrapers"
   },
   "plugin": [],
   "skipErrorChecking": false,


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Status | Verification |
|---|---|---|---|
|  1 | Conventional Commits + Co-authored-by trailer (commit-guidlines.md) | ✅ | 1 commit `fix(metadata): ...` with `Co-authored-by: Copilot` trailer |
|  2 | One PR == one logical change (pr-guidlines.md §1) | ✅ | Scope = hot-fix the filter-repo over-scrub bug only |
|  3 | ZERO CSS selectors in interaction code (CLAUDE.md) | ✅ N/A | No interaction code touched — only metadata files |
|  4 | CLEAN_CODE.md function/file/complexity caps | ✅ N/A | No source code logic touched |
|  5 | `npm run lint` exit 0 | ✅ | Verified locally |
|  6 | `npm run lint:fixtures-pii` 0 hits | ✅ | 165 fixtures / 0 PII hits |
|  7 | `npm run type-check` | ⚠️ EXPECTED FAIL | Type-check is broken on `origin/main` due to filter-repo leaving bare-identifier tokens (`[REDACTED-ACCT-6]` etc.) in 7 test files. **PR-2 (PII infrastructure + sweep) fixes those.** This PR intentionally addresses only the metadata over-scrub bug to keep file count tight (65 files) and reviewable as a hot-fix |
|  8 | No PII or customer identifiers in code/tests/commits (pr-guidlines.md §13) | ✅ | 0 `sergienko4` hits in `src/`, `scripts/`, `tests/`; verified via `git grep -l 'sergienko4' -- src/ scripts/ tests/` |
|  9 | Husky pre-commit gates pass (before-commit-guidlines.md) | ✅ | Cherry-pick honored all 23 husky gates |
| 10 | Public API byte-identical at `lib/index.cjs` | ✅ | No source code surface changes — only `package.json` metadata (name + URLs) |

## Why

The PII history rewrite (`git filter-repo`) over-aggressively replaced the npm scope / GitHub username `sergienko4` with `[REDACTED-USER]` in **65 metadata files**, breaking:

- **`package.json`** — the npm package name was rewritten to `@[REDACTED-USER]/israeli-bank-scrapers`, which is unpublishable
- **`package-lock.json`** — matching scope reference
- **`.github/dependabot.yml`** — reviewer was set to `[REDACTED-USER]`, failing the dependabot config validator on every PR (the "fail" status check on `.github/dependabot.yml`)
- **`docs/**/*.md`** — 50 documentation pages had GitHub-source URLs pointing to `github.com/[REDACTED-USER]/...` which 404, causing the **lychee link checker step in `Validate` job to fail with 200+ broken-link errors**
- **`README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`** — public-facing repository metadata
- **`.github/CODEOWNERS`, `.github/FUNDING.yml`, `.github/docs-coverage-allowlist.txt`, `.github/workflows/pr.yml`** — GitHub config
- **`CLAUDE.md`, `mkdocs.yml`, `typedoc.json`** — tooling/docs config

Per operator clarification: `sergienko4` is the **public npm scope and GitHub repo owner** (`github.com/sergienko4/israeli-bank-scrapers`). It is intentionally visible in metadata files. Only pipeline/test code (`src/`, `scripts/`, `tests/`) must stay scrubbed of operator references.

This PR restores `sergienko4` in those 65 metadata files. **0 `sergienko4` occurrences are reintroduced into `src/`, `scripts/`, or `tests/`** — the PII guard remains intact.

## What

Single commit `99eb511c`: pure 1-line swaps in 65 files (292 insertions, 292 deletions). Every `[REDACTED-USER]` → `sergienko4`.

**Files changed by category** (65 total):
- npm package: `package.json`, `package-lock.json`
- Root markdown: `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CLAUDE.md`
- `.github/`: `CODEOWNERS`, `FUNDING.yml`, `dependabot.yml`, `docs-coverage-allowlist.txt`, `workflows/pr.yml`
- Tooling: `mkdocs.yml`, `typedoc.json`
- `docs/`: 50 markdown files under `architecture/`, `banks/`, `contributing/`, `observability/`, `phases/`, `workflow/`, plus `index.md` + `quick-start.md`

## Test plan

- [x] `npm run lint:fixtures-pii` passes (165 files / 0 hits)
- [x] No `sergienko4` reintroduced into `src/`, `scripts/`, `tests/` — verified via `git grep`
- [x] `package.json` name is back to `@sergienko4/israeli-bank-scrapers` (npm-publishable)
- [x] `dependabot.yml` reviewer is valid GitHub user
- [ ] `npm run type-check` — fails on `origin/main` due to 7 test files with bare-identifier tokens; **fixed by follow-up PR-2**

## Docs

- [x] N/A — metadata restoration only; no user-visible behaviour change

## CI / security

- [x] no new secrets committed
- [x] no PII or customer identifiers reintroduced into pipeline/test code
- [x] no new third-party actions
- [x] no new shell scripts

## Notes for reviewer

**This is the first of 4 sequential PRs** splitting the original 220-file PR #318:

1. **PR-1 (this PR)** — PII over-scrub metadata hot-fix (65 files) — fixes lychee + dependabot failures on `main`
2. **PR-2** — PII infrastructure + test data restoration + fixture sweep (~95 files) — depends on PR-1; fixes type-check
3. **PR-3** — Discount Mode A static drive (~62 files) — depends on PR-2
4. **PR-4** — Discount Mode B SIMULATOR drive (~3 files) — depends on PR-3

**Expected CI status for this PR:**
- ✅ Lychee link checker (restored)
- ✅ `.github/dependabot.yml` validator (restored)
- ✅ `npm run lint:fixtures-pii`
- ✅ PR Body Compliance, PR Title, CodeRabbit, zizmor
- ⚠️ `Validate` job — will partially fail on `Unit tests with coverage` + `Type check` because main has 7 test files with bare-identifier tokens (`[REDACTED-ACCT-6]`, `[REDACTED-USER]`). **PR-2 fixes those.** Reviewer can land this PR with that step yellow; PR-2 turns it green.
