### PR TITLE
test: derive Mizrahi fixture dates from now

### DIFF
--- a/src/Tests/MizrahiFixtures.ts
+++ b/src/Tests/MizrahiFixtures.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import moment from 'moment';
 
 import { type IMockPage } from './MockPage.js';
 
@@ -78,6 +79,20 @@ export interface IMizrahiScrapedTxn {
 }
 
 /**
+ * Recent date string inside the scraper's rolling 1-year window.
+ *
+ * The Mizrahi scraper drops transactions older than one year before now,
+ * so a hardcoded fixture date silently falls out of range once the
+ * calendar passes it. Deriving the date from the current time keeps the
+ * fixtures evergreen.
+ * @param daysAgo - How many days before now to anchor the date.
+ * @returns A DATETIME_LOCAL_SECONDS-formatted date string.
+ */
+function recentDate(daysAgo: number): string {
+  return moment().subtract(daysAgo, 'days').format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS);
+}
+
+/**
  * Builds a scraped transaction with sensible defaults.
  * @param overrides - partial transaction fields to merge with defaults.
  * @returns complete scraped transaction object.
@@ -85,12 +100,12 @@ export interface IMizrahiScrapedTxn {
 export function scrapedTxn(overrides: Partial<IMizrahiScrapedTxn> = {}): IMizrahiScrapedTxn {
   return {
     RecTypeSpecified: true,
-    MC02PeulaTaaEZ: '2025-06-15T10:00:00',
+    MC02PeulaTaaEZ: recentDate(30),
     MC02SchumEZ: -150,
     MC02AsmahtaMekoritEZ: '12345',
     MC02TnuaTeurEZ: 'העברה בנקאית',
     IsTodayTransaction: false,
-    MC02ErehTaaEZ: '2025-06-16T00:00:00',
+    MC02ErehTaaEZ: recentDate(29),
     MC02ShowDetailsEZ: '0',
     TransactionNumber: null,
     ...overrides,


### PR DESCRIPTION
## Why

`Mizrahi.test.ts` was failing on `main` and in CI (the "Unit tests" job),
blocking the whole `test:pipeline` gate. Root cause: a date time-bomb in
the test fixture.

`scrapedTxn` hardcoded `MC02PeulaTaaEZ: '2025-06-15T10:00:00'`. The Mizrahi
scraper drops transactions older than one year (`getStartMoment` =
`max(now - 1 year, startDate)`). Once the calendar passed 2025-06-15, the
default fixture transaction fell outside the rolling window and was
filtered out, so every test asserting non-empty transactions failed with
`Cannot read properties of undefined (reading 'originalAmount')`
(i.e. `accounts[0].txns[0]` was undefined). This is purely clock drift -
no product regression.

## What

- Introduce a `recentDate(daysAgo)` helper in `MizrahiFixtures.ts` that
  formats `now - daysAgo` as `DATETIME_LOCAL_SECONDS`.
- Default `MC02PeulaTaaEZ` -> `recentDate(30)` and `MC02ErehTaaEZ` ->
  `recentDate(29)` so fixtures stay evergreen inside the one-year window.
- The explicit `2020-01-01` override in the "filters transactions before
  start date" test is untouched and still correctly filtered.

Test-only change; no production code touched. All 41 Mizrahi tests pass,
full local husky gate (incl. `test:pipeline`, mock + live E2E) green.

## Guideline compliance

- **commit-guidlines** - atomic, single-purpose commit; Conventional
  `test:` type (test-only, no release); 50/72 subject/body; WHY-focused
  body; `Co-authored-by` trailer.
- **before-commit-guidlines** - ran tsc, eslint, prettier, full husky;
  selective staging (no `git add .`); no hook bypass; reviewed diff.
- **test-guidlines** - fixtures made deterministic and drift-resistant;
  no test logic weakened, only the expiring constant replaced with a
  relative anchor.
- **coding-principle-guidlines** - extracted a named helper over inline
  duplication; documents WHY (window drift), not HOW.