### PR TITLE
test(pipeline): Phase 2 Seq #1 coverage closeout — lift branch buffer 95.0→95.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ tasks/
 scripts/**
 !scripts/audit-fixtures-pii.cjs
 !scripts/sweep-fixtures-pii.ts
+!scripts/validate-pr-body.mjs
 
 # Stale lint-output left by an older verify-script version. Current
 # src/Scrapers/Pipeline/EslintCanaries/verify.sh writes to os.tmpdir(),

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Pre-push PR-body validator.
+#
+# Mirrors `.github/workflows/pr-body-check.yml` locally. CR cycle PR
+# #336 #1 paired a CR finding with a CI failure on `Validate PR body
+# sections` — the PR was opened without the mandatory headers because
+# nothing validated the body locally. This hook closes that gap.
+#
+# Activation: opt-in. The hook validates ONLY when a PR-body file is
+# discoverable via one of:
+#
+#   1. `PR_BODY_FILE` environment variable  — explicit path
+#   2. `.git/PR_BODY.md`                    — standard local artifact
+#   3. `.github/PR_BODY.md`                 — alternate location
+#
+# Otherwise the hook prints a hint and exits 0 — most pushes (work-in-
+# progress + branch syncing) happen BEFORE the PR body exists, so the
+# default must be non-blocking. The agent / contributor writes the body
+# file before `gh pr create` to get local validation.
+#
+# Skip with `--no-verify` only in emergencies (the CI check still
+# blocks merges).
+set -o pipefail
+
+PR_BODY_PATH=""
+if [ -n "${PR_BODY_FILE:-}" ] && [ -f "${PR_BODY_FILE}" ]; then
+    PR_BODY_PATH="${PR_BODY_FILE}"
+elif [ -f ".git/PR_BODY.md" ]; then
+    PR_BODY_PATH=".git/PR_BODY.md"
+elif [ -f ".github/PR_BODY.md" ]; then
+    PR_BODY_PATH=".github/PR_BODY.md"
+fi
+
+if [ -z "${PR_BODY_PATH}" ]; then
+    echo "ℹ️  pre-push: no PR_BODY_FILE / .git/PR_BODY.md / .github/PR_BODY.md found — skipping PR-body validation"
+    echo "   (CI 'Validate PR body sections' still enforces the gate on PR open/edit)"
+    exit 0
+fi
+
+echo "🔍 pre-push: validating PR body at ${PR_BODY_PATH}"
+if ! node scripts/validate-pr-body.mjs --file "${PR_BODY_PATH}"; then
+    echo ""
+    echo "❌ pre-push: PR body validation failed. Fix ${PR_BODY_PATH} or unset PR_BODY_FILE."
+    echo "   See .github/PULL_REQUEST_TEMPLATE.md for the canonical layout."
+    exit 1
+fi
+
+echo "✅ pre-push: PR body OK"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,16 @@ Published as `@sergienko4/israeli-bank-scrapers` on npm.
 - Only attempt full commit when targeted tests pass
 - If commit hook gate 7 (real E2E) fails: READ THE LOG, investigate, don't retry blindly
 
+### Pre-Push / PR Protocol
+- Write the PR body to `.git/PR_BODY.md` (gitignored) **before** running `gh pr create`
+- Validate locally with `npm run lint:pr-body -- --file .git/PR_BODY.md`
+  (mirrors the CI `Validate PR body sections` gate — checks for `## Why`,
+  `## What`, `## Guideline compliance` per `pr-guidlines.md` §7 + §10)
+- The `.husky/pre-push` hook auto-runs the same validation when it finds
+  `PR_BODY_FILE`, `.git/PR_BODY.md`, or `.github/PR_BODY.md`
+- Open the PR with `gh pr create --body-file .git/PR_BODY.md`
+- See [docs/workflow/pre-push.md](./docs/workflow/pre-push.md) for the full workflow
+
 ## Workflow
 
 1. Branch from `main`: `git checkout -b fix/description`

--- a/docs/workflow/ci.md
+++ b/docs/workflow/ci.md
@@ -20,6 +20,7 @@ GitHub Actions runs every gate on every PR. The matrix below is the source of tr
 | **Mock suite (orchestrated)** | `test:mock` | `scripts/run-mock-suite.ts` driving all configured banks | Same fixtures |
 | **Bank tests** | `test:e2e-factory-tests` | Phase H cross-bank factory drives every phase per bank | `src/Tests/Unit/Pipeline/CrossValidation/Phases/` |
 | **Build** | `build` | `tsup` ESM + CJS bundle | `lib/index.{mjs,cjs,d.ts,d.cts}` produced |
+| **PR body compliance** | n/a (server-side `actions/github-script`) | PR body missing one of the 3 mandatory sections (`## Why`, `## What`, `## Guideline compliance`) | `.github/workflows/pr-body-check.yml` — mirrored locally by [`npm run lint:pr-body`](pre-push.md) |
 
 ## Coverage thresholds
 

--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -8,6 +8,7 @@
 |---|---|
 | [CI gates](ci.md) | Every check that runs on a PR, what fails it, where to look for the log |
 | [Pre-commit hook](pre-commit.md) | 12 quality gates run in parallel before any commit lands locally |
+| [Pre-push hook](pre-push.md) | Opt-in PR-body validator mirroring the `Validate PR body sections` CI gate |
 | [Branch flow & release-please](branch-flow.md) | Branch policy, PR rules, release-please automated versioning |
 | [Code-review tooling](code-review-tooling.md) | How to query CodeRabbit + SonarCloud findings via API + the OSS rate-limit posture in `.coderabbit.yaml` |
 

--- a/docs/workflow/pre-push.md
+++ b/docs/workflow/pre-push.md
@@ -1,0 +1,75 @@
+# Pre-push hook
+
+A lightweight, opt-in hook that mirrors the `Validate PR body sections` CI gate locally so PR bodies can be validated **before** opening / updating the PR.
+
+| Source | [`.husky/pre-push`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/.husky/pre-push) |
+|---|---|
+
+## What it does
+
+If the hook finds a PR body file at one of these paths it validates that the file contains the three mandatory headers required by [`.github/workflows/pr-body-check.yml`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/.github/workflows/pr-body-check.yml):
+
+| Source (in priority order) | Why |
+|---|---|
+| `PR_BODY_FILE=<path>` environment variable | Explicit pointer used by automation / agents |
+| `.git/PR_BODY.md` | Per-repo, gitignored by default (lives under `.git/`) |
+| `.github/PR_BODY.md` | Versioned alternative for teams that prefer it |
+
+If none of those are present the hook prints a hint and exits 0 (most pushes are work-in-progress + branch syncing — the body doesn't exist yet).
+
+## Required headers
+
+| Header | `pr-guidlines.md` cite |
+|---|---|
+| `## Guideline compliance` | §10 — compliance table |
+| `## Why` | §7 — motivation paragraph |
+| `## What` | §7 — bullet list of touched files |
+
+These are the same three headers the CI workflow enforces on every PR open / edit / synchronise.
+
+## Manual invocation
+
+The validator runs as a standalone npm script too:
+
+```bash
+# Validate a file
+npm run lint:pr-body -- --file .git/PR_BODY.md
+
+# Validate via env var
+PR_BODY_FILE=.git/PR_BODY.md npm run lint:pr-body
+
+# Pipe from another tool
+gh pr view 336 --json body -q .body | node scripts/validate-pr-body.mjs --stdin
+```
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Body contains all mandatory sections |
+| `1` | At least one mandatory section is missing |
+| `2` | Usage error (no source provided / file unreadable) |
+
+## Why this hook exists
+
+CR cycle PR #336 #1 paired a CodeRabbit code finding with a CI failure on `Validate PR body sections` — the PR was opened without the mandatory headers because nothing validated the body locally. This hook closes the gap so contributors and agents (who write the body file before invoking `gh pr create --body-file …`) get the same enforcement the CI workflow applies after the PR is opened.
+
+Bot-author exemption (Dependabot, release-please, github-actions) lives **only** on the CI side — local pushes from a human contributor always validate when a body file is discoverable.
+
+## Recommended workflow
+
+```bash
+# 1. Write the PR body to the standard local artifact path
+$EDITOR .git/PR_BODY.md
+
+# 2. Optional: validate without pushing
+npm run lint:pr-body -- --file .git/PR_BODY.md
+
+# 3. Push — the pre-push hook validates again
+git push
+
+# 4. Open the PR with the validated body
+gh pr create --body-file .git/PR_BODY.md
+```
+
+## Bypassing the hook (don't)
+
+The hook can be bypassed with `git push --no-verify`. Don't. The CI gate still blocks the PR until the body is fixed, wasting your iteration time.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -331,6 +331,25 @@ const PHASE_10_INTEGRATION_FILES = [
   'src/Tests/Unit/Integration/**/*.ts',
 ];
 
+// Phase 10 wave 2 — Pipeline coverage-closeout tests (PR #336 Seq #1).
+// Closes the gap CR cycle PR #336 #1 exposed: `buildEndpoint` shipped
+// at 12 LoC inside `ApiOriginDiscovery.test.ts`, but §7's broad
+// `src/Tests/**` override at line 866 turns `max-lines-per-function`
+// OFF entirely, so the ≤10-LoC cap from CLEAN_CODE.md §1 + CLAUDE.md
+// (Max 10 lines per method) was unenforceable. This wave re-arms the
+// cap on NEW pipeline-mirroring tests using BOTH:
+//   • `phase9-local/fn-declaration-max-lines:10` — line-count guard
+//   • `max-lines-per-function:10` + `max-statements:10` — built-in
+//     guards (overrides the §7 OFF on these specific paths).
+// Globs are deliberately narrow: the touched files + their immediate
+// directories. A future "wave 3" widens to all `src/Tests/Unit/Pipeline/**`
+// after the existing 2 317 violators are drained (Phase 9-style sweep).
+const PHASE_10_WAVE_2_PIPELINE_HARDENING_TESTS = [
+  'src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts',
+  'src/Tests/Unit/Pipeline/Mediator/Network/Scoring/**/*.test.ts',
+  'src/Tests/Unit/Pipeline/Types/PiiRedactor/JsonBody.test.ts',
+];
+
 const RESTRICTED_SYNTAX_RULES_NEW = [
   // 1. Coverage Bypasses
   {
@@ -2518,6 +2537,48 @@ export default tseslint.config(
   // proves §19.10 fires on a function §19.9 would miss.
   {
     files: ['src/Scrapers/Pipeline/EslintCanaries/test-helper-over-10-lines.canary.ts'],
+    plugins: { 'phase9-local': phase9LocalPlugin },
+    rules: {
+      'phase9-local/fn-declaration-max-lines': ['error', { max: 10 }],
+    },
+  },
+
+  // 19.11 PHASE 10 WAVE 2 — Pipeline coverage-closeout tests (PR #336
+  // Seq #1) MUST mirror the production ≤10-LoC cap. CR cycle #1 caught
+  // a 12-LoC `buildEndpoint` helper inside `ApiOriginDiscovery.test.ts`
+  // that ESLint silently allowed — because §7's broad `src/Tests/**`
+  // override at line 866 turns `max-lines-per-function` OFF entirely.
+  //
+  // Why only `phase9-local/fn-declaration-max-lines` here (and NOT the
+  // built-in `max-lines-per-function` / `max-statements`): the built-in
+  // rules fire on EVERY `describe`/`it` arrow callback (per the §19.10
+  // docstring, ~3 049 violators in `src/Tests/**` per AST audit) which
+  // makes them unusable on test files. The phase9-local rule fires
+  // ONLY on named `FunctionDeclaration`s — exactly the slip-class CR
+  // cycle #1 exposed (`function buildEndpoint() {}` over 10 lines).
+  // Statement-count enforcement is already provided by
+  // `TEST_HELPER_OVER_10_STMTS_RULE` wired into §7's `no-restricted-syntax`
+  // at line 877 — so we don't double up here.
+  //
+  // Globs are deliberately narrow: the 3 files PR #336 added + the
+  // Scoring/** glob so future co-located tests inherit. A wave 3
+  // widens to all `src/Tests/Unit/Pipeline/**` after the existing
+  // 2 317 violators are drained (Phase 9-style sweep).
+  {
+    files: PHASE_10_WAVE_2_PIPELINE_HARDENING_TESTS,
+    plugins: { 'phase9-local': phase9LocalPlugin },
+    rules: {
+      'phase9-local/fn-declaration-max-lines': ['error', { max: 10 }],
+    },
+  },
+
+  // 19.11 CANARY — re-enable §19.11 on a single fixture under
+  // `EslintCanaries/` (globally ignored at line 539) so `verify.sh`
+  // can confirm the wave-2 guardrail stays armed. Fixture is a
+  // 14-line named FunctionDeclaration — proves the wave-2 rule
+  // fires on the slip-class CR cycle PR #336 #1 exposed.
+  {
+    files: ['src/Scrapers/Pipeline/EslintCanaries/test-pipeline-hardening-fn-over-cap.canary.ts'],
     plugins: { 'phase9-local': phase9LocalPlugin },
     rules: {
       'phase9-local/fn-declaration-max-lines': ['error', { max: 10 }],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -337,10 +337,16 @@ const PHASE_10_INTEGRATION_FILES = [
 // `src/Tests/**` override at line 866 turns `max-lines-per-function`
 // OFF entirely, so the ≤10-LoC cap from CLEAN_CODE.md §1 + CLAUDE.md
 // (Max 10 lines per method) was unenforceable. This wave re-arms the
-// cap on NEW pipeline-mirroring tests using BOTH:
-//   • `phase9-local/fn-declaration-max-lines:10` — line-count guard
-//   • `max-lines-per-function:10` + `max-statements:10` — built-in
-//     guards (overrides the §7 OFF on these specific paths).
+// cap on NEW pipeline-mirroring tests via:
+//   • `phase9-local/fn-declaration-max-lines:10` — line-count guard on
+//     `FunctionDeclaration` only. The built-in `max-lines-per-function`
+//     and `max-statements` rules are deliberately NOT added because they
+//     fire on every `describe`/`it`/`beforeEach` arrow callback (see
+//     §19.10 docstring — ~3 049 violators across `src/Tests/**`).
+//   • Statement-count enforcement on named helpers already comes from
+//     `TEST_HELPER_OVER_10_STMTS_RULE` wired into §7's `no-restricted-
+//     syntax` block at line 877 — no new `max-statements` override is
+//     needed here.
 // Globs are deliberately narrow: the touched files + their immediate
 // directories. A future "wave 3" widens to all `src/Tests/Unit/Pipeline/**`
 // after the existing 2 317 violators are drained (Phase 9-style sweep).

--- a/jest.pipeline.config.cjs
+++ b/jest.pipeline.config.cjs
@@ -55,7 +55,11 @@ module.exports = {
   coverageReporters: ['text-summary', 'lcov', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 95,
+      // Phase 2 closeout (Seq #1): bumped from 95 -> 95.1 after adding
+      // MethodBundles / ApiOriginDiscovery / JsonBody coverage tests
+      // lifted measured branches from 94.98% -> 95.14% (effective
+      // global excluding per-glob overrides: 95.11% -> 95.28%).
+      branches: 95.1,
       functions: 97,
       lines: 98,
       statements: 97,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
       - Overview: workflow/index.md
       - CI gates: workflow/ci.md
       - Pre-commit hook: workflow/pre-commit.md
+      - Pre-push hook: workflow/pre-push.md
       - Branch flow & release-please: workflow/branch-flow.md
       - Code-review tooling (CodeRabbit + SonarCloud): workflow/code-review-tooling.md
   - Contributing:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lint:fixtures-pii": "node scripts/audit-fixtures-pii.cjs",
     "lint:docs-strict": "python -m mkdocs build --strict --site-dir .mkdocs-strict-out",
     "lint:phases:strict": "eslint src/Tests/Unit/Pipeline/CrossValidation/Phases --max-warnings 0",
+    "lint:pr-body": "node scripts/validate-pr-body.mjs",
     "lint:fix": "eslint src  --ignore-pattern '**/*.cjs' && npm run format",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md}\"",

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Local mirror of `.github/workflows/pr-body-check.yml`.
+ *
+ * Validates a PR body file against the 3 mandatory sections defined
+ * by `pr-guidlines.md` §7 + §10:
+ *
+ *   • `## Guideline compliance`   — guideline-compliance table (§10)
+ *   • `## Why`                    — paragraph explaining motivation (§7)
+ *   • `## What`                   — bullet list of touched files (§7)
+ *
+ * Why this script exists: CR cycle PR #336 #1 paired with a CI failure
+ * on `Validate PR body sections` — the PR body opened without the
+ * mandatory headers because the validation was only available server-
+ * side. This script lets contributors (and the pre-push hook) catch
+ * the gap BEFORE pushing.
+ *
+ * Usage:
+ *   node scripts/validate-pr-body.mjs --file <path>
+ *   PR_BODY_FILE=<path> node scripts/validate-pr-body.mjs
+ *   cat body.md | node scripts/validate-pr-body.mjs --stdin
+ *
+ * Exit codes:
+ *   0  — body contains all mandatory sections
+ *   1  — body is missing at least one mandatory section
+ *   2  — usage error (no source provided / file unreadable)
+ *
+ * Bot-author exemption (Dependabot, release-please, github-actions)
+ * lives ONLY on the CI side — local pushes from a human contributor
+ * always validate.
+ */
+import { readFileSync } from 'node:fs';
+import { argv, exit, stderr, stdin, stdout } from 'node:process';
+
+const REQUIRED_SECTIONS = [
+  { header: '## Guideline compliance', cite: 'pr-guidlines.md §10' },
+  { header: '## Why', cite: 'pr-guidlines.md §7' },
+  { header: '## What', cite: 'pr-guidlines.md §7' },
+];
+
+/**
+ * Read CLI args + env into a normalized request shape.
+ * @returns Source descriptor (`file` path, `stdin`, or `error`).
+ */
+function parseArgs() {
+  const args = argv.slice(2);
+  const stdinIdx = args.indexOf('--stdin');
+  if (stdinIdx !== -1) return { kind: 'stdin' };
+  const fileIdx = args.indexOf('--file');
+  if (fileIdx !== -1 && args[fileIdx + 1]) return { kind: 'file', path: args[fileIdx + 1] };
+  const positional = args.filter((a) => !a.startsWith('--'));
+  if (positional[0]) return { kind: 'file', path: positional[0] };
+  if (process.env.PR_BODY_FILE) return { kind: 'file', path: process.env.PR_BODY_FILE };
+  return { kind: 'error' };
+}
+
+/**
+ * Read body content from stdin synchronously.
+ * @returns Full stdin payload as a UTF-8 string.
+ */
+function readStdinSync() {
+  return readFileSync(0, 'utf8');
+}
+
+/**
+ * Resolve the body content from the parsed source descriptor.
+ * @param source - Parsed CLI request.
+ * @returns Body string (or throws if unreadable).
+ */
+function loadBody(source) {
+  if (source.kind === 'stdin') return readStdinSync();
+  if (source.kind === 'file') return readFileSync(source.path, 'utf8');
+  throw new Error('No source provided');
+}
+
+/**
+ * Determine which mandatory sections are missing.
+ * @param body - PR body string.
+ * @returns Array of missing section descriptors.
+ */
+function findMissingSections(body) {
+  return REQUIRED_SECTIONS.filter(({ header }) => !body.includes(header));
+}
+
+/**
+ * Print the failure report (mirrors the CI workflow message shape).
+ * @param missing - Missing section descriptors.
+ */
+function printFailure(missing) {
+  stderr.write('PR body is missing one or more mandatory sections:\n');
+  for (const { header, cite } of missing) {
+    stderr.write(`  - ${header}  (${cite})\n`);
+  }
+  stderr.write('\nSee .github/PULL_REQUEST_TEMPLATE.md for the canonical layout.\n');
+  stderr.write('See pr-guidlines.md §7 (Why/What) and §10 (Guideline compliance) for content rules.\n');
+}
+
+/**
+ * Print the usage banner + exit 2.
+ */
+function printUsageAndExit() {
+  stderr.write('Usage:\n');
+  stderr.write('  node scripts/validate-pr-body.mjs --file <path>\n');
+  stderr.write('  PR_BODY_FILE=<path> node scripts/validate-pr-body.mjs\n');
+  stderr.write('  cat body.md | node scripts/validate-pr-body.mjs --stdin\n');
+  exit(2);
+}
+
+const source = parseArgs();
+if (source.kind === 'error') printUsageAndExit();
+let body;
+try {
+  body = loadBody(source);
+} catch (err) {
+  stderr.write(`Failed to read PR body: ${err.message}\n`);
+  exit(2);
+}
+const missing = findMissingSections(body);
+if (missing.length > 0) {
+  printFailure(missing);
+  exit(1);
+}
+stdout.write('PR body contains all mandatory sections ✓\n');
+exit(0);

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -30,7 +30,7 @@
  * always validate.
  */
 import { readFileSync } from 'node:fs';
-import { argv, exit, stderr, stdin, stdout } from 'node:process';
+import { argv, env, exit, stderr, stdin, stdout } from 'node:process';
 
 const REQUIRED_SECTIONS = [
   { header: '## Guideline compliance', cite: 'pr-guidlines.md §10' },
@@ -50,7 +50,7 @@ function parseArgs() {
   if (fileIdx !== -1 && args[fileIdx + 1]) return { kind: 'file', path: args[fileIdx + 1] };
   const positional = args.filter((a) => !a.startsWith('--'));
   if (positional[0]) return { kind: 'file', path: positional[0] };
-  if (process.env.PR_BODY_FILE) return { kind: 'file', path: process.env.PR_BODY_FILE };
+  if (env.PR_BODY_FILE) return { kind: 'file', path: env.PR_BODY_FILE };
   return { kind: 'error' };
 }
 

--- a/src/Scrapers/Pipeline/EslintCanaries/test-pipeline-hardening-fn-over-cap.canary.ts
+++ b/src/Scrapers/Pipeline/EslintCanaries/test-pipeline-hardening-fn-over-cap.canary.ts
@@ -1,0 +1,53 @@
+// Canary: §19.11 — Phase 10 wave 2 pipeline-hardening test cap.
+//
+// The §19.11 wave 2 block (eslint.config.mjs §19.11) re-arms the
+// `phase9-local/fn-declaration-max-lines:10` rule on new pipeline-
+// mirroring tests (PR #336 Seq #1 added 3 such files). The rule
+// catches the slip-class CR cycle PR #336 #1 exposed: a 12-LoC
+// `buildEndpoint` FunctionDeclaration that ESLint silently allowed
+// because §7's broad `src/Tests/**` override turns the built-in
+// `max-lines-per-function` OFF entirely (~3 049 arrow-callback
+// violators across `src/Tests/**` would otherwise fire).
+//
+// Why duplicate the §19.10 canary? §19.10 + §19.11 use the SAME rule
+// implementation but enforce DIFFERENT file globs. This wave-2 canary
+// proves the rule remains armed on the wave-2 paths specifically —
+// future glob trimming (e.g. moving a file out of
+// PHASE_10_WAVE_2_PIPELINE_HARDENING_TESTS) cannot silently disarm
+// the wave-2 enforcement without also dropping this canary.
+//
+// This canary lives outside `src/Tests/**` (it is in `EslintCanaries/`
+// which is globally ignored at eslint.config.mjs line 539) but is
+// opted back in by the §19.11-canary single-file block so `verify.sh`
+// can confirm the guardrail stays armed.
+//
+// The function body below spans 14 LINES (>10 cap) — breaches the
+// §19.11 rule. Do NOT shrink this body. Do NOT add suppression
+// directives — the project's no-suppression rule (and the §19.11
+// contract) bars silencing this canary.
+
+/**
+ * Padded helper used purely as an ESLint fixture for the §19.11
+ * Phase 10 wave 2 pipeline-hardening test cap. Breaches the
+ * `phase9-local/fn-declaration-max-lines:10` rule (14 lines).
+ * @returns The sum (irrelevant — value is unused).
+ */
+function canaryPipelineHardeningFnOverCap(): number {
+  const s1 = 1;
+  const s2 = s1 + 1;
+  const s3 = s2 + 1;
+  const s4 = s3 + 1;
+  const s5 = s4 + 1;
+  const s6 = s5 + 1;
+  const s7 = s6 + 1;
+  const s8 = s7 + 1;
+  const s9 = s8 + 1;
+  const s10 = s9 + 1;
+  const s11 = s10 + 1;
+  return s11;
+}
+
+/** Second named export — keeps `import-x/prefer-default-export` quiet. */
+const CANARY_LABEL_WAVE_2 = '§19.11-pipeline-hardening-fn-over-cap' as const;
+
+export { CANARY_LABEL_WAVE_2, canaryPipelineHardeningFnOverCap };

--- a/src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts
@@ -21,22 +21,22 @@ import type { IDashboardClickState } from '../../../../../Scrapers/Pipeline/Medi
 import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 
 /**
- * Shared base for endpoint fixtures — every field except `status` is
- * constant so tests only vary the status window.
- * @returns Captured endpoint base without a `status` field.
+ * Module-scope endpoint-base fixture (no `status` field). Hoisting
+ * out of a helper function keeps the surrounding `buildEndpoint*`
+ * factories under the §19.11 ≤10-line cap — the inline-object
+ * variant ran 12 lines and would trip `phase9-local/fn-declaration
+ * -max-lines:10`.
  */
-function buildEndpointBase(): Omit<IDiscoveredEndpoint, 'status'> {
-  return {
-    url: 'https://bank.example/api/x',
-    method: 'GET',
-    postData: '',
-    contentType: 'application/json',
-    requestHeaders: {},
-    responseHeaders: {},
-    responseBody: {},
-    timestamp: 1,
-  };
-}
+const ENDPOINT_BASE_NO_STATUS: Omit<IDiscoveredEndpoint, 'status'> = {
+  url: 'https://bank.example/api/x',
+  method: 'GET',
+  postData: '',
+  contentType: 'application/json',
+  requestHeaders: {},
+  responseHeaders: {},
+  responseBody: {},
+  timestamp: 1,
+};
 
 /**
  * Build a captured endpoint fixture with the provided HTTP status.
@@ -44,7 +44,7 @@ function buildEndpointBase(): Omit<IDiscoveredEndpoint, 'status'> {
  * @returns Captured endpoint matching the `IDiscoveredEndpoint` shape.
  */
 function buildEndpoint(status: number): IDiscoveredEndpoint {
-  return { ...buildEndpointBase(), status };
+  return { ...ENDPOINT_BASE_NO_STATUS, status };
 }
 
 /**
@@ -54,7 +54,7 @@ function buildEndpoint(status: number): IDiscoveredEndpoint {
  * @returns Captured endpoint with `status` left undefined.
  */
 function buildEndpointWithoutStatus(): IDiscoveredEndpoint {
-  return buildEndpointBase();
+  return { ...ENDPOINT_BASE_NO_STATUS };
 }
 
 /**

--- a/src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Phase 2 coverage closeout — MethodBundles.ts had no co-located
+ * unit test, so `isSuccessStatus`, `countSuccessfulFn` and the
+ * `discoverTransactionsEndpoint` lambda all ran 0 times against
+ * the pipeline coverage gate (4 uncovered branches at lines 53-54,
+ * 2 uncovered DA lines at 86 and 114). The 2xx success window
+ * branches in `isSuccessStatus` are the empty-gate primitive the
+ * SCRAPE.POST prod-safe heuristic relies on — leaving them
+ * unguarded means a refactor could silently widen the range.
+ *
+ * <p>This file pins the 2xx window behaviour and the empty-pool
+ * shape of the endpoint-discovery lambdas. No selectors, no DOM —
+ * pure function-bundle wiring.
+ */
+import {
+  buildBucketingMethods,
+  buildCoreMethods,
+  buildEndpointMethods,
+} from '../../../../../Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/MethodBundles.js';
+import type { IDashboardClickState } from '../../../../../Scrapers/Pipeline/Mediator/Network/EndpointState/EndpointState.js';
+import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
+
+/**
+ * Shared base for endpoint fixtures — every field except `status` is
+ * constant so tests only vary the status window.
+ * @returns Captured endpoint base without a `status` field.
+ */
+function buildEndpointBase(): Omit<IDiscoveredEndpoint, 'status'> {
+  return {
+    url: 'https://bank.example/api/x',
+    method: 'GET',
+    postData: '',
+    contentType: 'application/json',
+    requestHeaders: {},
+    responseHeaders: {},
+    responseBody: {},
+    timestamp: 1,
+  };
+}
+
+/**
+ * Build a captured endpoint fixture with the provided HTTP status.
+ * @param status - HTTP status code under test.
+ * @returns Captured endpoint matching the `IDiscoveredEndpoint` shape.
+ */
+function buildEndpoint(status: number): IDiscoveredEndpoint {
+  return { ...buildEndpointBase(), status };
+}
+
+/**
+ * Build a captured endpoint WITHOUT a `status` field — models the
+ * frozen-replay / synthesised-fixture case where the bank capture
+ * was recorded without a response status.
+ * @returns Captured endpoint with `status` left undefined.
+ */
+function buildEndpointWithoutStatus(): IDiscoveredEndpoint {
+  return buildEndpointBase();
+}
+
+/**
+ * Click-state stub `mark` — accepts any timestamp, always reports true.
+ * @returns Always true (matches IDashboardClickState.mark contract).
+ */
+function clickStateMark(): true {
+  return true;
+}
+
+/**
+ * Click-state stub `read` — reports "no click yet".
+ * @returns Always false (the "no click marked" sentinel).
+ */
+function clickStateRead(): number | false {
+  return false;
+}
+
+/**
+ * Build a no-op IDashboardClickState. Bucketing methods only need
+ * `mark` + `read`; the test exercises the "no click yet" short-
+ * circuit at line 133 of MethodBundles.ts.
+ * @returns Click-state stub with read returning false.
+ */
+function buildIdleClickState(): IDashboardClickState {
+  return { mark: clickStateMark, read: clickStateRead };
+}
+
+describe('MethodBundles — buildCoreMethods', () => {
+  it('MB-COUNT-001 counts only 2xx responses (status in [200, 300))', () => {
+    const captured = [
+      buildEndpoint(200),
+      buildEndpoint(204),
+      buildEndpoint(299),
+      buildEndpoint(199),
+      buildEndpoint(300),
+      buildEndpoint(404),
+      buildEndpoint(500),
+    ];
+    const methods = buildCoreMethods(captured);
+    const count = methods.countSuccessfulResponses();
+    expect(count).toBe(3);
+  });
+
+  it('MB-COUNT-002 treats undefined status as 0 (non-2xx)', () => {
+    const captured = [buildEndpointWithoutStatus(), buildEndpoint(200)];
+    const methods = buildCoreMethods(captured);
+    const count = methods.countSuccessfulResponses();
+    expect(count).toBe(1);
+  });
+
+  it('MB-COUNT-003 returns 0 for an empty pool', () => {
+    const methods = buildCoreMethods([]);
+    const count = methods.countSuccessfulResponses();
+    expect(count).toBe(0);
+  });
+
+  it('MB-FIND-001 filters captured pool by URL pattern', () => {
+    const captured = [
+      { ...buildEndpoint(200), url: 'https://b.example/api/transactions' },
+      { ...buildEndpoint(200), url: 'https://b.example/api/balance' },
+    ];
+    const methods = buildCoreMethods(captured);
+    const matched = methods.findEndpoints(/transactions/);
+    expect(matched).toHaveLength(1);
+    expect(matched[0]?.url).toContain('transactions');
+  });
+
+  it('MB-GETALL-001 returns a shallow copy of the captured pool', () => {
+    const captured = [buildEndpoint(200)];
+    const methods = buildCoreMethods(captured);
+    const snapshot = methods.getAllEndpoints();
+    expect(snapshot).toEqual(captured);
+    expect(snapshot).not.toBe(captured);
+  });
+});
+
+describe('MethodBundles — buildEndpointMethods', () => {
+  it('MB-EP-TXN-001 returns false when no captured endpoint matches WK txn patterns', () => {
+    const methods = buildEndpointMethods([]);
+    const result = methods.discoverTransactionsEndpoint();
+    expect(result).toBe(false);
+  });
+
+  it('MB-EP-BAL-001 returns false when no captured endpoint matches WK balance patterns', () => {
+    const methods = buildEndpointMethods([]);
+    const result = methods.discoverBalanceEndpoint();
+    expect(result).toBe(false);
+  });
+});
+
+describe('MethodBundles — buildBucketingMethods (idle click)', () => {
+  it('MB-BUCKET-001 returns the full pool for pre/post when no click is marked', () => {
+    const captured = [buildEndpoint(200), buildEndpoint(404)];
+    const clickState = buildIdleClickState();
+    const methods = buildBucketingMethods(captured, clickState);
+    const pre = methods.getPreNavCaptures();
+    const post = methods.getPostNavCaptures();
+    expect(pre).toEqual(captured);
+    expect(post).toEqual(captured);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Phase 2 coverage closeout — ApiOriginDiscovery.ts shipped without
+ * a dedicated test, leaving the 3-tier discovery in
+ * `discoverApiOriginFromTraffic` and the CR PR #276 #9 guarded URL
+ * parse branches uncovered (BRDA 50, 76, 106). Banks regularly serve
+ * malformed referer / CORS / config-body URLs that crashed the
+ * pre-CR-#9 unguarded `new URL()` — the guarded branches are the
+ * regression net for that crash, so pin them with positive
+ * (success) + negative (malformed) input pairs through the public
+ * default export.
+ *
+ * <p>BRDA 90 (`discoverApiFromSubdomain` re-parse guard) is
+ * deliberately defensive — the predicate at line 87 already proved
+ * the URL parses; the re-parse at line 89 cannot fail on the same
+ * input — so it remains intentionally unreachable and is NOT
+ * targeted here.
+ */
+import type { IDiscoveredEndpoint } from '../../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
+import discoverApiOriginFromTraffic from '../../../../../../Scrapers/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.js';
+
+/**
+ * Build a captured endpoint with controllable URL + body + method.
+ * Defaults match a benign GET capture so each test only overrides
+ * the field under test.
+ * @param overrides - Per-test endpoint overrides.
+ * @returns Captured endpoint matching the `IDiscoveredEndpoint` shape.
+ */
+function buildEndpoint(overrides: Partial<IDiscoveredEndpoint> = {}): IDiscoveredEndpoint {
+  return {
+    url: 'https://bank.example/static/style.css',
+    method: 'GET',
+    postData: '',
+    contentType: 'application/json',
+    requestHeaders: {},
+    responseHeaders: {},
+    responseBody: {},
+    timestamp: 1,
+    status: 200,
+    ...overrides,
+  };
+}
+
+describe('ApiOriginDiscovery — Tier 1 (config body)', () => {
+  it('AOD-T1-001 extracts the API origin from a config body that lists API URLs', () => {
+    const capture = buildEndpoint({
+      url: 'https://bank.example/client-config.json',
+      responseBody: { endpoints: { txn: 'https://api.bank.example/api/v1/' } },
+    });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe('https://api.bank.example');
+  });
+
+  it('AOD-T1-002 returns false when the config body has no API URL match', () => {
+    const capture = buildEndpoint({
+      url: 'https://bank.example/client-config.json',
+      responseBody: { theme: 'dark' },
+    });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe(false);
+  });
+
+  it('AOD-T1-003 ignores a regex-matched URL whose hostname is malformed (CR PR #276 #9 guard fires)', () => {
+    // `https://[/api/` matches the API_PATH_REGEX but `new URL()`
+    // throws on the bare `[` (invalid IPv6 literal). Without the
+    // CR #9 guard the original `new URL` would crash discovery.
+    const capture = buildEndpoint({
+      url: 'https://bank.example/client-config.json',
+      responseBody: { malformed: 'https://[/api/foo' },
+    });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe(false);
+  });
+});
+
+describe('ApiOriginDiscovery — Tier 2 (api.* subdomain)', () => {
+  it('AOD-T2-001 returns the origin of the first endpoint whose host starts with api.', () => {
+    const capture = buildEndpoint({ url: 'https://api.bank.example/v1/accounts' });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe('https://api.bank.example');
+  });
+
+  it('AOD-T2-002 skips malformed-URL endpoints (CR PR #276 #9 guard fires)', () => {
+    // hasApiSubdomain calls safeParseWindowUrl; on parse failure
+    // it returns false and the endpoint is not chosen.
+    const malformed = buildEndpoint({ url: 'not-a-url' });
+    const ok = buildEndpoint({ url: 'https://api.bank.example/v1' });
+    const origin = discoverApiOriginFromTraffic([malformed, ok]);
+    expect(origin).toBe('https://api.bank.example');
+  });
+});
+
+describe('ApiOriginDiscovery — Tier 3 (POST with /api/ path)', () => {
+  it('AOD-T3-001 returns the origin of any POST endpoint containing /api/', () => {
+    const capture = buildEndpoint({
+      url: 'https://gateway.bank.example/api/login',
+      method: 'POST',
+    });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe('https://gateway.bank.example');
+  });
+
+  it('AOD-T3-002 returns false when the matching POST URL fails to parse (CR PR #276 #9 guard fires)', () => {
+    // `find()` matches on `.includes('/api/')` BEFORE the URL parse;
+    // the parse then rejects the malformed scheme-less form,
+    // exercising the CR #9 fallthrough.
+    const capture = buildEndpoint({
+      url: 'malformed-scheme/api/foo',
+      method: 'POST',
+    });
+    const origin = discoverApiOriginFromTraffic([capture]);
+    expect(origin).toBe(false);
+  });
+});
+
+describe('ApiOriginDiscovery — empty pool', () => {
+  it('AOD-EMPTY-001 returns false when no captures are present', () => {
+    const origin = discoverApiOriginFromTraffic([]);
+    expect(origin).toBe(false);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.test.ts
@@ -19,25 +19,30 @@ import type { IDiscoveredEndpoint } from '../../../../../../Scrapers/Pipeline/Me
 import discoverApiOriginFromTraffic from '../../../../../../Scrapers/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.js';
 
 /**
+ * Module-scope endpoint fixture base. Hoisting out of the helper
+ * function keeps `buildEndpoint` under the §19.11 ≤10-line cap
+ * (CR PR #336 #1 — the inline-object variant ran 13 lines and
+ * tripped `phase9-local/fn-declaration-max-lines`).
+ */
+const ENDPOINT_BASE: IDiscoveredEndpoint = {
+  url: 'https://bank.example/static/style.css',
+  method: 'GET',
+  postData: '',
+  contentType: 'application/json',
+  requestHeaders: {},
+  responseHeaders: {},
+  responseBody: {},
+  timestamp: 1,
+  status: 200,
+};
+
+/**
  * Build a captured endpoint with controllable URL + body + method.
- * Defaults match a benign GET capture so each test only overrides
- * the field under test.
  * @param overrides - Per-test endpoint overrides.
  * @returns Captured endpoint matching the `IDiscoveredEndpoint` shape.
  */
 function buildEndpoint(overrides: Partial<IDiscoveredEndpoint> = {}): IDiscoveredEndpoint {
-  return {
-    url: 'https://bank.example/static/style.css',
-    method: 'GET',
-    postData: '',
-    contentType: 'application/json',
-    requestHeaders: {},
-    responseHeaders: {},
-    responseBody: {},
-    timestamp: 1,
-    status: 200,
-    ...overrides,
-  };
+  return { ...ENDPOINT_BASE, ...overrides };
 }
 
 describe('ApiOriginDiscovery — Tier 1 (config body)', () => {

--- a/src/Tests/Unit/Pipeline/Types/PiiRedactor/JsonBody.test.ts
+++ b/src/Tests/Unit/Pipeline/Types/PiiRedactor/JsonBody.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Phase 2 coverage closeout — JsonBody.ts (the recursive PII redactor
+ * for parsed-or-string JSON payloads consumed by
+ * `NetworkDiscovery.dumpResponseBody` and the FixtureCapture writers)
+ * shipped without targeted tests for several recursive walk branches:
+ *
+ *   - `redactLeaf` empty-path nullish fallback (`path.at(-1) ?? ''`)
+ *   - `nestedHasPii` array dispatch
+ *   - `objectHasPii` PII-key short-circuit on the `||` predicate
+ *   - `nestedHasPii` depth bail-out (>{@link MAX_PII_PROBE_DEPTH})
+ *
+ * These branches gate the censor that prevents bank PII (account
+ * numbers, OTP codes, phone numbers) from leaking into on-disk
+ * captures — silent regression here is the highest-cost class of
+ * fixture-pipeline bug. Public surface is `redactJsonBody` only;
+ * the test exercises each branch through that single entry point.
+ */
+import { redactJsonBody } from '../../../../../Scrapers/Pipeline/Types/PiiRedactor.js';
+import type { IJsonObject } from '../../../../../Scrapers/Pipeline/Types/PiiRedactor/Types.js';
+
+/**
+ * Build an object nested `levels` deep with the PII-classified key
+ * `phone` at the leaf. Used to drive `nestedHasPii` past the
+ * MAX_PII_PROBE_DEPTH safety bail-out (50 levels).
+ * @param levels - Number of wrap layers.
+ * @returns Deeply nested object.
+ */
+function buildDeepObject(levels: number): IJsonObject {
+  let current: IJsonObject = { phone: '0501234567' };
+  for (let i = 0; i < levels; i += 1) {
+    current = { wrap: current };
+  }
+  return current;
+}
+
+describe('JsonBody — redactJsonBody string root', () => {
+  it('JB-STRING-ROOT-001 falls through redactLeaf with empty path (`.at(-1) ?? ""` fallback)', () => {
+    // A bare-string JSON document hits redactNode with path=[],
+    // typeof !== 'object' so the leaf path is taken; redactLeaf
+    // resolves `[].at(-1) ?? ''` — the nullish fallback was the
+    // uncovered branch at line 130.
+    const result = redactJsonBody('"hello world"');
+    expect(typeof result).toBe('string');
+    expect(result).toContain('hello world');
+  });
+
+  it('JB-FALLBACK-001 hits the regex-fallback branch when the body is not valid JSON', () => {
+    const result = redactJsonBody('not json at all');
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('JsonBody — redactJsonBody nested object trees', () => {
+  it('JB-PII-SHORTCIRCUIT-001 short-circuits the predicate when a key classifies as PII', () => {
+    // `objectHasPii` predicate is `classifyKey(k) !== "unknown" || nestedHasPii(...)`.
+    // With a PII key at depth 0 (`phone`), the left side is TRUE
+    // → branch 0 of BRDA:69 is exercised.
+    const result = redactJsonBody({ phone: '0501234567' });
+    expect(typeof result).toBe('string');
+    expect(result).not.toContain('0501234567');
+  });
+
+  it('JB-NESTED-ARRAY-001 dispatches nestedHasPii through the Array.isArray branch', () => {
+    // Outer key non-PII → recurses; inner value is an array → hits
+    // `if (Array.isArray(value))` true branch at BRDA:57 inside
+    // nestedHasPii, and the array contains PII so redactArray
+    // collapses to the `<N redacted items>` sentinel.
+    const body = { outer: { inner: [{ phone: '0501234567' }] } };
+    const result = redactJsonBody(body);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('redacted items');
+    expect(result).not.toContain('0501234567');
+  });
+});
+
+describe('JsonBody — redactJsonBody depth safety', () => {
+  it('JB-DEPTH-PROBE-001 trips the MAX_PII_PROBE_DEPTH bail-out for pathological nesting', () => {
+    // 60 wrap layers exceeds MAX_PII_PROBE_DEPTH (50) — the
+    // probe returns false before reaching the leaf PII key, so
+    // the array-collapse rule does NOT trigger. The branch under
+    // test is `if (depth > MAX_PII_PROBE_DEPTH) return false`
+    // at BRDA:55, which protects against pathological inputs.
+    const deep = buildDeepObject(60);
+    const result = redactJsonBody(deep);
+    expect(typeof result).toBe('string');
+    // The redactor must complete without throwing on a deeply
+    // nested input — the depth bail-out is the safety net.
+  });
+});


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Status | Verification |
|---|---|---|---|
|  1 | ≤10 LoC per function (CLEAN_CODE.md §1 + CLAUDE.md "Max 10 lines per method") | ✅ | `buildEndpoint` (was 12 LoC) split into module-level `ENDPOINT_BASE` const + 3-line factory; `buildEndpointBase` (was 12-13 LoC) replaced by `ENDPOINT_BASE_NO_STATUS` module const + 3-line factories. `npx eslint <3 new test files>` clean. |
|  2 | New §19.11 ESLint overlay enforces ≤10-LoC cap on the 3 new pipeline-mirroring tests (CR PR #336 #1 root-cause closure) | ✅ | `eslint.config.mjs §19.11` adds `PHASE_10_WAVE_2_PIPELINE_HARDENING_TESTS` glob + `phase9-local/fn-declaration-max-lines:10`; the original 12-LoC `buildEndpoint` would now fail pre-commit. |
|  3 | Every new ESLint rule has a canary fixture (`src/Scrapers/Pipeline/EslintCanaries/`) | ✅ | `test-pipeline-hardening-fn-over-cap.canary.ts` (14 lines / 1 stmt) triggers `phase9-local/fn-declaration-max-lines` via the §19.11-canary single-file block. `npm run lint:canaries` passes (68 TS canaries). |
|  4 | TypeScript strict mode — no `any`, no unused vars (CLAUDE.md) | ✅ | No new `: any`; type-check clean (`npm run type-check`). |
|  5 | Zero CSS selectors in interaction code (CLAUDE.md "ABSOLUTE") | ✅ | N/A — test-only PR, no `page.$` / `querySelector` / `waitForSelector('#…')` introduced. |
|  6 | Conventional Commits + `Co-authored-by: Copilot` trailer (commit-guidlines.md) | ✅ | `test(pipeline): close CR cycle PR #336 #1 + arm §19.11 wave-2 guardrail` with required trailer. |
|  7 | Pre-commit husky 23-gate green (before-commit-guidlines.md) | ✅ | Single-commit pass (timestamp recorded in commit metadata + `.pre-commit-output.log`). |
|  8 | `lint:guideline-coverage` gate green (asserts `eslint.config.mjs` enforces CLEAN_CODE.md caps for every Pipeline cluster) | ✅ | Pre-commit gate 10 passes — 7 clusters still enforced + 2 marked `pendingPhase2`. |
|  9 | `lint:canaries` gate green — every architectural canary still fires | ✅ | Pre-commit gate 8 passes; canary count rose from 67 → 68 (new wave-2 canary registered automatically via glob). |
| 10 | Public API byte-identical at `lib/index.cjs` (test-only PR) | ✅ | Touched files limited to `src/Tests/**`, `src/Scrapers/Pipeline/EslintCanaries/**`, `eslint.config.mjs`, `jest.pipeline.config.cjs`, `scripts/validate-pr-body.mjs`, `.husky/pre-push`, `docs/workflow/**`, `package.json` scripts, `CLAUDE.md`. Zero production-code diff. |
| 11 | Pipeline coverage 95.1 / 97 / 97 / 98 preserved (jest.pipeline.config.cjs) | ✅ | Seq #1 commit `c3ef763d` lifted measured branches 94.98% → 95.14%; current commit adds NO new test files (refactor only) so coverage stays at 95.14%. Threshold `branches: 95.1` holds. |
| 12 | `madge --circular` returns zero new cycles | ✅ | Test-only PR; pre-commit gate 6 (architecture) passes. |
| 13 | `npm run lint` (eslint + architecture + canaries + format:check) green | ✅ | Pre-commit gate 2. |
| 14 | T1-INVERSE branch lockdown — `test/phase-2-*` branch contains zero `src/Scrapers/**` diff (except `EslintCanaries/`) | ✅ | `.husky/pre-commit` lines 14-45 enforce; only canary file under `src/Scrapers/Pipeline/EslintCanaries/`. |
| 15 | PR body validates locally via `npm run lint:pr-body` (mirrors `.github/workflows/pr-body-check.yml`) | ✅ | `node scripts/validate-pr-body.mjs --file .git/PR_BODY.md` exits 0 — body contains `## Why`, `## What`, `## Guideline compliance`. |

## Why

CR cycle PR #336 #1 + CI cycle PR #336 paired two related failures:

1. **CodeRabbit**: `buildEndpoint` helper in `ApiOriginDiscovery.test.ts` ran 12 LoC — breaches the canonical ≤10-LoC cap from CLEAN_CODE.md §1 + CLAUDE.md "Max 10 lines per method", but ESLint silently allowed it because `src/Tests/**` is broadly excluded from `max-lines-per-function` at `eslint.config.mjs §7` (line 866).
2. **CI**: `Validate PR body sections` failed — the original Seq #1 PR body omitted the three mandatory headers (`## Why`, `## What`, `## Guideline compliance`) because nothing validated the body locally.

Both failures shared the same root cause: **policy without enforcement**. The cap exists in CLAUDE.md / CLEAN_CODE.md but ESLint had no rule to enforce it on test files; the PR-body contract exists in `.github/workflows/pr-body-check.yml` but ran only server-side. This PR closes both gaps with one commit so neither slip can recur.

## What

Refactor (CR-cycle fix):
- `src/Tests/Unit/Pipeline/Mediator/Network/Scoring/ApiOriginDiscovery.test.ts` — hoist endpoint defaults to module-level `ENDPOINT_BASE` const; `buildEndpoint(overrides)` is now a 3-line spread (was 12 lines).
- `src/Tests/Unit/Pipeline/Mediator/Network/MethodBundles.test.ts` — same pattern with `ENDPOINT_BASE_NO_STATUS`; `buildEndpoint(status)` + `buildEndpointWithoutStatus()` factories are 3 lines each (were 12).

ESLint enforcement (root-cause closure):
- `eslint.config.mjs §19.11` — new `PHASE_10_WAVE_2_PIPELINE_HARDENING_TESTS` glob list + overlay enforcing `phase9-local/fn-declaration-max-lines:10` on the 3 pipeline-mirroring test files PR #336 added (`MethodBundles.test.ts`, `Scoring/**/*.test.ts`, `JsonBody.test.ts`). The wave-2 design parallels §19.10's existing "Phase 9 + Phase 10 wave 1" enforcement scope.
- `src/Scrapers/Pipeline/EslintCanaries/test-pipeline-hardening-fn-over-cap.canary.ts` — over-cap fixture (14 lines) that proves the §19.11 wave-2 rule fires. `verify.sh` picks it up automatically via the existing `*.canary.ts` glob.

Local PR-body validator (CI mirror):
- `scripts/validate-pr-body.mjs` — standalone Node script mirroring `.github/workflows/pr-body-check.yml` logic; checks for `## Why`, `## What`, `## Guideline compliance`. Supports `--file`, `--stdin`, and `PR_BODY_FILE` env var.
- `package.json` — new `lint:pr-body` npm script.
- `.husky/pre-push` — new advisory hook that validates a body file (priority: `PR_BODY_FILE` env var → `.git/PR_BODY.md` → `.github/PR_BODY.md`) and exits 0 with a hint when none is found, so work-in-progress pushes don't trip.

Docs:
- `docs/workflow/pre-push.md` — new page documenting the hook + script + recommended workflow.
- `docs/workflow/index.md` + `docs/workflow/ci.md` — cross-link to the new page + add `PR body compliance` row to the gate matrix.
- `CLAUDE.md` — new "Pre-Push / PR Protocol" section instructing the agent to write `.git/PR_BODY.md` and run `npm run lint:pr-body` before `gh pr create`.

## Test plan

- [x] unit tests added / updated — N/A (refactor of helpers in 2 test files added by Seq #1; the 21 existing tests all still pass)
- [x] integration tests added / updated where the surface warrants — N/A (no production behaviour change)
- [x] `npm run lint` passes — pre-commit gate 2
- [x] `npm run lint:guideline-coverage` passes — pre-commit gate 10
- [x] `npm run lint:canaries` passes — pre-commit gate 8 (68 TS canaries, +1 from wave-2 canary)
- [x] `npm run test:pipeline` passes — pre-commit gate 13 (coverage 95.14 / 97.25 / 97.44 / 98.40)
- [x] `npm run test:e2e:mock` passes — pre-commit gate 15

## Docs

- [x] page added or updated under `docs/` for any user-visible change — `docs/workflow/pre-push.md` (new), `docs/workflow/ci.md` (PR-body-compliance row added), `docs/workflow/index.md` (cross-link)
- [x] `mkdocs.yml` nav updated when adding a new page — added under `Workflow → Pre-push hook`
- [x] JSDoc comments updated on every changed exported symbol — N/A (no new exported symbols; `scripts/validate-pr-body.mjs` is a binary, not a library)
- [ ] N/A — explain why

## CI / security

- [x] no secrets committed
- [x] no PII or customer identifiers in code, tests, or commit messages
- [x] new third-party action pinned by SHA (not by tag) — N/A (no new actions)
- [x] new shell scripts include `set -euo pipefail` — `.husky/pre-push` uses `set -o pipefail` (matches existing `.husky/pre-commit` convention)

## Notes for reviewer

- This PR amends Seq #1 (PR #336) — its sole purpose is to close the CR finding + the CI red gate from the original commit `c3ef763d`. The +21 tests + coverage threshold bump from Seq #1 remain untouched.
- The §19.11 overlay deliberately uses **only** `phase9-local/fn-declaration-max-lines` (and **not** built-in `max-lines-per-function` / `max-statements`). Both built-ins fire on every `describe` / `it` arrow callback — the §19.10 docstring records ~3 049 violators across `src/Tests/**` per AST audit — so they cannot be globally enabled. Statement-count enforcement on named helpers is already provided by `TEST_HELPER_OVER_10_STMTS_RULE` wired into `§7`'s `no-restricted-syntax` at line 877; no double-up here.
- A future "wave 3" widens §19.11 to all `src/Tests/Unit/Pipeline/**` after the existing 2 317 over-cap helpers are drained (Phase 9-style sweep, tracked as a separate task).
- Coverage stays exactly where Seq #1 landed it (no new tests added in this commit — just refactor + enforcement + tooling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for pipeline network methods, API origin discovery, and JSON body PII redaction.

* **Documentation**
  * Updated workflow documentation with PR body validation requirements.
  * Added pre-push hook documentation for local PR body validation.

* **Chores**
  * Added PR body validation script and npm command for compliance checking.
  * Updated configuration to enforce function line-length limits in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->