### PR TITLE
refactor(scrape): break ScrapeChunking leaky-barrel cycle

### DIFF
--- a/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeChunking.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeChunking.ts
@@ -1,6 +1,12 @@
 /**
  * Scrape chunking — monthly chunk fetch, dedup, date filter, assembly.
  * Extracted from ScrapeFetchHelpers.ts to respect max-lines.
+ *
+ * <p>Imports its dedup/assembly helpers from the concrete `ScrapeData/*`
+ * siblings, NOT from the `ScrapeDataActions` barrel — the barrel re-exports
+ * {@link scrapeWithMonthlyChunking} from this file, so importing back through
+ * it would close a leaky-barrel dependency cycle. Keep these direct; the
+ * acyclic-dependencies gate fails if they are routed via the barrel again.
  */
 
 import type { ITransaction, ITransactionsAccount } from '../../../../Transactions.js';
@@ -10,16 +16,16 @@ import { generateMonthChunks, replaceField } from '../../Mediator/Scrape/ScrapeA
 import type { JsonRecord } from '../../Mediator/Scrape/ScrapeReplayAction.js';
 import { applyDateRangeAndAppend } from '../../Mediator/Scrape/UrlDateRange.js';
 import { PIPELINE_WELL_KNOWN_TXN_FIELDS as WK } from '../../Registry/WK/ScrapeWK.js';
+import type { Brand } from '../../Types/Brand.js';
+import type { Procedure } from '../../Types/Procedure.js';
+import { isOk } from '../../Types/Procedure.js';
+import buildAccountResult from './ScrapeData/ScrapeDataAssembly.js';
 import {
-  buildAccountResult,
   deduplicateTxns,
   FALLBACK_DEDUP_KEY_FIELDS,
   parseStartDate,
   rateLimitPause,
-} from '../../Strategy/Scrape/ScrapeDataActions.js';
-import type { Brand } from '../../Types/Brand.js';
-import type { Procedure } from '../../Types/Procedure.js';
-import { isOk } from '../../Types/Procedure.js';
+} from './ScrapeData/ScrapeDataDedup.js';
 import { EMPTY_TXN_ENDPOINT, type IAccountAssemblyCtx, type IChunkingCtx } from './ScrapeTypes.js';
 
 type IsAfterStart = Brand<boolean, 'IsAfterStart'>;

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 11,
+  "cycleCount": 10,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts",
@@ -114,10 +114,6 @@
     [
       "src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts",
       "src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigSeeder.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Strategy/Scrape/ScrapeChunking.ts",
-      "src/Scrapers/Pipeline/Strategy/Scrape/ScrapeDataActions.ts"
     ]
   ]
 }


### PR DESCRIPTION
# Break the ScrapeChunking ↔ ScrapeDataActions leaky-barrel cycle

Step 3 of the corrected, **coupling-driven** decoupling approach: the first
real dependency-cycle burn-down on the acyclic-dependencies gate — proof
that the method (measure coupling, not file size) actually removes cycles.

## Why

The cycle gate ([#359](https://github.com/sergienko4/israeli-bank-scrapers/pull/359))
froze 11 dependency cycles. One of them was a **leaky barrel**:
`Strategy/Scrape/ScrapeChunking.ts` imported `buildAccountResult` and the
dedup helpers **from** the `ScrapeDataActions` barrel, while that same
barrel re-exports this file's `scrapeWithMonthlyChunking`. The mutual
reference formed a 2-node SCC. This is exactly the "we split the file in
#358 but left the cycle" issue the coupling audit surfaced — splitting a
god-module behind a barrel lowers per-file LoC but can leave (or create)
cycles that `max-lines` never sees.

## What

- **Rewired** `ScrapeChunking.ts` to import the concrete `ScrapeData/*`
  siblings **directly** instead of through the barrel:
  `import buildAccountResult from './ScrapeData/ScrapeDataAssembly.js'`
  (default) and `{ deduplicateTxns, FALLBACK_DEDUP_KEY_FIELDS,
  parseStartDate, rateLimitPause }` from `'./ScrapeData/ScrapeDataDedup.js'`
  (named). The bound symbols are byte-identical to what the barrel re-exported.
- **Barrel unchanged** — `ScrapeDataActions.ts` still re-exports every
  symbol for its other consumers; only the back-edge from ScrapeChunking
  is removed.
- **Added a JSDoc note** on `ScrapeChunking.ts` explaining the direct
  sibling imports must stay direct, so the cycle is not silently
  reintroduced by a future "tidy-up" back to the barrel.
- **Re-froze the cycle baseline 11 → 10**, dropping the resolved
  `[ScrapeChunking, ScrapeDataActions]` entry. The gate's subset ratchet
  now **fails** if the barrel import is ever reintroduced (it would be a
  new, unbaselined cycle).

**No public API or runtime behavior change** — pure import rewiring; the 56
unit tests across ScrapeChunking + ScrapeDataActions + ImportCycles pass
unmodified.

## Guideline compliance

> Self-declaration produced during the A3.5 pre-PR exit gate
> (`agent-contract.md` §A3.5.9). This PR touches production Pipeline source
> (one import block) but adds **no** new eslint guardrail — it removes a
> cycle and tightens the existing cycle baseline, so no `chore(eslint):`
> cap change is needed.

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | CLEAN_CODE.md §Functions ≤ 10 LoC | ✅ no function bodies changed — import-source rewiring + JSDoc only; `npx eslint --max-warnings=0` on the file = 0 problems |
| 2 | CLEAN_CODE.md §Files ≤ 150 LoC | ✅ ScrapeChunking net change is import lines + a doc comment; still under cap; eslint clean |
| 3 | CLEAN_CODE.md §Complexity ≤ 10 | ✅ eslint `complexity: 10` passes (no logic touched) |
| 4 | CLEAN_CODE.md §Params ≤ 3 | ✅ N/A — no signatures changed |
| 5 | CLAUDE.md §ZERO CSS Selectors / architecture | ✅ N/A — module-wiring only; no interaction code, no selectors |
| 6 | design-patterns-guidlines.md — barrels must not re-export their own importers (Hyrum's-Law leaky barrel) | ✅ this PR **is** that fix: removes the back-edge that made the barrel leak into its own dependency |
| 7 | agent-contract.md §A3.5 — pre-PR exit gate | ✅ ALL GREEN — see exit-gate summary below (incl. rubber-duck, 0 findings) |
| 8 | agent-contract.md §Test safety net — test BODIES unchanged | ✅ zero test files changed; 56 existing unit tests pass unmodified |
| 9 | NEVER list — no `--no-verify`, no weakened rules/gates | ✅ committed through all 21 husky gates; `eslint.config.mjs` untouched; the cycle baseline is **tightened** (11→10), never widened |
| 10 | Conventional Commits (commit-guidlines.md) | ✅ `refactor(scrape): break ScrapeChunking cycle` — subject 44 chars, body wrapped ≤ 72, `Co-authored-by` trailer |
| 11 | before-commit-guidlines.md — selective staging + 21 husky gates | ✅ no `git add .`; exactly 2 files staged; all 21 pre-commit gates green (tsc, eslint, biome, build, canaries, dead-code, **cycles**, guideline-coverage, …) |
| 12 | Public API byte-identical surface | ✅ `src/index.ts` unchanged; the rewired symbols are internal; `npm run build` exit 0 (in pre-commit) |
| 13 | Coverage preserved | ✅ no production logic added or removed — only the import source path changed |
| 14 | `lint:canaries` count matches `status.txt` | ✅ N/A — no numeric eslint rule added; `lint:canaries` still passes |
| 15 | `madge`/cycle gate in touched cluster | ✅ `npm run lint:cycles` = **10** cycles (was 11), all within the re-frozen baseline; the ScrapeChunking↔ScrapeDataActions SCC is gone |

### A3.5 pre-PR exit-gate summary

```
SCRAPE CYCLE-BREAK PRE-PR REVIEW — 2026-06-16
================================================
A3.5.1  doc-drift            GREEN (no public docs affected; internal JSDoc added)
A3.5.2  eslint audit         GREEN (eslint.config.mjs untouched; no new grandfather)
A3.5.3  public surface       GREEN (src/index.ts unchanged; lib build exit 0)
A3.5.4  test-body freeze     GREEN (zero test files changed; 56 unit tests pass)
A3.5.5  cycle gate           GREEN (10 cycles, was 11; baseline re-frozen, entry dropped)
A3.5.6  cap-align            GREEN (no new caps needed; file under 150 LoC, fns ≤ 10)
A3.5.7  rubber-duck          GREEN (0 RED, 0 YELLOW; independently re-verified export shapes)
A3.5.8  prod-leak            GREEN (no debug/PII/TODO; minimal import diff)
A3.5.9  tsc/eslint/tests     GREEN (type-check, eslint, dead-code, architecture, 56 tests pass)
================================================
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal module organization to improve code maintainability and reduce dependency complexity within the scraping pipeline architecture.

* **Chores**
  * Updated test baselines to reflect code organization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->