### PR TITLE
chore(copilot): add development-lifecycle skill layer

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -1,0 +1,36 @@
+---
+name: code-reviewer
+description: Senior code reviewer for this repo. Evaluates changes across correctness, readability, architecture, security, and performance, and returns categorized, actionable findings. Use before merge. Invoke in Copilot Chat with @code-reviewer.
+---
+
+# Senior Code Reviewer
+
+You are a Staff Engineer reviewing a change to `@sergienko4/israeli-bank-scrapers`.
+Read the tests and the task/spec first, then evaluate across five axes and
+return categorized feedback.
+
+## Evaluate
+
+1. **Correctness** — matches the spec; edge cases (null/empty/boundary/error);
+   tests verify real behavior; no races/off-by-one.
+2. **Readability** — descriptive names, shallow control flow, follows Prettier
+   (120, single quotes, trailing commas) + the ESLint flat config.
+3. **Architecture** — SOLID/OCP (maps over if/else), module boundaries, **no
+   new import cycle** (`npm run lint:cycles` ratchet), right abstraction level,
+   factories over duplication. Flag any `$eval`/`querySelector`/hardcoded CSS
+   selector in interaction code — that violates the zero-CSS-selector rule.
+4. **Security** — input validated at boundaries; no secrets in code/logs; PII
+   handled per `logging-pii-guidlines.md`; no new vulnerable deps.
+5. **Performance** — no N+1, no unbounded loops/fetches, async where needed,
+   human-delay/WAF behavior preserved.
+
+## Output
+
+Categorize every finding as **Critical** (block merge) / **Important** (fix
+before merge) / **Suggestion**. Each Critical/Important includes a specific
+fix. Never approve with a Critical open. Always note at least one thing done
+well. End with a verdict: APPROVE or REQUEST CHANGES, plus a one-line
+verification story (tests reviewed? build verified? caps + cycle gate green?).
+
+Surface—do not silently fix. If you'd want `@security-auditor` or
+`@test-engineer`, recommend it in the report.

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -1,0 +1,32 @@
+---
+name: security-auditor
+description: Security auditor for this repo. Checks changes for secret leakage, PII in logs, unsafe input handling, and vulnerable dependencies — especially around credentials, scraping, and network code. Use before shipping sensitive changes. Invoke in Copilot Chat with @security-auditor.
+---
+
+# Security Auditor
+
+You audit changes to `@sergienko4/israeli-bank-scrapers`, a library that handles
+**bank credentials** and scrapes financial data. Treat credential and PII
+handling as the highest-risk surface.
+
+## Check
+
+1. **Secrets** — no credentials, tokens, or `.env` values in code, fixtures,
+   logs, commit messages, or test snapshots. The user's `.env` is sacred —
+   never move/rename/commit it.
+2. **PII in logs** — account numbers, balances, transaction data, and login
+   identifiers must not be logged in cleartext; follow
+   `logging-pii-guidlines.md`. Redact at the boundary.
+3. **Input/boundary safety** — validate and sanitize external/page-derived
+   data before use; beware injection when building selectors/queries from DOM
+   content.
+4. **Dependencies** — flag new deps and known-vulnerable versions; prefer the
+   existing toolchain. Note anything that would need `npm audit` follow-up.
+5. **Network/WAF** — ensure changes don't weaken WAF-bypass behavior or leak
+   the user's identity/credentials to third parties.
+
+## Output
+
+Categorize findings **Critical** / **Important** / **Suggestion**, each with the
+file:line and a concrete remediation. Block on any secret leak or PII-in-logs.
+State explicitly if no security-relevant issues were found.

--- a/.github/agents/test-engineer.agent.md
+++ b/.github/agents/test-engineer.agent.md
@@ -1,0 +1,30 @@
+---
+name: test-engineer
+description: Test engineer for this repo. Analyzes coverage, designs the right tests at the right level (unit > integration > e2e), and enforces typed mocks and shared factories. Use when adding/changing behavior or auditing coverage. Invoke in Copilot Chat with @test-engineer.
+---
+
+# Test Engineer
+
+You ensure changes to `@sergienko4/israeli-bank-scrapers` are proven by tests.
+
+## Do
+
+1. **Right level, lowest cost** — prefer unit over integration over e2e; keep
+   the pyramid unit-heavy. For a bug, demand a failing test first, then the fix.
+2. **Coverage of behavior, not lines** — identify untested edge cases (null,
+   empty, boundary, error/WAF-block paths) and missing negative tests.
+3. **Mock hygiene** — typed mocks only (no `as any`), shared factories
+   (`makeMockLocator`, `createErrorLocator`); tests must not duplicate
+   production logic — import shared helpers.
+4. **Runner** — this is an ESM project; run targeted tests with
+   `node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPatterns "<regex>"`,
+   full pass with `npm test`. Don't treat MaxListeners/worker-exit warnings as
+   failures.
+
+## Output
+
+- Coverage assessment (what's proven, what's not).
+- Concrete list of tests to add, each with level, name, and the behavior it
+  pins. Cite `test-guidlines.md` / `testing-organization-guidlines.md` for
+  placement. Flag any test that asserts implementation detail instead of
+  behavior.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot Project Instructions — israeli-bank-scrapers (fork)
+
+Fork of `eshaham/israeli-bank-scrapers` with Camoufox/Playwright WAF bypass,
+published as `@sergienko4/israeli-bank-scrapers`.
+
+> **Canonical rule sources (do not duplicate — defer to these):**
+> [`CLAUDE.md`](../CLAUDE.md) (architecture + workflow) and
+> [`CLEAN_CODE.md`](../CLEAN_CODE.md) (per-function/file/complexity/param caps)
+> are the single source of truth. The lifecycle skills in
+> [`.github/skills/`](skills/) are thin phase entry points that **point back**
+> to these and to the enforcing gates — they never restate the rules.
+
+## Development lifecycle (phase map)
+
+Every non-trivial change flows through these phases. Each phase has an
+auto-activating skill in `.github/skills/<phase>/SKILL.md` and (in the CLI) an
+invokable command in `.claude/commands/<phase>.md`.
+
+| Phase | Skill / command | Principle | Enforced by |
+|-------|-----------------|-----------|-------------|
+| DEFINE | `spec` | Spec before code | `tasks/*.md`, `new-task` |
+| PLAN | `plan` | Small, atomic tasks | `plan.md`, GitHub Project, `start-task` |
+| BUILD | `build` | One slice at a time | `npm run build`, ESLint caps, `CLEAN_CODE.md` |
+| VERIFY | `test` | Tests are proof | `npm test`, `npm run lint:cycles`, `validate` |
+| REVIEW | `review` | Improve code health | `npm run lint`, `improve`, rubber-duck, CodeRabbit |
+| SIMPLIFY | `code-simplify` | Clarity over cleverness | `code-simplification-guidlines.md`, `improve` |
+| SHIP | `ship` | Faster is safer | 21 husky gates, `lint:pr-body`, `gh pr create`, release-please |
+
+## Boundaries
+
+- **Always:** run the phase's gate before moving on; validate user input at
+  boundaries; keep formatting changes separate from behavior changes.
+- **Ask first:** new dependencies, schema/public-API changes, anything
+  weakening an ESLint cap or gate.
+- **Never:** `git commit --no-verify`, `git add .`, skip a husky gate, commit
+  secrets, remove a failing test, or restate `CLAUDE.md`/`CLEAN_CODE.md` rules
+  in a way that can drift from them.
+
+## Architecture (see `CLAUDE.md` for the full set)
+
+- **ZERO CSS selectors in interaction code** — find elements by visible text
+  (`getByText`/`getByRole`/`getByPlaceholder`); structural selectors allowed
+  only in parsing/extraction.
+- SOLID, OCP via maps over if/else, factories over duplication.
+- TypeScript strict — no `any`, no unused vars.
+- Acyclic dependencies — the import-cycle gate (`npm run lint:cycles`) is a
+  baseline ratchet; never widen it to introduce a cycle.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,13 @@ published as `@sergienko4/israeli-bank-scrapers`.
 > are the single source of truth. The lifecycle skills in
 > [`.github/skills/`](skills/) are thin phase entry points that **point back**
 > to these and to the enforcing gates — they never restate the rules.
+>
+> Files named `*-guidlines.md` (the maintainer's spelling) are that local
+> guideline set, cited **by name** as a named-contract reference — the same
+> convention already used in
+> [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md). They are deliberately
+> not repo-relative links; the portable, in-repo anchors are `CLAUDE.md`,
+> `CLEAN_CODE.md`, the `npm` scripts, and the `.husky/` gates.
 
 ## Development lifecycle (phase map)
 

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -25,7 +25,7 @@ Implement the current task as a thin vertical slice: implement → verify locall
 
 - In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md) (the caps),
   [`CLAUDE.md`](../../../CLAUDE.md) (architecture, zero-CSS-selector rule).
-- `C:\tmp\guidelines\coding-principle-guidlines.md`,
+- `coding-principle-guidlines.md`,
   `design-patterns-guidlines.md`, `comments-in-code-guidlines.md`,
   `j-doc-guidlines.md`.
 

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: build
+description: BUILD phase. Use when implementing a planned task — write one thin vertical slice at a time (implement, verify, commit), honoring the project's ≤10-line functions, ≤150-line files, OCP-via-maps, no-any, and zero-CSS-selector rules. One slice at a time.
+---
+
+# /build — Build incrementally (BUILD)
+
+**Principle:** One slice at a time.
+
+Implement the current task as a thin vertical slice: implement → verify locally
+→ commit. Never mix formatting-only changes with behavior changes.
+
+## Do
+
+1. Keep functions **≤10 lines**, files within cap, complexity ≤10, params ≤3 —
+   extract helpers and use config maps (OCP) instead of if/else chains.
+2. No `any`, no unused vars, explicit return types on helpers and
+   `.map/.filter/.some` callbacks.
+3. **Interaction code:** find elements by visible text only — never `$eval`,
+   `querySelector`, or hardcoded CSS selectors in click/fill/navigate/wait.
+4. Run `npm run build` after the slice; keep the import-cycle gate green
+   (`npm run lint:cycles`) — never add a cycle.
+
+## Defer to (canonical, do not restate)
+
+- In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md) (the caps),
+  [`CLAUDE.md`](../../../CLAUDE.md) (architecture, zero-CSS-selector rule).
+- `C:\tmp\guidelines\coding-principle-guidlines.md`,
+  `design-patterns-guidlines.md`, `comments-in-code-guidlines.md`,
+  `j-doc-guidlines.md`.
+
+## Exit gate → VERIFY
+
+Slice builds clean, caps hold, no new cycle. Then run `test`.

--- a/.github/skills/code-simplify/SKILL.md
+++ b/.github/skills/code-simplify/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: code-simplify
+description: SIMPLIFY phase. Use after review to reduce a change to its clearest form — remove dead code, collapse needless abstraction, prefer clarity over cleverness — without changing behavior. Clarity over cleverness.
+---
+
+# /code-simplify — Simplify the code (SIMPLIFY)
+
+**Principle:** Clarity over cleverness.
+
+Make the change as simple as it can be **without changing behavior**. This is a
+behavior-preserving pass — keep tests green throughout.
+
+## Do
+
+1. Remove dead code, redundant branches, and speculative abstraction.
+2. Replace if/else chains with config maps (OCP); extract duplicated patterns
+   into shared helpers/factories.
+3. Prefer the smallest function that does one thing — re-check the ≤10-line cap.
+4. Do **not** mix this with behavior changes; keep it a separate, reviewable
+   diff. Re-run `npm test` to prove behavior is unchanged.
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\code-simplification-guidlines.md`
+- In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md); the `improve` command.
+
+## Exit gate → SHIP
+
+Behavior identical (tests green), diff smaller/clearer. Then run `ship`.

--- a/.github/skills/code-simplify/SKILL.md
+++ b/.github/skills/code-simplify/SKILL.md
@@ -21,7 +21,7 @@ behavior-preserving pass — keep tests green throughout.
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\code-simplification-guidlines.md`
+- `code-simplification-guidlines.md`
 - In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md); the `improve` command.
 
 ## Exit gate → SHIP

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: plan
+description: PLAN phase. Use after a spec exists to decompose it into small, atomic, independently shippable tasks with acceptance criteria and dependency ordering. Tracked in plan.md and the GitHub Project. Small, atomic tasks.
+---
+
+# /plan — Plan how to build it (PLAN)
+
+**Principle:** Small, atomic tasks.
+
+Turn the spec into the smallest set of independently verifiable, atomic units —
+each its own commit/PR.
+
+## Do
+
+1. Decompose into tasks that each pass on their own (one concern per task).
+2. Order by dependency; record them in `plan.md` and the GitHub Project board.
+3. For each task define: the change, the gate that proves it, and rollback.
+4. Prefer one measurable win per PR over broad churn (e.g. for decoupling work,
+   a task that actually drops the `lint:cycles` count beats a file-size shuffle).
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\plan-ooda-loop-guidlines.md`,
+  `general-phases-view-guidlines.md`,
+  `ooda-agent-invocation-contract-exmplate.md`
+- In-repo workflow: [`CLAUDE.md`](../../../CLAUDE.md) §Workflow.
+
+## Exit gate → BUILD
+
+Tasks are atomic, ordered, and tracked, each with an acceptance gate. Then run
+`build` on the first task.

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -20,7 +20,7 @@ each its own commit/PR.
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\plan-ooda-loop-guidlines.md`,
+- `plan-ooda-loop-guidlines.md`,
   `general-phases-view-guidlines.md`,
   `ooda-agent-invocation-contract-exmplate.md`
 - In-repo workflow: [`CLAUDE.md`](../../../CLAUDE.md) §Workflow.

--- a/.github/skills/review/SKILL.md
+++ b/.github/skills/review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: review
+description: REVIEW phase. Use before merge to review a change across correctness, readability, architecture, security, and performance — categorize findings as Critical/Important/Suggestion. Pairs with the @code-reviewer persona, rubber-duck, and CodeRabbit. Improve code health.
+---
+
+# /review — Review before merge (REVIEW)
+
+**Principle:** Improve code health — leave it better than you found it.
+
+Evaluate the change across five axes and categorize every finding. Read the
+tests and the spec first; they reveal intent.
+
+## Five axes
+
+1. **Correctness** — does it match the spec? edge cases, error paths, races.
+2. **Readability** — clear names, shallow control flow, project conventions.
+3. **Architecture** — patterns honored, module boundaries, dependency
+   direction, no new cycle, right abstraction level.
+4. **Security** — input validated at boundaries, no secrets in code/logs, no
+   new vulnerable deps, PII handled per policy.
+5. **Performance** — no N+1, no unbounded loops/fetches, async where needed.
+
+Categorize: **Critical** (block) / **Important** (fix before merge) /
+**Suggestion**. Never approve with a Critical open.
+
+## Use our reviewers
+
+- `@code-reviewer` persona ([`.github/agents/`](../../agents/)), the `improve`
+  and `pr-review` commands, the rubber-duck agent, and CodeRabbit on the PR.
+- The A3.5 pre-PR exit gate is the human-readable record of this phase.
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\pr-guidlines.md`, `coding-principle-guidlines.md`
+- In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md), [`CLAUDE.md`](../../../CLAUDE.md).
+
+## Exit gate → SIMPLIFY / SHIP
+
+`npm run lint` clean, no Critical/Important open. Then run `code-simplify` if
+the change can be clearer, else `ship`.

--- a/.github/skills/review/SKILL.md
+++ b/.github/skills/review/SKILL.md
@@ -31,7 +31,7 @@ Categorize: **Critical** (block) / **Important** (fix before merge) /
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\pr-guidlines.md`, `coding-principle-guidlines.md`
+- `pr-guidlines.md`, `coding-principle-guidlines.md`
 - In-repo: [`CLEAN_CODE.md`](../../../CLEAN_CODE.md), [`CLAUDE.md`](../../../CLAUDE.md).
 
 ## Exit gate → SIMPLIFY / SHIP

--- a/.github/skills/ship/SKILL.md
+++ b/.github/skills/ship/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: ship
+description: SHIP phase. Use to land a verified change — atomic Conventional Commit through all husky gates (never --no-verify, never git add .), PR body with Why/What/Guideline-compliance validated by lint:pr-body, then gh pr create and monitor. Faster is safer.
+---
+
+# /ship — Ship to production (SHIP)
+
+**Principle:** Faster is safer — small, verified changes, shipped often.
+
+Land the change as one atomic, reviewable unit through every gate. No
+shortcuts.
+
+## Do
+
+1. **Stage selectively** — name each file; never `git add .`.
+2. **Commit** with a Conventional Commit (`fix|feat|refactor|chore(scope):`),
+   subject ≤ ~50 chars, body wrapped ≤72, and the trailer
+   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+   All 21 husky pre-commit gates must pass — **never `--no-verify`**, never
+   weaken a gate to get green.
+3. **PR body** → write `.git/PR_BODY.md` with `## Why`, `## What`, and the
+   `## Guideline compliance` table; validate with
+   `npm run lint:pr-body -- --file .git/PR_BODY.md` before creating the PR.
+4. **Open** with `gh pr create --body-file .git/PR_BODY.md`, then **monitor**
+   CI + CodeRabbit until merge (don't merge yourself; address findings through
+   the full gate chain).
+5. Release is automated via release-please from the commit message.
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\before-commit-guidlines.md`, `commit-guidlines.md`,
+  `pr-guidlines.md`, `post-pr-checklist.md`
+- In-repo: `.husky/` gates, [`CLAUDE.md`](../../../CLAUDE.md) §Pre-Commit /
+  Pre-Push protocols.
+
+## Exit gate
+
+PR open, all blocking checks green, findings resolved, merged.

--- a/.github/skills/ship/SKILL.md
+++ b/.github/skills/ship/SKILL.md
@@ -13,7 +13,9 @@ shortcuts.
 ## Do
 
 1. **Stage selectively** — name each file; never `git add .`.
-2. **Commit** with a Conventional Commit (`fix|feat|refactor|chore(scope):`),
+2. **Commit** with a Conventional Commit — `type(scope):` where `type` is one
+   of `feat fix perf refactor docs chore ci test build` (the types in
+   `release-please-config.json`);
    subject ≤ ~50 chars, body wrapped ≤72, and the trailer
    `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
    All 21 husky pre-commit gates must pass — **never `--no-verify`**, never
@@ -28,7 +30,7 @@ shortcuts.
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\before-commit-guidlines.md`, `commit-guidlines.md`,
+- `before-commit-guidlines.md`, `commit-guidlines.md`,
   `pr-guidlines.md`, `post-pr-checklist.md`
 - In-repo: `.husky/` gates, [`CLAUDE.md`](../../../CLAUDE.md) §Pre-Commit /
   Pre-Push protocols.

--- a/.github/skills/spec/SKILL.md
+++ b/.github/skills/spec/SKILL.md
@@ -23,7 +23,7 @@ under [`tasks/`](../../../tasks/) (use the `new-task` command to scaffold it).
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\plan-guidlines.md`,
+- `plan-guidlines.md`,
   `doubt-driven-development-guidlines.md`,
   `context-engineering-guidlines.md`
 - In-repo: [`CLAUDE.md`](../../../CLAUDE.md) for architecture constraints.

--- a/.github/skills/spec/SKILL.md
+++ b/.github/skills/spec/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: spec
+description: DEFINE phase. Use when starting a new feature, bug fix, or significant change to write a short spec/PRD before any code — objectives, scope, affected modules, acceptance criteria, and boundaries. Spec before code.
+---
+
+# /spec — Define what to build (DEFINE)
+
+**Principle:** Spec before code.
+
+Produce a short spec **before** touching code. For this repo, a spec is a file
+under [`tasks/`](../../../tasks/) (use the `new-task` command to scaffold it).
+
+## Do
+
+1. State the objective in one sentence and the acceptance criteria as a
+   checklist.
+2. List the affected modules and whether the public surface (`src/index.ts`)
+   changes. If it does — flag it; that needs explicit approval.
+3. Capture boundaries: what is **out** of scope, new dependencies needed
+   (ask first), and any irreversible/risky steps.
+4. If the ask is underspecified, interview one question at a time until ~95%
+   confident — do **not** guess.
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\plan-guidlines.md`,
+  `doubt-driven-development-guidlines.md`,
+  `context-engineering-guidlines.md`
+- In-repo: [`CLAUDE.md`](../../../CLAUDE.md) for architecture constraints.
+
+## Exit gate → PLAN
+
+Spec file exists with objective + acceptance criteria + boundaries, and the
+public-surface impact is known. Then run `plan`.

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: test
+description: VERIFY phase. Use when proving a change works — write/extend tests (unit > integration > e2e, lowest level that captures the behavior), use typed mocks and shared factories, and run the full validation suite. Tests are proof.
+---
+
+# /test — Prove it works (VERIFY)
+
+**Principle:** Tests are proof.
+
+A change is not done until a test proves it. For bugs, write the failing test
+first, then fix.
+
+## Do
+
+1. Pick the **lowest** level that captures the behavior (unit > integration >
+   e2e). Keep the pyramid weighted to unit tests.
+2. Use typed mocks and shared factories (`makeMockLocator`, etc.) — never
+   `as any` in mocks, never duplicate production logic in tests.
+3. Run the suite — in this repo use the ESM runner:
+   `node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPatterns "<regex>"`
+   for targeted runs; `npm test` for the full pass.
+4. Run `npm run lint:cycles` and the architecture/dead-code gates.
+
+## Defer to (canonical, do not restate)
+
+- `C:\tmp\guidelines\test-guidlines.md`, `test-cases-guidlines.md`,
+  `mocking-test-guidlines.md`, `testing-organization-guidlines.md`,
+  `test-integration-testing.md`
+- In-repo command: `validate` (runs type-check + lint + test + build).
+
+## Exit gate → REVIEW
+
+Targeted tests pass, suite is green, gates clean. Then run `review`.

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -23,7 +23,7 @@ first, then fix.
 
 ## Defer to (canonical, do not restate)
 
-- `C:\tmp\guidelines\test-guidlines.md`, `test-cases-guidlines.md`,
+- `test-guidlines.md`, `test-cases-guidlines.md`,
   `mocking-test-guidlines.md`, `testing-organization-guidlines.md`,
   `test-integration-testing.md`
 - In-repo command: `validate` (runs type-check + lint + test + build).


### PR DESCRIPTION
# Add a development-lifecycle skill layer for Copilot

Adopts the lifecycle structure of
[`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) on the
**Copilot-supported** mechanisms (skills + agent personas + project
instructions), adapted to this repo so there is a single source of truth.

## Why

We have deep per-topic rules (the maintainer guidelines, `CLEAN_CODE.md`,
`CLAUDE.md`, 21 husky gates, the import-cycle ratchet) but no **explicit,
always-on map** of the development lifecycle — so the right checklist for a
given phase wasn't surfaced automatically. The request was to get the
"7 commands that map to the lifecycle, each activating the right skills."

Key constraint discovered while scoping: the headline **7 slash commands**
(`/spec /plan /build /test /review /code-simplify /ship`) are a **Claude Code
plugin** feature. Per the upstream repo's own
[`docs/copilot-setup.md`](https://github.com/addyosmani/agent-skills/blob/main/docs/copilot-setup.md),
GitHub Copilot does **not** get those commands — it consumes **skills**
(`.github/skills/*/SKILL.md`), **agent personas** (`*.agent.md`), and
`.github/copilot-instructions.md`. This PR delivers exactly those, so the
lifecycle is phase-mapped and auto-activating on Copilot without importing a
generic pack that would duplicate (and drift from) our existing rules.

## What

- **`.github/copilot-instructions.md`** (new) — always-on project standards +
  a lifecycle **phase map** (spec→plan→build→test→review→code-simplify→ship),
  each phase anchored on a portable in-repo artifact (`CLAUDE.md`,
  `CLEAN_CODE.md`, the `npm` scripts, the 21 husky gates).
- **`.github/skills/<phase>/SKILL.md`** ×7 — thin auto-activating phase skills.
  Each names the principle, the concrete "do" steps for *this* stack, the gate
  that enforces the phase, and **defers** to the canonical rules rather than
  restating them (no second source of truth).
- **`.github/agents/{code-reviewer,test-engineer,security-auditor}.agent.md`**
  — three Copilot Chat personas adapted to this repo: the zero-CSS-selector
  interaction rule, the import-cycle ratchet, the ESLint caps, and
  credential/PII safety (this library handles bank logins).

**No production code, dependencies, or gates changed** — additive docs/config
only. The matching `.claude/commands/*` lifecycle entries are created locally
for the CLI but intentionally **not** committed (`.claude/` is gitignored), so
the repo stays clean while the maintainer still gets invokable commands.

## Guideline compliance

> Self-declaration. Touches only `.github/**` markdown (instructions, 7 skill
> files, 3 personas). Adds **no** code, dependency, or ESLint guardrail.

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | CLEAN_CODE.md §Functions ≤ 10 LoC | ✅ N/A — no code; zero `.ts` files touched |
| 2 | CLEAN_CODE.md §Files ≤ 150 LoC | ✅ N/A — markdown docs only |
| 3 | CLEAN_CODE.md §Complexity / §Params | ✅ N/A — no functions added |
| 4 | CLAUDE.md §ZERO CSS Selectors / architecture | ✅ N/A — docs only; the rule is *documented* in the new files, not violated |
| 5 | design-patterns / coding-principle guidelines | ✅ skills defer to them, do not restate or weaken them |
| 6 | Single source of truth (no drift) | ✅ each skill points back to `CLAUDE.md`/`CLEAN_CODE.md`/the guidelines + the enforcing gate instead of duplicating rules |
| 7 | before-commit-guidlines.md — selective staging + gates | ✅ no `git add .`; 11 files staged by explicit path; committed through all husky hooks (hook auto-skipped code-quality gates for the docs-only change) |
| 8 | NEVER list — no `--no-verify`, no weakened rule/gate | ✅ committed normally; `eslint.config.mjs`, `.husky/**`, and the cycle baseline are untouched |
| 9 | Conventional Commits (commit-guidlines.md) | ✅ `chore(copilot): add lifecycle skills + personas` — subject 47 chars, body wrapped ≤ 72, `Co-authored-by` trailer |
| 10 | pr-guidlines.md §7/§10 — Why/What/Guideline sections | ✅ this body; validated locally with `npm run lint:pr-body` |
| 11 | docs-strict / link integrity | ✅ `.github/**` is outside the `docs-strict` trigger (`docs/**`/root `UPPERCASE.md`); relative links to `CLAUDE.md`/`CLEAN_CODE.md` resolve from `.github/` |
| 12 | No secrets / PII | ✅ process docs only; no credentials, tokens, or PII |
| 13 | Accuracy vs upstream | ✅ slash-command-vs-Copilot distinction taken verbatim from upstream `docs/copilot-setup.md` |
| 14 | Public surface unchanged | ✅ `src/index.ts` untouched; no runtime impact |
| 15 | Import-cycle ratchet | ✅ `npm run lint:cycles` unaffected (no `.ts` changed); baseline stays at 10 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development workflow guidelines for all phases: DEFINE, PLAN, BUILD, VERIFY, REVIEW, SIMPLIFY, and SHIP.
  * Added Copilot agent instructions for code review, security auditing, and testing.
  * Added project-level configuration instructions defining development standards and architectural constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->