### PR TITLE
refactor(pipeline): peel Types off cycle (12i-1)

### DIFF
--- a/src/Scrapers/Pipeline/Types/Domain/LoginTypes.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/LoginTypes.ts
@@ -1,4 +1,4 @@
-import type { IFormAnchor } from '../../Mediator/Form/FormAnchor.js';
+import type { IFormAnchor } from '../../Mediator/Form/Anchor/AnchorTypes.js';
 import type { Option } from '../Option.js';
 import type { IResolvedTarget } from './PreLoginTypes.js';
 

--- a/src/Scrapers/Pipeline/Types/Domain/ScrapeDiscoveryTypes.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/ScrapeDiscoveryTypes.ts
@@ -1,4 +1,4 @@
-import type { IDiscoveredEndpoint } from '../../Mediator/Network/NetworkDiscoveryTypes.js';
+import type { IDiscoveredEndpoint } from '../../Mediator/Network/Types/Endpoint.js';
 import type { ITxnEndpoint } from './TxnEndpointTypes.js';
 
 /** Scrape phase discovery — qualification results from PRE step. */

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -67,8 +67,6 @@
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.main.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.notFound.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.ts",
-      "src/Scrapers/Pipeline/Types/Domain/LoginTypes.ts",
-      "src/Scrapers/Pipeline/Types/Domain/ScrapeDiscoveryTypes.ts",
       "src/Scrapers/Pipeline/Types/LogEvent.ts",
       "src/Scrapers/Pipeline/Types/Phase.ts",
       "src/Scrapers/Pipeline/Types/PipelineContext.ts"


### PR DESCRIPTION
## Why

The decoupling campaign drives the acyclic-dependencies cycle gate toward
zero. After Phase 12e the only remaining cycle is the 69-file Mediator
"monster" SCC. Two of its edges run the **wrong direction** — the Types
layer (which should be a stable leaf) imports interface contracts from the
Mediator layer, pulling Types into the cycle:

- Types/Domain/LoginTypes.ts imported `IFormAnchor` from the
  `Mediator/Form/FormAnchor` barrel (a cycle member).
- Types/Domain/ScrapeDiscoveryTypes.ts imported `IDiscoveredEndpoint`
  from the `Mediator/Network/NetworkDiscoveryTypes` barrel (a cycle
  member).

Both interfaces are actually **defined** in pure type-leaf files that sit
*outside* the SCC; the barrels merely re-export them. Importing through the
barrel was what created the back-edge.

## What

Redirect both type-only imports to their definition-site leaf (same
symbol, identical shape — `tsc` clean), removing the two wrong-direction
`Types -> Mediator` cycle edges:

- `IFormAnchor` now imported from `Mediator/Form/Anchor/AnchorTypes`
  (its definition; imports only `playwright-core` + `Base`).
- `IDiscoveredEndpoint` now imported from `Mediator/Network/Types/Endpoint`
  (its definition; zero imports).

The `FormAnchor` / `NetworkDiscoveryTypes` barrels are untouched and
still re-export for their other consumers. `LoginTypes` and
`ScrapeDiscoveryTypes` are peeled off the SCC; the frozen cycle baseline
shrinks **69 -> 67** nodes (purely subtractive). First slice of Phase 12i
(the monster decomposition); the bidirectional `IApiMediator` /
`IElementMediator` contract entanglements are tracked as follow-up slices.

## Guideline compliance

| # | Guideline | How this PR complies |
|---|-----------|----------------------|
| 1 | Atomic Conventional Commit | Single commit `19a2f2b4` `refactor(pipeline): peel Types off cycle (12i-1)` |
| 2 | Selective staging (no `git add .`) | Exactly 3 files staged by path |
| 3 | No hook bypass | All 21 husky gates green (incl. Mock + Live E2E); no `--no-verify` |
| 4 | Acyclic-dependencies ratchet | Cycle gate green; baseline re-frozen 69->67, subset of prior |
| 5 | OCP / direction | Removes wrong-direction Types->Mediator edges; layering improved |
| 6 | Behavior-preserving refactor | Same symbol identity; `tsc` clean; 27 arch/cycle tests pass |
| 7 | No `any` / strict types | Type-only import-source change; no new types |
| 8 | DRY / single source | Imports now resolve to the interface definition site, not a barrel |
| 9 | Tests pass | LayerSeparation + CoreBankIndependence + ImportCycles (27) green |
| 10 | 50/72 commit message | Subject 48 chars; body wrapped <=72 |
| 11 | No secrets / PII | Pure import-path + baseline edit; none present |
| 12 | File-count cap (<=150) | 3 files changed |