### PR TITLE
refactor(pipeline): break 2 orphan import cycles (12g part 2/2)

### DIFF
--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -1174,3 +1174,11 @@ runTlsPhase
 ApiDirectScrapeResult
 # Reason: ApiDirectScrape — bound phase-action fn type; framework-internal, relocated to a leaf in the 12g cycle-break (was already exported from ApiDirectScrapePhase.ts). Not user-facing.
 ApiDirectScrapeFn
+# Reason: Form — credential field-fill fn; framework-internal, relocated to the LoginFieldFill leaf in the 12g-2 cycle-break (was already exported from LoginFormFill.ts, still re-exported there). Not user-facing.
+fillOneField
+# Reason: Form — single-field fill options; framework-internal type relocated to the LoginFieldFill leaf in the 12g-2 cycle-break (was already exported from LoginFormFill.ts). Not user-facing.
+IFillOpts
+# Reason: Form — bundled fill-field options; framework-internal type relocated to the LoginFieldFill leaf in the 12g-2 cycle-break (was already exported from LoginFormFill.ts). Not user-facing.
+IFillFieldOpts
+# Reason: Form — field-fill result; framework-internal type relocated to the LoginFieldFill leaf in the 12g-2 cycle-break (was already exported from LoginFormFill.ts). Not user-facing.
+IFillResult

--- a/src/Scrapers/Pipeline/Banks/Amex/AmexPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Amex/AmexPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Beinleumi/BeinleumiPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Beinleumi/BeinleumiPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Discount/DiscountPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Discount/DiscountPipeline.ts
@@ -6,7 +6,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Hapoalim/HapoalimPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Isracard/IsracardPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Isracard/IsracardPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Massad/MassadPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Massad/MassadPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Max/MaxPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Max/MaxPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Mercantile/MercantilePipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Mercantile/MercantilePipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/OneZero/OneZeroPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/OneZero/OneZeroPipeline.ts
@@ -10,7 +10,7 @@
 import './graphql/OneZeroQueries.js';
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import { ONEZERO_API_DIRECT_CALL } from '../../Registry/Config/PipelineBankConfigOneZero.js';
 import type { Procedure } from '../../Types/Procedure.js';

--- a/src/Scrapers/Pipeline/Banks/OtsarHahayal/OtsarHahayalPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/OtsarHahayal/OtsarHahayalPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/Pagi/PagiPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Pagi/PagiPipeline.ts
@@ -5,7 +5,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Banks/PayBox/PayBoxPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/PayBox/PayBoxPipeline.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import { PAYBOX_API_DIRECT_CALL } from '../../Registry/Config/PipelineBankConfigPayBox.js';
 import type { Procedure } from '../../Types/Procedure.js';

--- a/src/Scrapers/Pipeline/Banks/Pepper/PepperPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/Pepper/PepperPipeline.ts
@@ -10,7 +10,7 @@
 import './graphql/PepperQueries.js';
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import { PEPPER_API_DIRECT_CALL } from '../../Registry/Config/PipelineBankConfigPepper.js';
 import type { Procedure } from '../../Types/Procedure.js';

--- a/src/Scrapers/Pipeline/Banks/VisaCal/VisaCalPipeline.ts
+++ b/src/Scrapers/Pipeline/Banks/VisaCal/VisaCalPipeline.ts
@@ -6,7 +6,7 @@
 
 import type { ScraperOptions } from '../../../Base/Interface.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../Core/PipelineDescriptor.js';
 import type { Procedure } from '../../Types/Procedure.js';
 

--- a/src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts
+++ b/src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts
@@ -142,4 +142,3 @@ class PipelineBuilder {
 export type { LoginFn } from './PipelineAssembly.js';
 export type { ScrapeFn } from './PipelineBuilderHelpers.js';
 export { PipelineBuilder };
-export { createPipelineBuilder } from './PipelineBuilderFactory.js';

--- a/src/Scrapers/Pipeline/Mediator/Form/LoginFieldFill.ts
+++ b/src/Scrapers/Pipeline/Mediator/Form/LoginFieldFill.ts
@@ -1,0 +1,85 @@
+/**
+ * Low-level credential field fill — resolves one field via the element
+ * mediator and fills it. Extracted from LoginFormFill.ts so it has no
+ * back-edge to LoginFormFill/LoginScopeResolver, breaking their cycle.
+ */
+
+import type { Frame, Page } from 'playwright-core';
+
+import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
+import type { ScraperLogger } from '../../Types/Debug.js';
+import { maskVisibleText } from '../../Types/LogEvent.js';
+import type { Procedure } from '../../Types/Procedure.js';
+import { succeed } from '../../Types/Procedure.js';
+import type { IElementMediator } from '../Elements/ElementMediator.js';
+import { deepFillInput } from '../Elements/ElementsInteractions.js';
+import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';
+
+/** Options for filling a single credential field. */
+export interface IFillOpts {
+  readonly credentialKey: string;
+  readonly value: string;
+  readonly selectors: readonly SelectorCandidate[];
+}
+
+/** Bundled options for filling one field via mediator. */
+export interface IFillFieldOpts {
+  readonly mediator: IElementMediator;
+  readonly fill: IFillOpts;
+  readonly scopeContext?: Page | Frame;
+  readonly formSelector?: string;
+  readonly logger: ScraperLogger;
+}
+
+/** Result of filling one field. */
+export interface IFillResult {
+  readonly isOk: boolean;
+  readonly procedure: Procedure<boolean>;
+  readonly resolvedContext?: Page | Frame;
+}
+
+/** Lookup for resolve outcome labels. */
+const RESOLVE_STATUS: Record<string, string> = { true: 'FOUND', false: 'NOT_FOUND' };
+
+/**
+ * Log field resolution intent and outcome.
+ * @param log - Logger instance.
+ * @param key - Credential key name.
+ * @param success - Whether resolution succeeded.
+ * @returns The success flag for chaining.
+ */
+function logResolveResult(log: ScraperLogger, key: string, success: boolean): boolean {
+  const status = RESOLVE_STATUS[String(success)];
+  log.debug({ field: maskVisibleText(key), result: status });
+  return success;
+}
+
+/**
+ * Resolve a credential field via mediator, logging the outcome.
+ * @param opts - Bundled fill options.
+ * @returns Resolve result from the mediator.
+ */
+async function resolveCredentialField(opts: IFillFieldOpts): Promise<Procedure<IFieldContext>> {
+  const key = opts.fill.credentialKey;
+  opts.logger.debug({ message: `resolving ${maskVisibleText(key)}` });
+  const result = await opts.mediator.resolveField(
+    key,
+    opts.fill.selectors,
+    opts.scopeContext,
+    opts.formSelector,
+  );
+  logResolveResult(opts.logger, key, result.success);
+  return result;
+}
+
+/**
+ * Fill one credential field via mediator.
+ * @param opts - Bundled fill options.
+ * @returns Fill result with resolved context.
+ */
+export async function fillOneField(opts: IFillFieldOpts): Promise<IFillResult> {
+  const result = await resolveCredentialField(opts);
+  if (!result.success) return { isOk: false, procedure: result };
+  await deepFillInput(result.value.context, result.value.selector, opts.fill.value);
+  return { isOk: true, procedure: succeed(true), resolvedContext: result.value.context };
+}

--- a/src/Scrapers/Pipeline/Mediator/Form/LoginFormFill.ts
+++ b/src/Scrapers/Pipeline/Mediator/Form/LoginFormFill.ts
@@ -1,91 +1,14 @@
 /**
- * Login field-fill helpers — resolves and fills credential fields via mediator.
- * Submit logic in LoginSubmitStep.ts, scope logic in LoginScopeStep.ts.
+ * Login credential validation + sequential field-fill reducer.
+ * Field-level fill in LoginFieldFill.ts, scope logic in LoginScopeResolver.ts.
  */
 
-import type { Frame, Page } from 'playwright-core';
-
-import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import type { IFieldConfig } from '../../../Base/Interfaces/Config/FieldConfig.js';
 import type { ILoginConfig } from '../../../Base/Interfaces/Config/LoginConfig.js';
-import type { ScraperLogger } from '../../Types/Debug.js';
-import { maskVisibleText } from '../../Types/LogEvent.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail, succeed } from '../../Types/Procedure.js';
-import type { IElementMediator } from '../Elements/ElementMediator.js';
-import { deepFillInput } from '../Elements/ElementsInteractions.js';
-import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';
 import { fillFieldStep, type IFillAccum, type IFillContext } from './LoginScopeResolver.js';
-
-/** Options for filling a single credential field. */
-export interface IFillOpts {
-  readonly credentialKey: string;
-  readonly value: string;
-  readonly selectors: readonly SelectorCandidate[];
-}
-
-/** Bundled options for filling one field via mediator. */
-export interface IFillFieldOpts {
-  readonly mediator: IElementMediator;
-  readonly fill: IFillOpts;
-  readonly scopeContext?: Page | Frame;
-  readonly formSelector?: string;
-  readonly logger: ScraperLogger;
-}
-
-/** Result of filling one field. */
-export interface IFillResult {
-  readonly isOk: boolean;
-  readonly procedure: Procedure<boolean>;
-  readonly resolvedContext?: Page | Frame;
-}
-
-/** Lookup for resolve outcome labels. */
-const RESOLVE_STATUS: Record<string, string> = { true: 'FOUND', false: 'NOT_FOUND' };
-
-/**
- * Log field resolution intent and outcome.
- * @param log - Logger instance.
- * @param key - Credential key name.
- * @param success - Whether resolution succeeded.
- * @returns The success flag for chaining.
- */
-function logResolveResult(log: ScraperLogger, key: string, success: boolean): boolean {
-  const status = RESOLVE_STATUS[String(success)];
-  log.debug({ field: maskVisibleText(key), result: status });
-  return success;
-}
-
-/**
- * Resolve a credential field via mediator, logging the outcome.
- * @param opts - Bundled fill options.
- * @returns Resolve result from the mediator.
- */
-async function resolveCredentialField(opts: IFillFieldOpts): Promise<Procedure<IFieldContext>> {
-  const key = opts.fill.credentialKey;
-  opts.logger.debug({ message: `resolving ${maskVisibleText(key)}` });
-  const result = await opts.mediator.resolveField(
-    key,
-    opts.fill.selectors,
-    opts.scopeContext,
-    opts.formSelector,
-  );
-  logResolveResult(opts.logger, key, result.success);
-  return result;
-}
-
-/**
- * Fill one credential field via mediator.
- * @param opts - Bundled fill options.
- * @returns Fill result with resolved context.
- */
-export async function fillOneField(opts: IFillFieldOpts): Promise<IFillResult> {
-  const result = await resolveCredentialField(opts);
-  if (!result.success) return { isOk: false, procedure: result };
-  await deepFillInput(result.value.context, result.value.selector, opts.fill.value);
-  return { isOk: true, procedure: succeed(true), resolvedContext: result.value.context };
-}
 
 /**
  * Check if a credential is missing from the map.
@@ -136,3 +59,5 @@ async function reduceField(
 }
 
 export { reduceField, validateCredentials };
+export type { IFillFieldOpts, IFillOpts, IFillResult } from './LoginFieldFill.js';
+export { fillOneField } from './LoginFieldFill.js';

--- a/src/Scrapers/Pipeline/Mediator/Form/LoginScopeResolver.ts
+++ b/src/Scrapers/Pipeline/Mediator/Form/LoginScopeResolver.ts
@@ -15,7 +15,7 @@ import {
   type IFillFieldOpts,
   type IFillOpts,
   type IFillResult,
-} from './LoginFormFill.js';
+} from './LoginFieldFill.js';
 
 interface IFieldScope {
   readonly ctx?: Page | Frame;

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,11 +1,7 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 7,
+  "cycleCount": 5,
   "cycles": [
-    [
-      "src/Scrapers/Pipeline/Core/Builder/PipelineBuilder.ts",
-      "src/Scrapers/Pipeline/Core/Builder/PipelineBuilderFactory.ts"
-    ],
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.factories.ts",
@@ -90,10 +86,6 @@
       "src/Scrapers/Pipeline/Mediator/Elements/ElementsInteractions.ts",
       "src/Scrapers/Pipeline/Mediator/Elements/ElementWaitAction.ts",
       "src/Scrapers/Pipeline/Mediator/Elements/PageEvalAction.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Form/LoginFormFill.ts",
-      "src/Scrapers/Pipeline/Mediator/Form/LoginScopeResolver.ts"
     ],
     [
       "src/Scrapers/Pipeline/Mediator/Scrape/FrozenScrapeAction.ts",

--- a/src/Tests/Unit/Pipeline/Core/Builder/PipelineBuilderHeadless.test.ts
+++ b/src/Tests/Unit/Pipeline/Core/Builder/PipelineBuilderHeadless.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ScraperOptions } from '../../../../../Scrapers/Base/Interface.js';
-import { createPipelineBuilder } from '../../../../../Scrapers/Pipeline/Core/Builder/PipelineBuilder.js';
+import { createPipelineBuilder } from '../../../../../Scrapers/Pipeline/Core/Builder/PipelineBuilderFactory.js';
 import type { IPipelineDescriptor } from '../../../../../Scrapers/Pipeline/Core/PipelineDescriptor.js';
 import type {
   IActionContext,


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
| --- | --- | --- |
| 1 | Acyclic-dependencies cycle gate | ✅ baseline ratcheted 7→5; `lint:cycles` green; 2 SCCs removed from `import-cycles.baseline.json` |
| 2 | CLEAN_CODE.md — function/file caps | ✅ `tsc` + `eslint` green; new leaf is 85 LoC; every function ≤10 lines |
| 3 | CLAUDE.md — ZERO CSS selectors / architecture | ✅ N/A — no interaction code touched; pure import-graph rewire |
| 4 | coding-principle-guidlines.md — SOLID, no `any` | ✅ no new `any`; structural relocation only (rubber-duck confirmed byte-identical logic) |
| 5 | before-commit-guidlines.md — husky gates | ✅ all 21 gates passed incl. Mock + Live E2E (commit `5d95ba9e`); allowlist-only amend correctly skipped by the hook (no source change) |
| 6 | commit-guidlines.md — Conventional Commits + 50/72 | ✅ subject 49 chars; body wrapped ≤72; imperative |
| 7 | No behavior change | ✅ 89 affected unit tests pass; `fillOneField` identity preserved via re-export |
| 8 | Selective staging (no `git add .`) | ✅ 21 files staged by explicit path |
| 9 | docs-coverage gate | ✅ 4 relocated framework-internal Form symbols allowlisted with `# Reason:` (all already exported pre-PR) |
| 10 | pr-guidlines.md §9 pre-PR review | ✅ rubber-duck review — 1 Important (allowlist line concat) found and fixed in the amend; final verdict: safe, behavior-preserving |
| 11 | pr-guidlines.md §12 150-file cap | ✅ 21 files changed — under the cap |
| 12 | Public API unchanged | ✅ `LoginFormFill.ts` re-exports `fillOneField` + IFill* from the leaf; bank pipelines behave identically |

## Why

Continues the decoupling campaign's headline metric — burning down the
frozen dependency cycles. This is "Phase 12g — part 2/2", clearing the
last two localized 2-node cycles after part 1 (#367) took the other
three. The frozen baseline drops from 7 to 5, leaving only the
multi-node cycles (ApiDirectCall, Dashboard, Elements, Scrape) and the
69-file Mediator monster.

## What

Two 2-node import cycles broken:

- **PipelineBuilder ↔ PipelineBuilderFactory**: dropped the convenience
  re-export `createPipelineBuilder` from `PipelineBuilder.ts` (the cyclic
  edge — the factory imports `PipelineBuilder` back). Repointed the 15
  consumers (14 bank pipelines + `PipelineBuilderHeadless.test.ts`) to
  import `createPipelineBuilder` from `PipelineBuilderFactory.js`
  directly.
- **LoginFormFill ↔ LoginScopeResolver**: extracted `fillOneField` (plus
  its private helpers and the `IFillOpts`/`IFillFieldOpts`/`IFillResult`
  interfaces) into a new low-level leaf `LoginFieldFill.ts` with no
  back-edge to either module. `LoginScopeResolver.ts` imports from the
  leaf; `LoginFormFill.ts` re-exports the leaf's symbols so external
  consumers (tests, actions) are unaffected. Layering is now
  FormFill → ScopeResolver → LoginFieldFill (acyclic).

Baseline re-frozen to 5. The 4 relocated framework-internal Form symbols
are allowlisted for docs-coverage (all already exported pre-PR).

Validation: `tsc`, `eslint` (+canaries/prettier), `lint:cycles` (5),
89 affected unit tests, all 21 husky gates incl. Mock + Live E2E — green.