### PR TITLE
fix(deps): pin playwright-core to 1.59.x + validate dep PRs in CI

### DIFF
--- a/.github/scripts/ci/detect-changes.sh
+++ b/.github/scripts/ci/detect-changes.sh
@@ -16,6 +16,14 @@
 #                 (drives the docs-coverage canary)
 #   ci_scripts  — `.github/scripts/ci/**` or `.github/workflows/**`
 #                 was modified (drives the CI scripts smoke test)
+#   deps        — `package.json`, `package-lock.json`, or
+#                 `.github/dependabot.yml` was modified. Forces the
+#                 browser E2E gates (e2e-mocked + e2e-factory) to RUN on
+#                 dependency-only PRs (e.g. dependabot bumps) that touch
+#                 no `src/` file. Without this a runtime-dep bump such as
+#                 playwright-core could land UNvalidated against Camoufox
+#                 (the 1.61.0 `Browser.setDefaultViewport` regression that
+#                 broke `browser.newContext` slipped onto main this way).
 #
 # Why one detector instead of `paths:` filters per workflow:
 # Workflow-level `paths:` filters skip the WHOLE workflow on path
@@ -42,6 +50,7 @@ if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "${ZERO_SHA}" ]; then
     echo "docs=true"
     echo "pipeline_ts=true"
     echo "ci_scripts=true"
+    echo "deps=true"
   } >> "$GITHUB_OUTPUT"
   exit 0
 fi
@@ -70,6 +79,7 @@ if [ -z "${changed_files}" ]; then
     echo "docs=false"
     echo "pipeline_ts=false"
     echo "ci_scripts=false"
+    echo "deps=false"
   } >> "$GITHUB_OUTPUT"
   exit 0
 fi
@@ -92,12 +102,14 @@ md=false
 docs=false
 pipeline_ts=false
 ci_scripts=false
+deps=false
 
 if has '^src/'; then src=true; fi
 if has '\.md$'; then md=true; fi
 if has '^docs/|^mkdocs\.yml$|^requirements-docs\.txt$'; then docs=true; fi
 if has '^src/Scrapers/Pipeline/.*\.ts$'; then pipeline_ts=true; fi
 if has '^\.github/scripts/ci/|^\.github/workflows/'; then ci_scripts=true; fi
+if has '^package\.json$|^package-lock\.json$|^\.github/dependabot\.yml$'; then deps=true; fi
 
 {
   echo "src=${src}"
@@ -105,6 +117,7 @@ if has '^\.github/scripts/ci/|^\.github/workflows/'; then ci_scripts=true; fi
   echo "docs=${docs}"
   echo "pipeline_ts=${pipeline_ts}"
   echo "ci_scripts=${ci_scripts}"
+  echo "deps=${deps}"
 } >> "$GITHUB_OUTPUT"
 
 echo "[detect-changes] decisions:"
@@ -113,3 +126,4 @@ echo "  md=${md}"
 echo "  docs=${docs}"
 echo "  pipeline_ts=${pipeline_ts}"
 echo "  ci_scripts=${ci_scripts}"
+echo "  deps=${deps}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -105,6 +105,7 @@ jobs:
       docs: ${{ steps.changes.outputs.docs }}
       pipeline_ts: ${{ steps.changes.outputs.pipeline_ts }}
       ci_scripts: ${{ steps.changes.outputs.ci_scripts }}
+      deps: ${{ steps.changes.outputs.deps }}
       # Single-source-of-truth booleans for downstream `if:` conditions.
       # `trusted_event` — true unless this is a PR from a fork (untrusted secrets).
       # `real_gates_enabled` — true only when ALL prerequisites for running real-network /
@@ -265,11 +266,14 @@ jobs:
 
   # ──────────────────────────────────────────────────────────────
   # E2E factory tests — independent of Mode A / Mode B / e2e-mocked.
+  # Also runs on dependency-only PRs (`deps`) so runtime-dep bumps that
+  # touch no `src/` file are still validated against the real Camoufox
+  # browser launch. See detect-changes.sh `deps` output.
   # ──────────────────────────────────────────────────────────────
   e2e-factory:
     name: E2E factory
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -289,11 +293,16 @@ jobs:
   # package.json `test:e2e:mock` script pins `--maxWorkers=2` to
   # avoid CPU-contention timeouts documented in the husky pre-commit
   # cycle (PRs #331+ cycle-4 cache-marker workaround).
+  # Also runs on dependency-only PRs (`deps`): this is the gate that
+  # exercises `browser.newContext` against the pinned Camoufox build,
+  # so a playwright-core bump can no longer land UNvalidated (the
+  # 1.61.0 `setDefaultViewport` regression slipped onto main because a
+  # dependency-only PR skipped this job).
   # ──────────────────────────────────────────────────────────────
   e2e-mocked:
     name: E2E mocked
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
         "pino": "^10.3.1",
-        "playwright-core": "~1.61.0",
+        "playwright-core": "~1.59.1",
         "utility-types": "^3.11.0"
       },
       "devDependencies": {
@@ -8161,9 +8161,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "pino": "^10.3.1",
-    "playwright-core": "~1.61.0",
+    "playwright-core": "~1.59.1",
     "utility-types": "^3.11.0"
   },
   "files": [


### PR DESCRIPTION
## Why

`playwright-core@1.61.0` (merged to `main` via dependabot PR #351) broke
every browser-launch path. Its Firefox backend now sends the Juggler
`Browser.setDefaultViewport` command with a `viewport.isMobile` property
that the pinned Camoufox build''s schema rejects, so `browser.newContext()`
throws:

```
browser.newContext: Protocol error (Browser.setDefaultViewport):
ERROR: failed to call method ''Browser.setDefaultViewport'':
Found property "<root>.viewport.isMobile" - not described in this scheme
```

This surfaced as **19 E2E-mocked failures** on the first PR (#356) to run
the browser gates after the bump. Two root problems:

1. **The bump itself is incompatible** - no published Camoufox build accepts
   the 1.61 Juggler schema yet, so 1.61 cannot be used until Camoufox
   catches up.
2. **CI never validated the bump** - dependabot PR #351 changed only
   `package.json` / `package-lock.json`; the `e2e-mocked` and `e2e-factory`
   jobs gate on `src == ''true''`, so both were **skipped** and the
   regression landed on `main` unvalidated.

## What

Two atomic commits:

- **`fix(deps): pin playwright-core to 1.59.x`** - revert `playwright-core`
  to `~1.59.1`, the last release compatible with the current Camoufox
  build. Lockfile regenerated with `npm install` (not hand-edited).
- **`ci: run browser E2E on dependency-update PRs`** - add a `deps` output
  to `detect-changes.sh` (true when `package.json`, `package-lock.json`, or
  `.github/dependabot.yml` change) and OR it into the `e2e-mocked` /
  `e2e-factory` `if:` conditions. Dependency-only PRs now exercise the real
  Camoufox launch, and the required `Validate` aggregator goes red if either
  gate fails - so a future incompatible bump can no longer merge silently.

### Validation

- Full **E2E mocked** suite under the pinned 1.59.1: **8 suites, 31 tests,
  0 failures** (the 19 `setDefaultViewport` failures are gone).
- `detect-changes.sh`: `bash -n` clean; deps-only diff simulation yields
  `src=false deps=true` (drives the E2E gates).

## Guideline compliance

| Guideline | How this PR complies |
| --- | --- |
| `dependency-updates-guidlines.md` section 7 (validate **every** dep update via lint/unit/integration/E2E/build) | The `deps` gate forces `e2e-mocked` + `e2e-factory` to run on every dependency-manifest change - the validation that was missing for #351. |
| `dependency-updates-guidlines.md` section 26 (never hand-edit lock files) | Lockfile regenerated via `npm install`, then validated by the full E2E mocked suite. |
| `before-commit-guidlines.md` (atomic commits, selective staging, no `git add .`, no hook bypass) | Two atomic commits, files staged explicitly per commit, full husky hooks run (no `--no-verify`). |
| `before-commit-guidlines.md` section 2 (never weaken guards/thresholds) | No gate weakened - this PR **adds** a gate. |
| `commit-guidlines.md` (Conventional Commits, 50/72) | Subjects <= 50 chars, bodies wrapped <= 72, imperative mood, WHY explained. |
| `pr-guidlines.md` section 7/10 (Why/What/Guideline-compliance sections) | Present and validated via `npm run lint:pr-body`. |
