### PR TITLE
refactor(pipeline): break 3 multi-node import cycles (12f)

### DIFF
--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -1182,3 +1182,9 @@ IFillOpts
 IFillFieldOpts
 # Reason: Form — field-fill result; framework-internal type relocated to the LoginFieldFill leaf in the 12g-2 cycle-break (was already exported from LoginFormFill.ts). Not user-facing.
 IFillResult
+# Reason: Elements — element wait options (visibility/timeout); framework-internal type relocated to the ElementsActionTypes leaf in the 12f cycle-break (was already exported from ElementsInteractions.ts, still re-exported there). Not user-facing.
+IWaitOptions
+# Reason: Elements — single-element page-eval options; framework-internal type relocated to the ElementsActionTypes leaf in the 12f cycle-break (was already exported from ElementsInteractions.ts, still re-exported there). Not user-facing.
+IPageEvalOpts
+# Reason: Elements — multi-element page-eval options; framework-internal type relocated to the ElementsActionTypes leaf in the 12f cycle-break (was already exported from ElementsInteractions.ts, still re-exported there). Not user-facing.
+IPageEvalAllOpts

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Fingerprint/GenericFingerprintBuilder.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Fingerprint/GenericFingerprintBuilder.ts
@@ -6,13 +6,9 @@
  */
 
 import type { Procedure } from '../../../Types/Procedure.js';
-import type { JsonValue } from '../Envelope/JsonPointer.js';
 import type { IApiDirectCallConfig, IFingerprintConfig } from '../IApiDirectCallConfig.js';
 import { hydrate } from '../Template/GenericBodyTemplate.js';
-import type { ITemplateScope } from '../Template/RefResolver.js';
-
-/** Alias preserved for callers — the fingerprint is an opaque JsonValue. */
-type ICollectionResult = JsonValue;
+import type { ICollectionResult, ITemplateScope } from '../Template/RefResolver.js';
 
 /**
  * Build a synthetic scope for fingerprint hydration — empty carry,

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Template/RefResolver.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Template/RefResolver.ts
@@ -14,8 +14,12 @@ import { fail, isOk, succeed } from '../../../Types/Procedure.js';
 import type { IGenericKeypair } from '../Crypto/CryptoKeyFactory.js';
 import type { JsonValue } from '../Envelope/JsonPointer.js';
 import { walkPointer } from '../Envelope/JsonPointer.js';
-import type { ICollectionResult } from '../Fingerprint/GenericFingerprintBuilder.js';
 import type { IApiDirectCallConfig, RefToken } from '../IApiDirectCallConfig.js';
+
+/** Hydrated fingerprint payload — an opaque JsonValue. Defined here (where
+ *  ITemplateScope lives) so the fingerprint builder depends on this leaf,
+ *  not the reverse — breaks the Template↔Fingerprint import cycle. */
+type ICollectionResult = JsonValue;
 
 /** Scope passed into every $ref resolution — mediator-populated. */
 interface ITemplateScope {
@@ -226,6 +230,6 @@ function resolveRef(token: RefToken, scope: ITemplateScope): Procedure<JsonValue
   return handler(token, scope);
 }
 
-export type { ITemplateScope };
+export type { ICollectionResult, ITemplateScope };
 export { resolveRef };
 export default resolveRef;

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardDiscovery.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardDiscovery.ts
@@ -18,6 +18,7 @@ import {
 } from '../Timing/TimingConfig.js';
 import { buildDateCandidates } from './DashboardDateCandidates.js';
 
+export { resolveAbsoluteHref } from './DashboardHref.js';
 export { extractTransactionHref, NO_HREF } from './DashboardHrefExtraction.js';
 
 /**
@@ -53,44 +54,10 @@ function countTxnTraffic(network: INetworkDiscovery, sinceMs: number): number {
   return withBody.filter((ep): boolean => hasTxnArray(ep.responseBody)).length;
 }
 
-/** Lowercased URL schemes rejected by `resolveAbsoluteHref` —
- *  `javascript:` / `data:` / `vbscript:` / `file:` / `ws[s]:` are unsafe
- *  or unsupported targets for a dashboard navigation step (CodeQL
- *  js/incomplete-url-substring-sanitization). */
-const REJECTED_HREF_SCHEMES: readonly string[] = [
-  'javascript:',
-  'data:',
-  'vbscript:',
-  'file:',
-  'ws:',
-  'wss:',
-];
-
-/**
- * Test whether an href starts with a rejected URL scheme. Case-insensitive
- * because the WHATWG URL parser also normalises scheme to lower-case.
- * @param href - Trimmed href string.
- * @returns True iff href begins with any rejected scheme.
- */
-function startsWithRejectedScheme(href: string): boolean {
-  const lower = href.toLowerCase().trim();
-  return REJECTED_HREF_SCHEMES.some((scheme): boolean => lower.startsWith(scheme));
-}
-
-/**
- * Build absolute URL from a relative href.
- * @param href - Relative or absolute href.
- * @param pageUrl - Current page URL for resolution.
- * @returns Absolute URL string, or empty if malformed.
- */
-function resolveAbsoluteHref(href: string, pageUrl: string): string {
-  if (!href || href.startsWith('#') || startsWithRejectedScheme(href)) return '';
-  try {
-    return new URL(href, pageUrl).href;
-  } catch {
-    return '';
-  }
-}
+/** Lowercased URL schemes rejected by `resolveAbsoluteHref` and the
+ *  absolute-href builder now live in the dependency-free leaf
+ *  DashboardHref.ts (imported below) so DashboardNavigation can reuse
+ *  them without forming an import cycle back to this module. */
 
 /**
  * Probe WK.LOGIN.POST.SUCCESS indicators.
@@ -160,10 +127,4 @@ function validateTrafficGate(network: INetworkDiscovery, logger?: ScraperLogger)
 
 export { buildApiContext, triggerOrganicDashboard } from './DashboardNavigation.js';
 
-export {
-  countTxnTraffic,
-  probeDashboardReveal,
-  probeSuccessIndicators,
-  resolveAbsoluteHref,
-  validateTrafficGate,
-};
+export { countTxnTraffic, probeDashboardReveal, probeSuccessIndicators, validateTrafficGate };

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardHref.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardHref.ts
@@ -1,0 +1,47 @@
+/**
+ * Dashboard href resolution — absolute-URL building with unsafe-scheme
+ * rejection. Extracted from DashboardDiscovery.ts so DashboardNavigation
+ * can import it without a back-edge, breaking their import cycle.
+ */
+
+/** Lowercased URL schemes rejected by `resolveAbsoluteHref` —
+ *  `javascript:` / `data:` / `vbscript:` / `file:` / `ws[s]:` are unsafe
+ *  or unsupported targets for a dashboard navigation step (CodeQL
+ *  js/incomplete-url-substring-sanitization). */
+const REJECTED_HREF_SCHEMES: readonly string[] = [
+  'javascript:',
+  'data:',
+  'vbscript:',
+  'file:',
+  'ws:',
+  'wss:',
+];
+
+/**
+ * Test whether an href starts with a rejected URL scheme. Case-insensitive
+ * because the WHATWG URL parser also normalises scheme to lower-case.
+ * @param href - Trimmed href string.
+ * @returns True iff href begins with any rejected scheme.
+ */
+function startsWithRejectedScheme(href: string): boolean {
+  const lower = href.toLowerCase().trim();
+  return REJECTED_HREF_SCHEMES.some((scheme): boolean => lower.startsWith(scheme));
+}
+
+/**
+ * Build absolute URL from a relative href.
+ * @param href - Relative or absolute href.
+ * @param pageUrl - Current page URL for resolution.
+ * @returns Absolute URL string, or empty if malformed.
+ */
+function resolveAbsoluteHref(href: string, pageUrl: string): string {
+  if (!href || href.startsWith('#') || startsWithRejectedScheme(href)) return '';
+  try {
+    return new URL(href, pageUrl).href;
+  } catch {
+    return '';
+  }
+}
+
+export { resolveAbsoluteHref };
+export default resolveAbsoluteHref;

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardNavigation.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardNavigation.ts
@@ -14,7 +14,7 @@ import {
   DASHBOARD_DATE_FILTER_TIMEOUT_MS,
   DASHBOARD_ORGANIC_IDLE_MS,
 } from '../Timing/TimingConfig.js';
-import { resolveAbsoluteHref } from './DashboardDiscovery.js';
+import { resolveAbsoluteHref } from './DashboardHref.js';
 import { extractTransactionHref } from './DashboardHrefExtraction.js';
 
 export { buildApiContext } from '../Dashboard/DashboardApiContext.js';

--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementWaitAction.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementWaitAction.ts
@@ -9,10 +9,28 @@ import ScraperError from '../../../Base/ScraperError.js';
 import { getDebug as createLogger } from '../../Types/Debug.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
 import { waitUntil } from '../Timing/Waiting.js';
-import { IFRAME_DEFAULT_TIMEOUT_MS, IFRAME_POLL_INTERVAL_MS } from './ElementsInteractionConfig.js';
-import { capturePageText, type IWaitOptions } from './ElementsInteractions.js';
+import type { IWaitOptions } from './ElementsActionTypes.js';
+import {
+  IFRAME_DEFAULT_TIMEOUT_MS,
+  IFRAME_POLL_INTERVAL_MS,
+  PAGE_TEXT_CAPTURE_LIMIT,
+} from './ElementsInteractionConfig.js';
 
 const LOG = createLogger('elements-wait');
+
+/**
+ * Capture visible text from the page body for diagnostics.
+ * @param pageOrFrame - Page or frame.
+ * @returns First N chars of body text.
+ */
+async function capturePageText(pageOrFrame: Page | Frame): Promise<string> {
+  return pageOrFrame
+    .evaluate(
+      (limit: number): string => document.body.innerText.replaceAll(/\s+/g, ' ').slice(0, limit),
+      PAGE_TEXT_CAPTURE_LIMIT,
+    )
+    .catch((): string => '(context unavailable)');
+}
 
 /**
  * Resolve the Playwright wait state from the visibility flag.
@@ -169,4 +187,4 @@ async function waitUntilIframeFound(
   return frame;
 }
 
-export { waitUntilElementDisappear, waitUntilElementFound, waitUntilIframeFound };
+export { capturePageText, waitUntilElementDisappear, waitUntilElementFound, waitUntilIframeFound };

--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementsActionTypes.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementsActionTypes.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared element-action option contracts. Extracted from
+ * ElementsInteractions.ts so ElementWaitAction and PageEvalAction can
+ * import them without a back-edge to the hub, breaking the Elements
+ * import cycle. Pure types — zero runtime imports.
+ */
+
+/** Options for waiting on element visibility or attachment. */
+export interface IWaitOptions {
+  visible?: boolean;
+  timeout?: number;
+}
+
+/** Options for evaluating a single element. */
+export interface IPageEvalOpts<TResult> {
+  selector: string;
+  defaultResult: TResult;
+  callback: (element: Element, ...args: unknown[]) => TResult;
+}
+
+/** Options for evaluating multiple elements. */
+export interface IPageEvalAllOpts<TResult> {
+  selector: string;
+  defaultResult: TResult;
+  callback: (elements: Element[], ...args: unknown[]) => TResult;
+}

--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementsInteractions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementsInteractions.ts
@@ -14,44 +14,9 @@ import {
   CLICK_BUTTON_DELAY_MAX_MS,
   CLICK_BUTTON_DELAY_MIN_MS,
   ELEMENT_HTML_CAPTURE_LIMIT,
-  PAGE_TEXT_CAPTURE_LIMIT,
 } from './ElementsInteractionConfig.js';
 
 const LOG = createLogger('elements');
-
-/** Options for waiting on element visibility or attachment. */
-export interface IWaitOptions {
-  visible?: boolean;
-  timeout?: number;
-}
-
-/** Options for evaluating a single element. */
-export interface IPageEvalOpts<TResult> {
-  selector: string;
-  defaultResult: TResult;
-  callback: (element: Element, ...args: unknown[]) => TResult;
-}
-
-/** Options for evaluating multiple elements. */
-export interface IPageEvalAllOpts<TResult> {
-  selector: string;
-  defaultResult: TResult;
-  callback: (elements: Element[], ...args: unknown[]) => TResult;
-}
-
-/**
- * Capture visible text from the page body for diagnostics.
- * @param pageOrFrame - Page or frame.
- * @returns First 400 chars of body text.
- */
-export async function capturePageText(pageOrFrame: Page | Frame): Promise<string> {
-  return pageOrFrame
-    .evaluate(
-      (limit: number): string => document.body.innerText.replaceAll(/\s+/g, ' ').slice(0, limit),
-      PAGE_TEXT_CAPTURE_LIMIT,
-    )
-    .catch((): string => '(context unavailable)');
-}
 
 /**
  * Capture outer HTML of a matched element for diagnostics.
@@ -105,8 +70,10 @@ async function elementPresentOnPage(pageOrFrame: Page | Frame, selector: string)
   return (await pageOrFrame.locator(selector).count()) > 0;
 }
 
+export type { IPageEvalAllOpts, IPageEvalOpts, IWaitOptions } from './ElementsActionTypes.js';
 export { deepFillInput, fillInput, setValue } from './ElementsInputActions.js';
 export {
+  capturePageText,
   waitUntilElementDisappear,
   waitUntilElementFound,
   waitUntilIframeFound,

--- a/src/Scrapers/Pipeline/Mediator/Elements/PageEvalAction.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/PageEvalAction.ts
@@ -8,7 +8,7 @@ import type { Frame, Page } from 'playwright-core';
 import { getDebug as createLogger } from '../../Types/Debug.js';
 import { toError } from '../../Types/ErrorUtils.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
-import type { IPageEvalAllOpts, IPageEvalOpts } from './ElementsInteractions.js';
+import type { IPageEvalAllOpts, IPageEvalOpts } from './ElementsActionTypes.js';
 
 const LOG = createLogger('elements-eval');
 

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 5,
+  "cycleCount": 2,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -72,20 +72,6 @@
       "src/Scrapers/Pipeline/Types/LogEvent.ts",
       "src/Scrapers/Pipeline/Types/Phase.ts",
       "src/Scrapers/Pipeline/Types/PipelineContext.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/ApiDirectCall/Fingerprint/GenericFingerprintBuilder.ts",
-      "src/Scrapers/Pipeline/Mediator/ApiDirectCall/Template/GenericBodyTemplate.ts",
-      "src/Scrapers/Pipeline/Mediator/ApiDirectCall/Template/RefResolver.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Dashboard/DashboardDiscovery.ts",
-      "src/Scrapers/Pipeline/Mediator/Dashboard/DashboardNavigation.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Elements/ElementsInteractions.ts",
-      "src/Scrapers/Pipeline/Mediator/Elements/ElementWaitAction.ts",
-      "src/Scrapers/Pipeline/Mediator/Elements/PageEvalAction.ts"
     ],
     [
       "src/Scrapers/Pipeline/Mediator/Scrape/FrozenScrapeAction.ts",


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
| --- | --- | --- |
| 1 | Acyclic-dependencies cycle gate | ✅ baseline ratcheted 5→2; `lint:cycles` green; 3 SCCs removed from `import-cycles.baseline.json` |
| 2 | CLEAN_CODE.md — function/file caps | ✅ `tsc` + `eslint` green; both new leaves small; relocated functions unchanged (≤10-line cap not regressed) |
| 3 | CLAUDE.md — ZERO CSS selectors / architecture | ✅ N/A — no interaction code added; the relocated `resolveAbsoluteHref` / `capturePageText` keep their existing parsing-only selectors |
| 4 | coding-principle-guidlines.md — SOLID, no `any` | ✅ no new `any`; pure structural relocation (`ICollectionResult = JsonValue` identity preserved) |
| 5 | before-commit-guidlines.md — husky gates | ✅ all 21 gates passed incl. Mock + Live E2E (commit `4549d948`) |
| 6 | commit-guidlines.md — Conventional Commits + 50/72 | ✅ subject 47 chars; body wrapped ≤72; imperative |
| 7 | No behavior change | ✅ full unit suite green; all relocated symbols re-exported, sanitization/limit logic moved verbatim |
| 8 | Selective staging (no `git add .`) | ✅ 11 files staged by explicit path |
| 9 | docs-coverage gate | ✅ 3 relocated framework-internal Elements interfaces allowlisted with `# Reason:` (all already exported pre-PR) |
| 10 | pr-guidlines.md §9 pre-PR review | ✅ rubber-duck review run on the diff; behavior-preserving |
| 11 | pr-guidlines.md §12 150-file cap | ✅ 11 files changed — well under the cap |
| 12 | Public API unchanged | ✅ `ElementsInteractions`, `DashboardDiscovery`, `GenericFingerprintBuilder` re-export all relocated symbols; consumers behave identically |

## Why

Continues the decoupling campaign's headline metric — burning down the
frozen dependency cycles. After Phase 12g cleared the five localized
2-node cycles (#367, #368), three multi-node cycles remained in the
Mediator. This phase breaks all three, dropping the frozen baseline from
5 to 2 — leaving only the 6-node Scrape Strategy↔Mediator cycle and the
69-file Mediator monster.

## What

Three multi-node import cycles broken, each by making the dependency
flow one way:

- **ApiDirectCall/Template** (3-node): moved the `ICollectionResult`
  type alias from `GenericFingerprintBuilder.ts` to `RefResolver.ts`,
  where its sibling `ITemplateScope` already lives. This inverts the
  builder → `RefResolver` back-edge. `GenericFingerprintBuilder.ts`
  imports it from `RefResolver` and re-exports it for existing
  consumers.
- **Dashboard** (2-node): extracted `resolveAbsoluteHref` and its
  helpers (`startsWithRejectedScheme`, `REJECTED_HREF_SCHEMES`) into a
  new dependency-free leaf `DashboardHref.ts`. `DashboardNavigation.ts`
  imports the leaf directly; `DashboardDiscovery.ts` re-exports it so
  external consumers are unaffected. Layering is now
  Navigation/Discovery → `DashboardHref` (acyclic).
- **Elements** (3-node): extracted the 3 shared option interfaces
  (`IWaitOptions`, `IPageEvalOpts`, `IPageEvalAllOpts`) into a new
  pure-types leaf `ElementsActionTypes.ts`, and relocated
  `capturePageText` to its sole functional consumer
  `ElementWaitAction.ts`. `PageEvalAction.ts` imports the types from the
  leaf; `ElementsInteractions.ts` re-exports both the types and
  `capturePageText` so existing consumers (and the
  `src/Common/ElementsInteractions.ts` shim) are unaffected.

Baseline re-frozen to 2. The 3 relocated framework-internal Elements
interfaces are allowlisted for docs-coverage (all already exported
pre-PR).

Validation: `tsc`, `eslint` (+canaries/prettier), `lint:cycles` (2),
full unit suite, all 21 husky gates incl. Mock + Live E2E — green.
