### PR TITLE
refactor(scrape): unbarrel MatrixLoopStrategy helper imports

### DIFF
--- a/src/Scrapers/Pipeline/Strategy/Scrape/MatrixLoopStrategy.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/MatrixLoopStrategy.ts
@@ -4,6 +4,12 @@
  * Does NOT modify the legacy billing fallback used by Discount/VisaCal.
  *
  * SOLID (OCP): extends scrape capabilities without modifying existing code.
+ *
+ * <p>Pulls its dedup/assembly helpers from the concrete `ScrapeData/*`
+ * siblings, NOT from the `ScrapeDataActions` barrel — that barrel re-exports
+ * `ScrapeChunking`, so routing helper imports through it would couple this
+ * strategy to the chunking module (and its transitive graph) for no reason.
+ * Keep these imports direct.
  */
 
 import type { ITransaction, ITransactionsAccount } from '../../../../Transactions.js';
@@ -19,13 +25,13 @@ import { maskVisibleText } from '../../Types/LogEvent.js';
 import type { IBillingCycle } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { isOk } from '../../Types/Procedure.js';
+import buildAccountResult from './ScrapeData/ScrapeDataAssembly.js';
 import {
-  buildAccountResult,
   deduplicateTxns,
   FALLBACK_DEDUP_KEY_FIELDS,
   parseStartDate,
   rateLimitPause,
-} from './ScrapeDataActions.js';
+} from './ScrapeData/ScrapeDataDedup.js';
 import { withTrace } from './ScrapeTraceWrapper.js';
 import {
   EMPTY_TXN_ENDPOINT,


### PR DESCRIPTION
# Unbarrel MatrixLoopStrategy's helper imports (coupling burn-down)

Follow-up to [#364](https://github.com/sergienko4/israeli-bank-scrapers/pull/364):
apply the same leaky-barrel fix to the second Scrape strategy that routed
concrete helpers through the `ScrapeDataActions` re-export hub.

## Why

`MatrixLoopStrategy.ts` imported `buildAccountResult` + the four dedup
helpers **through** the `ScrapeDataActions` barrel. That barrel also
re-exports `ScrapeChunking`, so every consumer that pulls helpers through it
inherits a dependency on the chunking module's transitive graph for no
reason. This is the exact leaky-barrel coupling #364 removed from
`ScrapeChunking` itself — `MatrixLoopStrategy` is the next-largest consumer
of the same hub.

Honest scope note: `MatrixLoopStrategy` is **not** a member of any of the 10
frozen dependency cycles, so this PR does **not** drop the SCC count. It
removes a needless coupling **edge** (a strategy → re-export-hub → chunking
dependency) and prevents the edge from ever closing a cycle. The measurable
cycle burn-downs (cycle 7's `Strategy ↔ Mediator/Scrape/ScrapePhase`
inversion; the 69-file Mediator SCC) are tracked as separate items.

## What

- **Rewired** `MatrixLoopStrategy.ts` to import the concrete `ScrapeData/*`
  siblings directly: `buildAccountResult` (default) from
  `./ScrapeData/ScrapeDataAssembly.js`, and `{ deduplicateTxns,
  FALLBACK_DEDUP_KEY_FIELDS, parseStartDate, rateLimitPause }` (named) from
  `./ScrapeData/ScrapeDataDedup.js`. The bound symbols are byte-identical to
  what the barrel re-exported.
- **Barrel unchanged** — `ScrapeDataActions.ts` still re-exports everything
  for its other consumers.
- **Added a JSDoc note** so the imports are not "tidied" back through the
  barrel (which would re-introduce the coupling).

**No public API or runtime behavior change** — pure import rewiring; 108
unit tests across MatrixLoopStrategy, AccountScrapeStrategy, ScrapeChunking,
WaveOBranchGaps and ScrapeDataActions pass unmodified.

## Guideline compliance

> Self-declaration produced during the A3.5 pre-PR exit gate
> (`agent-contract.md` §A3.5.9). Touches one production Pipeline file (one
> import block + a doc comment); adds **no** new eslint guardrail.

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | CLEAN_CODE.md §Functions ≤ 10 LoC | ✅ no function bodies changed — import rewiring + JSDoc only; `npx eslint --max-warnings=0` = 0 problems |
| 2 | CLEAN_CODE.md §Files ≤ 150 LoC | ✅ net change is import lines + a comment; eslint clean |
| 3 | CLEAN_CODE.md §Complexity ≤ 10 | ✅ eslint `complexity` passes (no logic touched) |
| 4 | CLEAN_CODE.md §Params ≤ 3 | ✅ N/A — no signatures changed |
| 5 | CLAUDE.md §ZERO CSS Selectors / architecture | ✅ N/A — module-wiring only |
| 6 | design-patterns-guidlines.md — barrels must not re-export their own importers (leaky barrel) | ✅ removes a consumer's dependency on the leaky hub; barrel left export-only for others |
| 7 | agent-contract.md §A3.5 — pre-PR exit gate | ✅ ALL GREEN incl. rubber-duck (0 findings, export shapes re-verified) |
| 8 | agent-contract.md §Test safety net — test BODIES unchanged | ✅ zero test files changed; 108 existing unit tests pass unmodified |
| 9 | NEVER list — no `--no-verify`, no weakened rules/gates | ✅ committed through all 21 husky gates; `eslint.config.mjs` untouched; cycle baseline untouched (stays 10) |
| 10 | Conventional Commits (commit-guidlines.md) | ✅ `refactor(scrape): unbarrel MatrixLoop imports` — subject 45 chars, body wrapped ≤ 72, `Co-authored-by` trailer |
| 11 | before-commit-guidlines.md — selective staging + 21 husky gates | ✅ no `git add .`; exactly 1 file staged; all 21 pre-commit gates green |
| 12 | Public API byte-identical surface | ✅ `src/index.ts` unchanged; rewired symbols are internal; `npm run build` exit 0 (pre-commit) |
| 13 | Coverage preserved | ✅ no production logic added or removed — only the import source path changed |
| 14 | `lint:canaries` count matches `status.txt` | ✅ N/A — no numeric eslint rule added; `lint:canaries` still passes |
| 15 | `madge`/cycle gate in touched cluster | ✅ `npm run lint:cycles` = **10** (unchanged); MatrixLoopStrategy is in no cycle and none is introduced |

### A3.5 pre-PR exit-gate summary

```
MATRIXLOOP UNBARREL PRE-PR REVIEW — 2026-06-16
================================================
A3.5.1  doc-drift            GREEN (no public docs affected; internal JSDoc added)
A3.5.2  eslint audit         GREEN (eslint.config.mjs untouched)
A3.5.3  public surface       GREEN (src/index.ts unchanged; lib build exit 0)
A3.5.4  test-body freeze     GREEN (zero test files changed; 108 unit tests pass)
A3.5.5  cycle gate           GREEN (10 cycles, unchanged; baseline untouched)
A3.5.6  cap-align            GREEN (no new caps; file under cap, fns ≤ 10)
A3.5.7  rubber-duck          GREEN (0 RED/0 YELLOW; export shapes independently re-verified)
A3.5.8  prod-leak            GREEN (no debug/PII/TODO; minimal import diff)
A3.5.9  tsc/eslint/tests     GREEN (type-check, eslint, dead-code, architecture, 108 tests pass)
================================================
```
