### PR TITLE
fix(harvest): update isracard recipe URL — login form moved to /personalarea/Login/

### DIFF
--- a/src/Tests/Integration/Tools/PostLoginRecipes.ts
+++ b/src/Tests/Integration/Tools/PostLoginRecipes.ts
@@ -310,7 +310,8 @@ interface IBankRecipe {
 const BANK_RECIPES: Readonly<Partial<Record<string, IRecipeBody>>> = {
   isracard: {
     steps: [
-      { stepName: '02-pre-login', url: 'https://digital.isracard.co.il' },
+      { stepName: '01-home', url: 'https://www.isracard.co.il' },
+      { stepName: '02-pre-login', url: 'https://digital.isracard.co.il/personalarea/Login/' },
       { stepName: '03-after-flip', revealText: 'או כניסה עם סיסמה קבועה' },
     ],
   },


### PR DESCRIPTION
## Why

Isracard redesigned `https://digital.isracard.co.il`: the bare host is now a marketing/landing page (4.6MB, no login form, no `otpLobbyFormPassword`). The login form moved to `https://digital.isracard.co.il/personalarea/Login/`.

The harvest recipe in `BANK_RECIPES.isracard` still pointed at the old bare host, so `npx tsx HarvestBankHtml.ts isracard --include-post-login --mode-a-harvest` captured the marketing page at `02-pre-login` and then timed out at `03-after-flip` waiting for the password tab text (`או כניסה עם סיסמה קבועה`) that the marketing page does not contain.

## What

`src/Tests/Integration/Tools/PostLoginRecipes.ts` (1 file, +2/-1):

1. Added new `01-home` step pointing at the public marketing site (`https://www.isracard.co.il`) — consistent with the Discount/Hapoalim recipes that also capture the public marketing home.
2. Updated `02-pre-login` URL from bare `https://digital.isracard.co.il` to `https://digital.isracard.co.il/personalarea/Login/` (the actual login form URL).

The third step (`03-after-flip` `revealText`) is unchanged — the password tab text is still present at the new URL.

## Guideline compliance

| # | Rule | This PR |
|---|------|---------|
| §1 | ONE logical change per PR | ✅ recipe URL fix only — no fixture changes, no production scraper changes, no test changes |
| §2 | Title format `<type>(<scope>): <subject>` | ✅ `fix(harvest): update isracard recipe URL …` |
| §3 | Why → What → Compliance → Validation body | ✅ this body |
| §4 | Husky gates passed (no `--no-verify`) | ✅ all 23 gates green at `db684e42` |
| §5 | Conventional commit | ✅ `fix(harvest)` |
| §6 | File count under 150 | ✅ 1 file |
| §7 | No CSS selectors in interaction code | ✅ recipe is URL + visible Hebrew text only |
| §8 | TypeScript strict, no `any` | ✅ no type changes |
| §9 | Methods ≤10 lines | ✅ no method changes |
| §10 | No magic numbers | ✅ no numeric changes |
| §11 | Docs updated if behaviour changed | ✅ N/A (recipe is operator-facing infra; behaviour change documented in commit body) |
| §12 | Cross-cuts captured | ✅ none — recipe-only, runtime-only |
| §13 | PII clean | ✅ no fixtures committed; URLs are public marketing/login endpoints |
| §14 | Existing tests unaffected | ✅ verified: Mode A + Mode B + e2e:mock + e2e:real all green at commit time |
| §15 | A3.5 exit-gate evidence captured | ✅ see Validation table below |

## Validation evidence (husky 23-gate ladder green on `db684e42`, no `--no-verify`)

| Gate | Result |
|------|--------|
| Phase 1 prettier | ✅ |
| Phase 2 (parallel 15 gates: tsc / eslint / biome / audit / lint:phases:strict / architecture / build / canaries / dead-code / guideline-coverage / bank-coverage / fixtures-pii / docs-staleness / test:pipeline / bank-tests / test:mock) | ✅ all green |
| Phase 2b test:e2e:mock | ✅ |
| Phase 4 Mode A (3 suites, 49 pass / 5 skip, 185s) | ✅ incl. Discount.modeA 27s + Hapoalim.modeA 23s + LoginFormDiscovery 134s |
| Phase 4 Mode B (3 suites, 7 pass / 6 skip, 62s) | ✅ incl. Mirror 61s + Hapoalim.modeB + Discount.modeB |
| Phase 5 e2e:real | ✅ 0/0 (no-op per operator's run-real-suite list) |
| post-commit metrics snapshot | ✅ husky gate count 23 · 1287 src TS files · 993834 lib/index.cjs bytes |

## Scope clarification

This PR is **recipe-only**. It does NOT:

- Add new committed fixtures (existing isracard lobby fixtures continue to work for Mode A / Mode B tests; future re-harvest is what consumes the new recipe URL)
- Touch any production scraper code (the recipe lives in the test harvester `Tools/` directory)
- Affect any existing test (the recipe is consumed only by the `HarvestBankHtml.ts` CLI at runtime, not by tests)

## Operator-facing follow-up (separate work)

Reaching 8-phase Mode A + Mode B parity with Discount / Hapoalim for isracard requires operator harvest of post-login phases (`07-auth-discovery` → `11-balance`). During this PR's verification, the operator harvest attempt got past pre-login + login-action successfully (3 pre-login phases captured cleanly at the new URL, with valid `otpLobbyFormSms` + `otpLobbyFormPassword` + password input) but then failed at the `urlIncludes: 'NewAccountTransactions'` waitFor step.

Likely causes (operator must triage before re-running harvest):

1. **Stale credentials** — `ISRACARD_ID` / `ISRACARD_CARD6DIGITS` / `ISRACARD_PASSWORD` in `.env` may be expired; the captured `04-login-action.html` still shows the login form title `כניסה והרשמה לאזור האישי` (form re-rendered with error).
2. **Newly-required OTP** — if Isracard recently enabled OTP for harvest-host IPs, the recipe needs new `05-otp-trigger` + `06-otp-fill` snapshot steps (template: `BEINLEUMI_POST_LOGIN`).
3. **Post-login URL pattern change** — Isracard may have renamed the dashboard route; `urlIncludes: 'NewAccountTransactions'` in `ISRACARD_POST_LOGIN` would then need updating to the new pattern (operator can confirm by logging in manually and observing the dashboard URL).

This is tracked as separate isracard Mode A + Mode B PR work — it cannot start until operator triages the post-login blocker above.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
