### PR TITLE
refactor(pipeline): break the Scrape Strategy cycle (12e)

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Scrape/FrozenScrapeAction.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/FrozenScrapeAction.ts
@@ -39,7 +39,7 @@ import {
   readDateWindowParams,
   readDedupKeyFields,
   readPreDiscoveredTxn,
-} from './ScrapePhaseActions.js';
+} from './ScrapePhase/PreDiscovery.js';
 
 const LOG = createLogger('frozen-scrape');
 

--- a/src/Scrapers/Pipeline/Strategy/Scrape/GenericAutoScrapeStrategy.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/GenericAutoScrapeStrategy.ts
@@ -15,7 +15,7 @@ import type { INetworkDiscovery } from '../../Mediator/Network/NetworkDiscovery.
 import {
   readDateWindowParams,
   readDedupKeyFields,
-} from '../../Mediator/Scrape/ScrapePhaseActions.js';
+} from '../../Mediator/Scrape/ScrapePhase/PreDiscovery.js';
 import type { Brand } from '../../Types/Brand.js';
 import { getDebug as createLogger } from '../../Types/Debug.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 2,
+  "cycleCount": 1,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -72,14 +72,6 @@
       "src/Scrapers/Pipeline/Types/LogEvent.ts",
       "src/Scrapers/Pipeline/Types/Phase.ts",
       "src/Scrapers/Pipeline/Types/PipelineContext.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Scrape/FrozenScrapeAction.ts",
-      "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/DirectActions.ts",
-      "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/index.ts",
-      "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/PhaseActions.ts",
-      "src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhaseActions.ts",
-      "src/Scrapers/Pipeline/Strategy/Scrape/GenericAutoScrapeStrategy.ts"
     ]
   ]
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
| --- | --- | --- |
| 1 | Acyclic-dependencies cycle gate | ✅ baseline ratcheted 2→1; `lint:cycles` green; the 6-node Scrape SCC removed from `import-cycles.baseline.json` |
| 2 | CLEAN_CODE.md — function/file caps | ✅ `tsc` + `eslint` green; no functions added/changed — only 2 import-source lines edited |
| 3 | CLAUDE.md — ZERO CSS selectors / architecture | ✅ N/A — no interaction code; pure import-graph rewire |
| 4 | coding-principle-guidlines.md — SOLID, no `any` | ✅ no new `any`; redirects to the origin leaf (same symbols, same definitions) |
| 5 | before-commit-guidlines.md — husky gates | ✅ all 21 gates passed incl. Mock + Live E2E (commit `a2977f2b`) |
| 6 | commit-guidlines.md — Conventional Commits + 50/72 | ✅ subject 48 chars; body wrapped ≤72; imperative |
| 7 | No behavior change | ✅ 43 affected unit tests pass (incl. LayerSeparationArchitecture); readers resolve to identical functions |
| 8 | Selective staging (no `git add .`) | ✅ 3 files staged by explicit path |
| 9 | docs-coverage gate | ✅ passed — no new public exports (import redirects only) |
| 10 | pr-guidlines.md §9 pre-PR review | ✅ rubber-duck review run on the diff; behavior-preserving |
| 11 | pr-guidlines.md §12 150-file cap | ✅ 3 files changed — well under the cap |
| 12 | Public API unchanged | ✅ the `ScrapePhaseActions` shim stays intact for its other consumers; no exports removed |

## Why

Continues the decoupling campaign's headline metric — burning down the
frozen dependency cycles. After Phase 12f cleared the 3 multi-node
cycles (#369), two remained: the 6-node Scrape Strategy↔Mediator cycle
and the 69-file Mediator monster. This phase eliminates the Scrape
cycle, dropping the frozen baseline from 2 to 1 — leaving only the
monster.

## What

The 6-node SCC — `FrozenScrapeAction`, `ScrapePhase/DirectActions`,
`ScrapePhase/index`, `ScrapePhase/PhaseActions`, `ScrapePhaseActions`,
`GenericAutoScrapeStrategy` — was held together by the
`ScrapePhaseActions.ts` re-export shim. Both
`GenericAutoScrapeStrategy` (Strategy layer) and `FrozenScrapeAction`
(Mediator layer) pulled the pre-discovery reader helpers
(`readDateWindowParams`, `readDedupKeyFields`,
`readDashboardTxnHarvest`, `readPreDiscoveredTxn`) through that shim,
which re-exports them from the `ScrapePhase` barrel — looping back into
the Strategy/Mediator graph.

Both files now import those readers **directly from their origin leaf**
`ScrapePhase/PreDiscovery.ts` (the file that actually defines them; it
depends only on `Types` + `ScrapeTypes`, neither a cycle member). This
removes the two `→ shim` edges, and since they were the shim's only
incoming edges within the SCC, the entire cycle collapses.

The `ScrapePhaseActions.ts` shim is left intact — it still serves its
other consumers (`StepResolvers`, `Phases/Scrape/ScrapePhase`, the
`Read*` reader unit tests, canaries). No exports removed, no behavior
changed: the redirected imports resolve to the identical functions,
just sourced one hop earlier.

Validation: `tsc`, `eslint`, `lint:cycles` (1), 43 affected unit tests
(incl. `LayerSeparationArchitecture`), all 21 husky gates incl. Mock +
Live E2E — green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by reorganizing module imports and reducing dependency cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->