### PR TITLE
refactor(network): dissolve indexing import cycle (12i-4)

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Network/Indexing/Indexing.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Indexing/Indexing.ts
@@ -1,37 +1,32 @@
 /**
- * Network Indexing — primitives for filtering and parsing the JSON /
- * no-content responses captured from the live browser page.
+ * Network Indexing — header constants + captured-endpoint predicates
+ * for the JSON / no-content responses captured from the live browser
+ * page, plus the stable public facade for the indexing cluster.
  *
- * Boundary: pure functions over a single Playwright Response; no
- * cross-talk with scoring, endpoint-state, or discovery facade.
+ * Boundary: pure functions over a single Playwright Response or a
+ * captured endpoint; no cross-talk with scoring, endpoint-state, or
+ * the discovery facade.
  *
  *   • Header / content-type constants from the WK registry.
- *   • `parseTextOrNull` / `shouldRecordResponse` / `isUnsupportedUrl`
- *     — predicate gates that decide whether a response enters the
- *     captured pool.
- *   • `extractRequestMeta` — validated meta bag (CR #6 — removes the
- *     unsafe `as 'GET' | 'POST' | 'PUT'` cast).
  *   • `extractBaseUrl` — strip query params (used downstream by
  *     Scoring to find the most common base URL).
  *   • `isReplayablePost` — branch predicate used by Scoring's tier
  *     picker to recognise replayable POST templates.
+ *   • Request-meta extraction + capture-gate predicates
+ *     (`extractRequestMeta` / `parseTextOrNull` / `shouldRecordResponse`
+ *     / `isUnsupportedUrl`) live in {@link ./ResponsePrimitives.js} and
+ *     are re-exported here so the public-API surface stays stable.
  *   • `parseResponse` / `handleResponse` are re-exported from
- *     `ResponseParser.ts` so the public-API surface stays stable.
+ *     {@link ./ResponseParser.js} for the same reason.
  *
  * Extracted from NetworkDiscovery.ts (Phase 4 commit 3/9).
  * Split into Indexing + ResponseParser (PR #276 review — CR #7).
+ * Primitives split into ResponsePrimitives (slice 12i-4) to dissolve
+ * the Indexing ↔ ResponseParser ↔ ResponseParserLogs import cycle.
  */
 
-import type { Response } from 'playwright-core';
-
-import {
-  PIPELINE_WELL_KNOWN_API,
-  PIPELINE_WELL_KNOWN_HEADERS,
-} from '../../../Registry/WK/ScrapeWK.js';
-import { getDebug } from '../../../Types/Debug.js';
+import { PIPELINE_WELL_KNOWN_HEADERS } from '../../../Registry/WK/ScrapeWK.js';
 import type { IDiscoveredEndpoint } from '../NetworkDiscoveryTypes.js';
-
-const LOG = getDebug(import.meta.url);
 
 /** WK header names — imported from registry. */
 const ORIGIN_HEADERS = PIPELINE_WELL_KNOWN_HEADERS.origin;
@@ -39,143 +34,6 @@ const ORIGIN_KEY_HEADERS = PIPELINE_WELL_KNOWN_HEADERS.originKey;
 const REFERER_HEADERS = PIPELINE_WELL_KNOWN_HEADERS.referer;
 const SITE_ID_HEADERS = PIPELINE_WELL_KNOWN_HEADERS.siteId;
 const BROWSER_STANDARD_HEADERS = PIPELINE_WELL_KNOWN_HEADERS.browserStandard;
-
-/** Sentinel for missing content-type header. */
-const NO_CONTENT_TYPE = 'none';
-
-/** Sentinel for missing POST body. */
-const NO_POST_DATA = '';
-
-/** Content types that may contain a JSON API response. */
-const JSON_CONTENT_TYPES = ['application/json', 'text/json', 'text/plain', 'text/html'];
-
-/** WK allowed HTTP methods — CR PR #276 #6 validates request().method(). */
-const ALLOWED_METHODS = ['GET', 'POST', 'PUT'] as const;
-type AllowedMethod = (typeof ALLOWED_METHODS)[number];
-
-/**
- * Check if a content-type header indicates JSON.
- * @param contentType - The content-type header value.
- * @returns True if JSON response.
- */
-function isJsonContentType(contentType: string): boolean {
-  const lower = contentType.toLowerCase();
-  return JSON_CONTENT_TYPES.some((jsonType): boolean => lower.includes(jsonType));
-}
-
-/** Request metadata bag returned by {@link extractRequestMeta}. */
-interface IRequestMeta {
-  readonly url: string;
-  readonly method: AllowedMethod;
-  readonly postData: string;
-  readonly contentType: string;
-  readonly requestHeaders: Record<string, string>;
-}
-
-/**
- * Validate raw HTTP method against the allowed set; fall back to
- * `'GET'` for unsupported verbs (DELETE/PATCH/HEAD/OPTIONS). Logs
- * the fallback so unexpected verbs surface in trace logs.
- * CR PR #276 #6 — removes the unsafe `as 'GET'|'POST'|'PUT'` cast.
- * @param raw - Raw method string from Playwright request.
- * @returns Validated method or `'GET'` fallback.
- */
-function validateMethod(raw: string): AllowedMethod {
-  const isKnown = (ALLOWED_METHODS as readonly string[]).includes(raw);
-  if (isKnown) return raw as AllowedMethod;
-  LOG.trace({ event: 'extractRequestMeta.unsupportedMethod', method: raw });
-  return 'GET';
-}
-
-/** Bundled args for {@link extractRequestParts} return-type alias. */
-type RequestParts = Pick<IRequestMeta, 'method' | 'postData' | 'requestHeaders'>;
-
-/**
- * Extract the method + postData + requestHeaders triple from the
- * response's request. Pulled out of {@link extractRequestMeta} so the
- * orchestrator stays under the per-function 10-LoC cap.
- * @param response - Playwright response (for `response.request()`).
- * @returns Bundled method (validated), postData, requestHeaders.
- */
-function extractRequestParts(response: Response): RequestParts {
-  const request = response.request();
-  const rawMethod = request.method();
-  const method = validateMethod(rawMethod);
-  const postData = request.postData() ?? NO_POST_DATA;
-  const requestHeaders = request.headers();
-  return { method, postData, requestHeaders };
-}
-
-/**
- * Extract request metadata from a Playwright response.
- * @param response - Playwright response object.
- * @returns Bundled URL, method, postData, contentType, requestHeaders.
- */
-function extractRequestMeta(response: Response): IRequestMeta {
-  const headers = response.headers();
-  const contentType = headers['content-type'] ?? NO_CONTENT_TYPE;
-  const url = response.url();
-  const parts = extractRequestParts(response);
-  return { url, contentType, ...parts };
-}
-
-/** Parsed body wrapper — keeps the typed bag separate from raw `unknown`. */
-interface IParsedBody {
-  readonly value: unknown;
-}
-
-/** Branded signal — true when the response should enter the captured pool. */
-type ShouldRecordResponseSignal = boolean & {
-  readonly __brand: 'ShouldRecordResponseSignal';
-};
-
-/**
- * Parse a response-text payload, normalising empty / whitespace-only
- * bodies to `null` so they survive the picker's `urlOnlyMatch` rescue
- * tier. Throws on malformed JSON — callers must wrap in try/catch.
- * Exported for unit testing.
- * @param text - Raw response text.
- * @returns Wrapper carrying the parsed value (`null` for empty payloads).
- */
-function parseTextOrNull(text: string): IParsedBody {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) return { value: null };
-  return { value: JSON.parse(trimmed) as unknown };
-}
-
-/**
- * Decision predicate for `parseResponse`. 2xx-no-content responses
- * (HTTP 204) carry no body and typically have no `content-type`
- * header — they fail the JSON filter and would be dropped before
- * `parseTextOrNull` ever runs, making the picker's `urlOnlyMatch`
- * rescue tier unreachable for the exact captures it was added to
- * handle. Treat 204 as intrinsically recordable.
- * @param status - HTTP status code.
- * @param contentType - Response content-type header (or `'none'`).
- * @returns True when the response should enter the captured pool.
- */
-function shouldRecordResponse(status: number, contentType: string): ShouldRecordResponseSignal {
-  if (status === 204) return true as ShouldRecordResponseSignal;
-  return isJsonContentType(contentType) as ShouldRecordResponseSignal;
-}
-
-/** Branded boolean for the unsupported-URL gate. */
-type IsUnsupportedUrlSignal = boolean & {
-  readonly __brand: 'IsUnsupportedUrlSignal';
-};
-
-/**
- * Test if a URL is on the unsupported-URL block list. WK-driven via
- * `PIPELINE_WELL_KNOWN_API.unsupported` — currently `.ashx` (Amex
- * legacy ProxyRequestHandler). Excluded URLs never enter the captured
- * pool. Exported for unit testing.
- * @param url - Response URL.
- * @returns True when the URL matches a WK unsupported pattern.
- */
-function isUnsupportedUrl(url: string): IsUnsupportedUrlSignal {
-  const isMatch = PIPELINE_WELL_KNOWN_API.unsupported.some((p): boolean => p.test(url));
-  return isMatch as IsUnsupportedUrlSignal;
-}
 
 /**
  * Extract the base URL (before query params) from a full URL.
@@ -200,29 +58,31 @@ function isReplayablePost(ep: IDiscoveredEndpoint): boolean {
 }
 
 export { handleResponse, parseResponse } from './ResponseParser.js';
-
-export {
-  ALLOWED_METHODS,
-  BROWSER_STANDARD_HEADERS,
-  extractBaseUrl,
-  extractRequestMeta,
-  isJsonContentType,
-  isReplayablePost,
-  isUnsupportedUrl,
-  JSON_CONTENT_TYPES,
-  NO_CONTENT_TYPE,
-  NO_POST_DATA,
-  ORIGIN_HEADERS,
-  ORIGIN_KEY_HEADERS,
-  parseTextOrNull,
-  REFERER_HEADERS,
-  shouldRecordResponse,
-  SITE_ID_HEADERS,
-};
 export type {
   AllowedMethod,
   IParsedBody,
   IRequestMeta,
   IsUnsupportedUrlSignal,
   ShouldRecordResponseSignal,
+} from './ResponsePrimitives.js';
+export {
+  ALLOWED_METHODS,
+  extractRequestMeta,
+  isJsonContentType,
+  isUnsupportedUrl,
+  JSON_CONTENT_TYPES,
+  NO_CONTENT_TYPE,
+  NO_POST_DATA,
+  parseTextOrNull,
+  shouldRecordResponse,
+} from './ResponsePrimitives.js';
+
+export {
+  BROWSER_STANDARD_HEADERS,
+  extractBaseUrl,
+  isReplayablePost,
+  ORIGIN_HEADERS,
+  ORIGIN_KEY_HEADERS,
+  REFERER_HEADERS,
+  SITE_ID_HEADERS,
 };

--- a/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts
@@ -24,13 +24,6 @@ import { maskVisibleText } from '../../../Types/LogEvent.js';
 import { dumpResponseBody } from '../Debug/NetworkDump.js';
 import type { IDiscoveredEndpoint } from '../NetworkDiscoveryTypes.js';
 import {
-  extractRequestMeta,
-  type IRequestMeta,
-  isUnsupportedUrl,
-  parseTextOrNull,
-  shouldRecordResponse,
-} from './Indexing.js';
-import {
   type DropReason,
   type IResponseMeta,
   logCaptureMiss,
@@ -40,6 +33,13 @@ import {
   logParseEntry,
   logTextRead,
 } from './ResponseParserLogs.js';
+import {
+  extractRequestMeta,
+  type IRequestMeta,
+  isUnsupportedUrl,
+  parseTextOrNull,
+  shouldRecordResponse,
+} from './ResponsePrimitives.js';
 
 const LOG = getDebug(import.meta.url);
 

--- a/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParserLogs.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParserLogs.ts
@@ -9,7 +9,7 @@ import { getDebug } from '../../../Types/Debug.js';
 import { toErrorMessage } from '../../../Types/ErrorUtils.js';
 import { maskVisibleText } from '../../../Types/LogEvent.js';
 import { redactUrlFull } from '../../../Types/PiiRedactor.js';
-import type { IRequestMeta } from './Indexing.js';
+import type { IRequestMeta } from './ResponsePrimitives.js';
 
 const LOG = getDebug(import.meta.url);
 

--- a/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponsePrimitives.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponsePrimitives.ts
@@ -1,0 +1,177 @@
+/**
+ * Network Indexing / ResponsePrimitives — pure request-meta extraction
+ * and capture-gate predicates over a single Playwright Response.
+ *
+ * Boundary: a true leaf — depends only on the WK registry, Debug, and
+ * playwright types. Holds NO reference to `ResponseParser.ts` (the
+ * orchestrator) so the parser/logs half can import these primitives
+ * without re-entering `Indexing.ts`.
+ *
+ * Extracted from `Indexing.ts` (slice 12i-4) to dissolve the
+ * Indexing ↔ ResponseParser ↔ ResponseParserLogs import cycle:
+ * `Indexing.ts` re-exports every symbol here, so the public facade
+ * stays byte-identical for downstream consumers (Scoring, Discovery).
+ */
+
+import type { Response } from 'playwright-core';
+
+import { PIPELINE_WELL_KNOWN_API } from '../../../Registry/WK/ScrapeWK.js';
+import { getDebug } from '../../../Types/Debug.js';
+
+const LOG = getDebug(import.meta.url);
+
+/** Sentinel for missing content-type header. */
+const NO_CONTENT_TYPE = 'none';
+
+/** Sentinel for missing POST body. */
+const NO_POST_DATA = '';
+
+/** Content types that may contain a JSON API response. */
+const JSON_CONTENT_TYPES = ['application/json', 'text/json', 'text/plain', 'text/html'];
+
+/** WK allowed HTTP methods — CR PR #276 #6 validates request().method(). */
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT'] as const;
+type AllowedMethod = (typeof ALLOWED_METHODS)[number];
+
+/**
+ * Check if a content-type header indicates JSON.
+ * @param contentType - The content-type header value.
+ * @returns True if JSON response.
+ */
+function isJsonContentType(contentType: string): boolean {
+  const lower = contentType.toLowerCase();
+  return JSON_CONTENT_TYPES.some((jsonType): boolean => lower.includes(jsonType));
+}
+
+/** Request metadata bag returned by {@link extractRequestMeta}. */
+interface IRequestMeta {
+  readonly url: string;
+  readonly method: AllowedMethod;
+  readonly postData: string;
+  readonly contentType: string;
+  readonly requestHeaders: Record<string, string>;
+}
+
+/**
+ * Validate raw HTTP method against the allowed set; fall back to
+ * `'GET'` for unsupported verbs (DELETE/PATCH/HEAD/OPTIONS). Logs
+ * the fallback so unexpected verbs surface in trace logs.
+ * CR PR #276 #6 — removes the unsafe `as 'GET'|'POST'|'PUT'` cast.
+ * @param raw - Raw method string from Playwright request.
+ * @returns Validated method or `'GET'` fallback.
+ */
+function validateMethod(raw: string): AllowedMethod {
+  const isKnown = (ALLOWED_METHODS as readonly string[]).includes(raw);
+  if (isKnown) return raw as AllowedMethod;
+  LOG.trace({ event: 'extractRequestMeta.unsupportedMethod', method: raw });
+  return 'GET';
+}
+
+/** Bundled args for {@link extractRequestParts} return-type alias. */
+type RequestParts = Pick<IRequestMeta, 'method' | 'postData' | 'requestHeaders'>;
+
+/**
+ * Extract the method + postData + requestHeaders triple from the
+ * response's request. Pulled out of {@link extractRequestMeta} so the
+ * orchestrator stays under the per-function 10-LoC cap.
+ * @param response - Playwright response (for `response.request()`).
+ * @returns Bundled method (validated), postData, requestHeaders.
+ */
+function extractRequestParts(response: Response): RequestParts {
+  const request = response.request();
+  const rawMethod = request.method();
+  const method = validateMethod(rawMethod);
+  const postData = request.postData() ?? NO_POST_DATA;
+  const requestHeaders = request.headers();
+  return { method, postData, requestHeaders };
+}
+
+/**
+ * Extract request metadata from a Playwright response.
+ * @param response - Playwright response object.
+ * @returns Bundled URL, method, postData, contentType, requestHeaders.
+ */
+function extractRequestMeta(response: Response): IRequestMeta {
+  const headers = response.headers();
+  const contentType = headers['content-type'] ?? NO_CONTENT_TYPE;
+  const url = response.url();
+  const parts = extractRequestParts(response);
+  return { url, contentType, ...parts };
+}
+
+/** Parsed body wrapper — keeps the typed bag separate from raw `unknown`. */
+interface IParsedBody {
+  readonly value: unknown;
+}
+
+/** Branded signal — true when the response should enter the captured pool. */
+type ShouldRecordResponseSignal = boolean & {
+  readonly __brand: 'ShouldRecordResponseSignal';
+};
+
+/**
+ * Parse a response-text payload, normalising empty / whitespace-only
+ * bodies to `null` so they survive the picker's `urlOnlyMatch` rescue
+ * tier. Throws on malformed JSON — callers must wrap in try/catch.
+ * Exported for unit testing.
+ * @param text - Raw response text.
+ * @returns Wrapper carrying the parsed value (`null` for empty payloads).
+ */
+function parseTextOrNull(text: string): IParsedBody {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return { value: null };
+  return { value: JSON.parse(trimmed) as unknown };
+}
+
+/**
+ * Decision predicate for `parseResponse`. 2xx-no-content responses
+ * (HTTP 204) carry no body and typically have no `content-type`
+ * header — they fail the JSON filter and would be dropped before
+ * `parseTextOrNull` ever runs, making the picker's `urlOnlyMatch`
+ * rescue tier unreachable for the exact captures it was added to
+ * handle. Treat 204 as intrinsically recordable.
+ * @param status - HTTP status code.
+ * @param contentType - Response content-type header (or `'none'`).
+ * @returns True when the response should enter the captured pool.
+ */
+function shouldRecordResponse(status: number, contentType: string): ShouldRecordResponseSignal {
+  if (status === 204) return true as ShouldRecordResponseSignal;
+  return isJsonContentType(contentType) as ShouldRecordResponseSignal;
+}
+
+/** Branded boolean for the unsupported-URL gate. */
+type IsUnsupportedUrlSignal = boolean & {
+  readonly __brand: 'IsUnsupportedUrlSignal';
+};
+
+/**
+ * Test if a URL is on the unsupported-URL block list. WK-driven via
+ * `PIPELINE_WELL_KNOWN_API.unsupported` — currently `.ashx` (Amex
+ * legacy ProxyRequestHandler). Excluded URLs never enter the captured
+ * pool. Exported for unit testing.
+ * @param url - Response URL.
+ * @returns True when the URL matches a WK unsupported pattern.
+ */
+function isUnsupportedUrl(url: string): IsUnsupportedUrlSignal {
+  const isMatch = PIPELINE_WELL_KNOWN_API.unsupported.some((p): boolean => p.test(url));
+  return isMatch as IsUnsupportedUrlSignal;
+}
+
+export {
+  ALLOWED_METHODS,
+  extractRequestMeta,
+  isJsonContentType,
+  isUnsupportedUrl,
+  JSON_CONTENT_TYPES,
+  NO_CONTENT_TYPE,
+  NO_POST_DATA,
+  parseTextOrNull,
+  shouldRecordResponse,
+};
+export type {
+  AllowedMethod,
+  IParsedBody,
+  IRequestMeta,
+  IsUnsupportedUrlSignal,
+  ShouldRecordResponseSignal,
+};

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 2,
+  "cycleCount": 1,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -34,11 +34,6 @@
       "src/Scrapers/Pipeline/Types/LogEvent.ts",
       "src/Scrapers/Pipeline/Types/Phase.ts",
       "src/Scrapers/Pipeline/Types/PipelineContext.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/Indexing.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts",
-      "src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParserLogs.ts"
     ]
   ]
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | ✅ one logical change; `refactor(network): dissolve indexing import cycle`; subject 49 chars, body ≤72 |
| 2 | Selective staging, no `git add .` (before-commit §38) | ✅ staged exactly 5 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit §40) | ✅ all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | ✅ `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | ✅ `eslint --max-warnings=0` on all 4 cluster files green (sort autofix applied); husky `eslint`/`biome` green |
| 6 | ≤10-LoC functions / ≤300-line files (CLEAN_CODE.md) | ✅ all moved fns ≤10 LoC verbatim; ResponsePrimitives.ts 177 lines (skipComments well under cap) |
| 7 | Acyclic-dependencies gate (cycle ratchet) | ✅ `npm run lint:cycles` 2 cycles → **1**; baseline re-frozen to single 31-node cycle (mass 34→31) |
| 8 | Tests pass (270, incl. 27 architecture/cycle) | ✅ 25 suites green: NetworkDiscovery*/ParseResponse204/UnsupportedUrl/ParseTextOrNull + arch/cycle |
| 9 | Public facade byte-identical | ✅ Indexing.js exported symbol set unchanged (18 values + 5 types); zero consumer/test edits; lib unchanged |
| 10 | Behaviour-preserving move | ✅ rubber-duck confirmed all 7 fns moved verbatim (status/204/JSON/method-fallback/ashx unchanged) |
| 11 | PII-free diff + commit message | ✅ no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines §3/§9) | ✅ rubber-duck GREEN, 0 RED; cycle dissolution + facade parity + leaf-purity verified |

## Why

Slice 12i-3 fragmented the 58-node monster SCC into a 31-node core plus
a residual 3-node Indexing cycle. This slice dissolves that 3-node cycle
— the cheapest immediate win — returning `cycleCount` to **1** while
the 31-node core remains the headline target.

The cycle existed because `Indexing.ts` is the cluster's public facade
(re-exporting `parseResponse`/`handleResponse` from
`ResponseParser.ts`), yet `ResponseParser.ts` and
`ResponseParserLogs.ts` reached *back* into `Indexing.ts` for the
low-level request-meta primitives — a low-level↔high-level mutual
dependency.

## What

Extract the request-meta extraction + capture-gate predicates
(`extractRequestMeta`, `parseTextOrNull`, `shouldRecordResponse`,
`isUnsupportedUrl`, `isJsonContentType` + their constants/types)
**verbatim** out of `Indexing.ts` into a new leaf
`ResponsePrimitives.ts` that depends only on the WK registry, Debug,
and playwright types.

- `ResponseParser.ts` + `ResponseParserLogs.ts` now import those
  primitives from `./ResponsePrimitives.js` — removing **both**
  back-edges into `Indexing.ts`.
- `Indexing.ts` re-exports every moved symbol from the leaf (and still
  re-exports `parseResponse`/`handleResponse` from
  `ResponseParser.ts`), so its **public facade is byte-identical** —
  zero changes to any external consumer or test.

Result: the 3-node SCC is fully dissolved (`Indexing → ResponseParser →
ResponsePrimitives` with no return edge). Cycle gate **2 → 1**; coupling
mass **34 → 31**; baseline re-frozen to the single 31-node core.

Next slice attacks the 31-node core (`PipelineContext` DIP interface
extraction is the big prize).