### PR TITLE
refactor(pipeline): split monster SCC at discovery (12i-3)

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
@@ -20,7 +20,7 @@ import type { Option } from '../../Types/Option.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import type { IFormAnchor } from '../Form/FormAnchor.js';
 import type { IFormErrorScanResult } from '../Form/FormErrorDiscovery.js';
-import type { INetworkDiscovery } from '../Network/NetworkDiscovery.js';
+import type { INetworkDiscovery } from '../Network/Types/Discovery.js';
 import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';
 
 /**

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 1,
+  "cycleCount": 2,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -17,33 +17,6 @@
       "src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts",
       "src/Scrapers/Pipeline/Mediator/Form/Anchor/AnchorWalk.ts",
       "src/Scrapers/Pipeline/Mediator/Form/FormAnchor.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery/index.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery/Orchestrator.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery/StorageFrames.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthDiscovery/StorageScanAll.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/BodyReaders.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/Factory.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/index.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/Inspector.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/State.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/Waiter.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/AuthCache.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/DiscoveryEngine.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/Lifecycle.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/MetaBuilders.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/MethodBundles.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryEngine/PostInterceptor.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/DiscoveryHeaders/DiscoveryHeaders.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/FrozenReplay/FrozenReplay.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/FrozenReplay/FrozenSlices.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/Indexing.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParserLogs.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/NetworkDiscovery.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Scoring/Scoring.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Scoring/ShapeAware.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.forAttr.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.walkUp.ts",
@@ -61,6 +34,11 @@
       "src/Scrapers/Pipeline/Types/LogEvent.ts",
       "src/Scrapers/Pipeline/Types/Phase.ts",
       "src/Scrapers/Pipeline/Types/PipelineContext.ts"
+    ],
+    [
+      "src/Scrapers/Pipeline/Mediator/Network/Indexing/Indexing.ts",
+      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts",
+      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParserLogs.ts"
     ]
   ]
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | ✅ one logical change; `refactor(pipeline): split monster SCC at discovery`; subject 50 chars, body wrapped ≤72 |
| 2 | Selective staging, no `git add .` (before-commit §38) | ✅ staged exactly 2 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit §40) | ✅ all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | ✅ `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | ✅ `eslint --max-warnings=0` on changed file green; husky `eslint`/`biome` green |
| 6 | Acyclic-dependencies gate (cycle ratchet) | ✅ `npm run lint:cycles` PASS — 2 cycles, both subsets of frozen baseline; baseline re-frozen 58 → 31+3 |
| 7 | Architecture/cycle tests | ✅ 27 tests pass (LayerSeparationArchitecture, CoreBankIndependence, ImportCycles) |
| 8 | CLAUDE.md ZERO CSS selectors | ✅ N/A — type-only import-path redirect, no interaction code |
| 9 | Public API byte-identical | ✅ `import type` erased at runtime; lib unchanged; husky `docs-coverage`/`docs-staleness` green |
| 10 | PII-free diff + commit message | ✅ no credentials/paths/PII; `fixtures-pii` gate green |
| 11 | Self-review + rubber-duck (pr-guidlines §3/§9) | ✅ rubber-duck GREEN, 0 RED/0 YELLOW; symbol identity + no cycle-regrowth verified |
| 12 | No temp/debug artifacts (before-commit §27-31) | ✅ read-only Tarjan simulator deleted pre-commit; working tree clean |

## Why

The decoupling campaign's headline metric is the acyclic-dependencies
cycle gate. After slices 12i-1 and 12i-2 peeled the cheap leaf edges,
one dense 58-node Mediator SCC ("the monster") remained — the bulk of
the project's residual import coupling. Cheap peel-to-acyclic redirects
are now exhausted: the remaining core is mutually entangled, so the only
way to make progress is to **decompose** the blob into smaller cycles
that can each be dissolved in turn.

## What

Redirect `ElementMediator`'s type-only `INetworkDiscovery` import
(line 23) from the `NetworkDiscovery` barrel — a *member* of the
58-node SCC — to the symbol's definition file
`Network/Types/Discovery.ts`, an out-of-SCC leaf peeled in slice
12i-2. Same symbol identity (`import type`, `tsc` clean), so no
runtime change.

Effect on the cycle graph:
- 24 nodes drop out of all cycles; the monster splits into a **31-node**
  core plus a residual **3-node** Indexing cycle
  (`Indexing` / `ResponseParser` / `ResponseParserLogs`).
- Total nodes-in-cycles fall **58 → 34** (coupling mass, the honest
  progress metric for SCC decomposition).
- `cycleCount` rises **1 → 2** — expected when one monolithic SCC
  fragments. The gate accepts both new cycles as subsets of the frozen
  58-node baseline; baseline re-frozen to 31 + 3 (stricter ratchet — a
  future re-merge would now fail).

The 3-node Indexing cycle is the immediate next slice (extract the
shared `IRequestMeta` + parser primitives to a leaf).