### PR TITLE
refactor(pipeline): peel FormAnchor off the Mediator SCC (12i-5)

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
@@ -18,7 +18,7 @@ import type { Frame, Locator, Page } from 'playwright-core';
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
 import type { Option } from '../../Types/Option.js';
 import type { Procedure } from '../../Types/Procedure.js';
-import type { IFormAnchor } from '../Form/FormAnchor.js';
+import type { IFormAnchor } from '../Form/Anchor/AnchorTypes.js';
 import type { IFormErrorScanResult } from '../Form/FormErrorDiscovery.js';
 import type { INetworkDiscovery } from '../Network/Types/Discovery.js';
 import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -15,8 +15,6 @@
       "src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts",
       "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts",
       "src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts",
-      "src/Scrapers/Pipeline/Mediator/Form/Anchor/AnchorWalk.ts",
-      "src/Scrapers/Pipeline/Mediator/Form/FormAnchor.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.forAttr.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.walkUp.ts",


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | ✅ one logical change; `refactor(pipeline): redirect IFormAnchor to leaf`; subject 48 chars, body ≤72 |
| 2 | Selective staging, no `git add .` (before-commit §38) | ✅ staged exactly 2 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit §40) | ✅ all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | ✅ `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | ✅ `eslint` on the changed file exit 0; husky `eslint`/`biome` green |
| 6 | ≤10-LoC functions / ≤300-line files (CLEAN_CODE.md) | ✅ one-line import redirect; no function or file-size change |
| 7 | Acyclic-dependencies gate (cycle ratchet) | ✅ `npm run lint:cycles` green; SCC 31 → **29** nodes; baseline re-frozen (subtractive) |
| 8 | Tests pass (223, incl. architecture/cycle) | ✅ 23 suites green: LayerSeparationArchitecture/ImportCycles/CoreBankIndependence + all ElementMediator + Form/Anchor |
| 9 | Symbol identity unchanged (type-only redirect) | ✅ `IFormAnchor` is the same interface (defined in `AnchorTypes.ts`); FormAnchor barrel untouched; consumers unaffected |
| 10 | Behaviour-preserving (no runtime change) | ✅ rubber-duck confirmed type-only import; zero value/runtime edges changed; lib unchanged |
| 11 | PII-free diff + commit message | ✅ no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines §3/§9) | ✅ rubber-duck GREEN, 0 RED; leaf-purity + single-edge + subtractive baseline verified |

## Why

The 31-node Mediator dependency cycle (the campaign's headline SCC) trapped
`FormAnchor.ts` and `AnchorWalk.ts` only because `ElementMediator.ts`
imported the `IFormAnchor` **type** through the in-SCC `Form/FormAnchor.js`
barrel. That barrel chains `FormAnchor → AnchorWalk → AnchorTypes` to reach
the same interface, closing the loop:

```
ElementMediator → FormAnchor → AnchorWalk → LogEvent → Phase →
PipelineContext → ElementMediator
```

It is the only `ElementMediator → FormAnchor` edge, so redirecting it to the
type's definition leaf peels both files out of every cycle.

## What

Redirect `ElementMediator.ts:21` to import `IFormAnchor` straight from its
definition leaf `Form/Anchor/AnchorTypes.ts` (out of the SCC; imports only
playwright types and `Base` `Nullable`) instead of the `Form/FormAnchor.js`
barrel.

- Type-only import → symbol identity unchanged (`tsc --noEmit` exit 0).
- The `FormAnchor` barrel is untouched, so all other consumers still
  resolve `IFormAnchor` through it.
- The back-edge into the core is removed.

Result: `FormAnchor.ts` and `AnchorWalk.ts` leave all cycles — coupling mass
**31 → 29** with `cycleCount` unchanged at **1** (no fragmentation). The
frozen cycle baseline is re-frozen to the 29-node core (subtractive ratchet),
so the gate now fails if the edge returns. This also makes `IFormAnchor`
leaf-reachable, unblocking the later `PipelineContext` DIP extraction.
