### PR TITLE
refactor(pipeline): break 3 orphan import cycles (12g part 1/2)

### DIFF
--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -1170,3 +1170,7 @@ defaultTlsUpgrade
 IRunTlsInput
 # Reason: Tls — runs the TLS phase within budget; consumed only by the Probe orchestrator.
 runTlsPhase
+# Reason: ApiDirectScrape — action-context payload type for the shape-driven scrape fn; framework-internal phase type relocated to a leaf in the 12g cycle-break (was already exported from ApiDirectScrapePhase.ts). Not user-facing.
+ApiDirectScrapeResult
+# Reason: ApiDirectScrape — bound phase-action fn type; framework-internal, relocated to a leaf in the 12g cycle-break (was already exported from ApiDirectScrapePhase.ts). Not user-facing.
+ApiDirectScrapeFn

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineAssembly.ts
@@ -26,7 +26,7 @@ import { createAuthDiscoveryPhase } from '../../Phases/AuthDiscovery/AuthDiscove
 import { createBalanceResolvePhase } from '../../Phases/BalanceResolve/BalanceResolvePhase.js';
 import { createDashboardPhase } from '../../Phases/Dashboard/DashboardPhase.js';
 import { createHomePhase } from '../../Phases/Home/HomePhase.js';
-import { createInitPhase } from '../../Phases/Init/InitPhase.js';
+import { createInitPhase } from '../../Phases/Init/InitPhaseFactory.js';
 import { createOtpFillPhase } from '../../Phases/OtpFill/OtpFillPhase.js';
 import { createOtpTriggerPhase } from '../../Phases/OtpTrigger/OtpTriggerPhase.js';
 import { createPreLoginPhase } from '../../Phases/PreLogin/FindLoginAreaPhase.js';

--- a/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeActions.ts
+++ b/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeActions.ts
@@ -15,7 +15,6 @@ import { some } from '../../Types/Option.js';
 import type { IActionContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { isOk, succeed } from '../../Types/Procedure.js';
-import type { ApiDirectScrapeResult } from './ApiDirectScrapePhase.js';
 import {
   buildPageFetcher,
   buildStop,
@@ -24,6 +23,7 @@ import {
   type IAcctCtx,
   type IDriverCtx,
 } from './ApiDirectScrapeSteps.js';
+import type { ApiDirectScrapeResult } from './ApiDirectScrapeTypes.js';
 import type { IApiDirectScrapeShape } from './IApiDirectScrapeShape.js';
 
 /** Accumulator for per-account scrape results. */

--- a/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapePhase.ts
+++ b/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapePhase.ts
@@ -15,7 +15,7 @@
 
 import { logForensicAudit } from '../../Mediator/Scrape/ForensicAuditAction.js';
 import { BasePhase } from '../../Types/BasePhase.js';
-import { type Option, some } from '../../Types/Option.js';
+import { some } from '../../Types/Option.js';
 import type {
   IActionContext,
   IPipelineContext,
@@ -24,22 +24,10 @@ import type {
 import type { Procedure } from '../../Types/Procedure.js';
 import { succeed } from '../../Types/Procedure.js';
 import { buildGenericHeadlessScrape } from './ApiDirectScrapeActions.js';
+import type { ApiDirectScrapeFn } from './ApiDirectScrapeTypes.js';
 import type { IApiDirectScrapeShape } from './IApiDirectScrapeShape.js';
 
-/**
- * Action-context payload returned by the shape-driven scrape function:
- * the sealed action context augmented with the `scrape` slot that
- * DASHBOARD-style phases would otherwise commit. The intersection is
- * a true subtype of {@link IActionContext}, so this Procedure is
- * directly assignable to `Procedure<IActionContext>` (the shape
- * required by {@link BasePhase.action}) without an unsafe cast.
- */
-export type ApiDirectScrapeResult = IActionContext & {
-  readonly scrape: Option<IScrapeState>;
-};
-
-/** Bound phase action — the shape-driven scrape function. */
-export type ApiDirectScrapeFn = (ctx: IActionContext) => Promise<Procedure<ApiDirectScrapeResult>>;
+export type { ApiDirectScrapeFn, ApiDirectScrapeResult } from './ApiDirectScrapeTypes.js';
 
 /** ApiDirectScrape phase — BasePhase bound to a shape literal. */
 class ApiDirectScrapePhase extends BasePhase {

--- a/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeTypes.ts
+++ b/src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * ApiDirectScrape shared types — extracted so ApiDirectScrapeActions and
+ * ApiDirectScrapePhase both depend on this leaf module instead of each
+ * other, breaking the Actions<->Phase import cycle.
+ */
+
+import type { Option } from '../../Types/Option.js';
+import type { IActionContext, IScrapeState } from '../../Types/PipelineContext.js';
+import type { Procedure } from '../../Types/Procedure.js';
+
+/**
+ * Action-context payload returned by the shape-driven scrape function:
+ * the sealed action context augmented with the `scrape` slot that
+ * DASHBOARD-style phases would otherwise commit. The intersection is
+ * a true subtype of {@link IActionContext}, so this Procedure is
+ * directly assignable to `Procedure<IActionContext>` (the shape
+ * required by {@link BasePhase.action}) without an unsafe cast.
+ */
+export type ApiDirectScrapeResult = IActionContext & {
+  readonly scrape: Option<IScrapeState>;
+};
+
+/** Bound phase action — the shape-driven scrape function. */
+export type ApiDirectScrapeFn = (ctx: IActionContext) => Promise<Procedure<ApiDirectScrapeResult>>;

--- a/src/Scrapers/Pipeline/Phases/Init/InitPhase.ts
+++ b/src/Scrapers/Pipeline/Phases/Init/InitPhase.ts
@@ -94,5 +94,4 @@ class InitPhase extends BasePhase {
   }
 }
 
-export { createInitPhase, INIT_STEP } from './InitPhaseFactory.js';
-export { InitPhase };
+export default InitPhase;

--- a/src/Scrapers/Pipeline/Phases/Init/InitPhaseFactory.ts
+++ b/src/Scrapers/Pipeline/Phases/Init/InitPhaseFactory.ts
@@ -5,7 +5,7 @@
 
 import type { IPipelineContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
-import { InitPhase } from './InitPhase.js';
+import InitPhase from './InitPhase.js';
 
 /**
  * Create the INIT phase instance.

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigSeeder.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigSeeder.ts
@@ -9,7 +9,7 @@ import type { CompanyTypes } from '../../../../Definitions.js';
 import type { Brand } from '../../Types/Brand.js';
 import type { WKUrlGroup } from '../WK/UrlsWK.js';
 import { registerWkUrl } from '../WK/UrlsWK.js';
-import type { IHeadlessUrlsConfig, IPipelineBankConfig } from './PipelineBankConfig.js';
+import type { IHeadlessUrlsConfig, IPipelineBankConfig } from './PipelineBankConfigTypes.js';
 
 /** WK seeder per-call result — branded so Rule #15 accepts the boolean return. */
 type DidSeed = Brand<boolean, 'DidSeed'>;

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 10,
+  "cycleCount": 7,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts",
@@ -102,18 +102,6 @@
       "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/PhaseActions.ts",
       "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhaseActions.ts",
       "src/Scrapers/Pipeline/Strategy/Scrape/GenericAutoScrapeStrategy.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapeActions.ts",
-      "src/Scrapers/Pipeline/Phases/ApiDirectScrape/ApiDirectScrapePhase.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Phases/Init/InitPhase.ts",
-      "src/Scrapers/Pipeline/Phases/Init/InitPhaseFactory.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts",
-      "src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigSeeder.ts"
     ]
   ]
 }

--- a/src/Tests/Unit/Scrapers/Pipeline/Phases/InitPhase.test.ts
+++ b/src/Tests/Unit/Scrapers/Pipeline/Phases/InitPhase.test.ts
@@ -49,7 +49,7 @@ jest.unstable_mockModule(
 
 const CAMOUFOX_MOD =
   await import('../../../../../Scrapers/Pipeline/Mediator/Browser/CamoufoxLauncher.js');
-const INIT_MOD = await import('../../../../../Scrapers/Pipeline/Phases/Init/InitPhase.js');
+const INIT_MOD = await import('../../../../../Scrapers/Pipeline/Phases/Init/InitPhaseFactory.js');
 
 // ── Helpers ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
| --- | --- | --- |
| 1 | Acyclic-dependencies cycle gate | ✅ baseline ratcheted 10→7; `lint:cycles` green; 3 SCCs removed from `import-cycles.baseline.json` |
| 2 | CLEAN_CODE.md — function/file caps | ✅ `tsc` + `eslint` green; new leaf file is 24 LoC; no changed function exceeds the 10-line cap |
| 3 | CLAUDE.md — ZERO CSS selectors / architecture | ✅ N/A — no interaction code touched; pure import-graph rewire |
| 4 | coding-principle-guidlines.md — SOLID, no `any` | ✅ no new `any`/unsafe cast; structural relocation only (rubber-duck confirmed) |
| 5 | before-commit-guidlines.md — husky gates | ✅ all 21 gates passed incl. Mock + Live E2E (commit `44b5ccf6`) |
| 6 | commit-guidlines.md — Conventional Commits + 50/72 | ✅ `refactor(pipeline): …` subject 48 chars; body wrapped ≤72; imperative |
| 7 | No behavior change | ✅ 102 affected unit tests pass; types/values relocated and re-exported for existing consumers |
| 8 | Selective staging (no `git add .`) | ✅ 10 files staged by explicit path |
| 9 | docs-coverage gate | ✅ 2 relocated framework-internal types allowlisted with `# Reason:` (both were already exported pre-PR) |
| 10 | pr-guidlines.md §9 pre-PR review | ✅ rubber-duck pass on full diff vs main — verdict: safe, behavior-preserving, no bugs |
| 11 | pr-guidlines.md §12 150-file cap | ✅ 10 files changed — well under the cap |
| 12 | Public API unchanged | ✅ package root barrel (`Pipeline/index.ts`) exports unchanged; relocated symbols are deep-internal |

## Why

The acyclic-dependencies cycle gate froze 10 dependency cycles. Burning them
down is the decoupling campaign's headline metric. Three of the ten are
localized 2-node cycles caused purely by a sibling importing a symbol back
through a re-export / value module. Breaking them ratchets the frozen
baseline from 10 to 7 with zero behavior change — the cheapest measurable
progress before the harder multi-node cycles.

This is "Phase 12g — part 1/2" (the localized orphan cycles). Part 2 will
take the wider PipelineBuilder re-export (16 consumers) and the Form
LoginFormFill↔LoginScopeResolver cycle.

## What

Three 2-node import cycles broken:

- **Init** (`InitPhase ↔ InitPhaseFactory`): dropped the convenience
  re-export from `InitPhase.ts`; the two consumers (`PipelineAssembly.ts`
  and the `InitPhase.test.ts` dynamic import) now import
  `createInitPhase` / `INIT_STEP` from `InitPhaseFactory.ts` directly.
  `InitPhase` becomes a default export (single-export lint rule); its sole
  importer, the factory, updated accordingly.
- **ApiDirectScrape** (`Actions ↔ Phase`): extracted
  `ApiDirectScrapeResult` / `ApiDirectScrapeFn` into a new leaf module
  `ApiDirectScrapeTypes.ts`. `ApiDirectScrapePhase.ts` imports the fn type
  from the leaf and re-exports both (existing consumers unaffected);
  `ApiDirectScrapeActions.ts` imports the result type from the leaf instead
  of from the phase.
- **Registry/Config** (`Config ↔ Seeder`): `PipelineBankConfigSeeder.ts`
  sources its two types from `PipelineBankConfigTypes.js` (their definition)
  instead of from the `PipelineBankConfig.js` value module.

Baseline re-frozen to 7. The 2 relocated framework-internal types are
allowlisted for docs-coverage (they were already exported pre-PR).

Validation: `tsc`, `eslint` (+ canaries/prettier), `lint:cycles` (7),
102 affected unit tests, all 21 husky gates incl. Mock + Live E2E — green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization to improve module structure and reduce circular dependencies.
  * Refactored type definitions into dedicated modules for better code separation.
  * Updated import paths and export patterns across pipeline infrastructure components.
  * Reduced dependency cycles from 10 to 7 through structural improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->