### PR TITLE
refactor(pipeline): fragment the 29-node Mediator SCC into [12,5] (12i-6)

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts
@@ -21,7 +21,7 @@ import type { Procedure } from '../../Types/Procedure.js';
 import type { IFormAnchor } from '../Form/Anchor/AnchorTypes.js';
 import type { IFormErrorScanResult } from '../Form/FormErrorDiscovery.js';
 import type { INetworkDiscovery } from '../Network/Types/Discovery.js';
-import type { IFieldContext } from '../Selector/SelectorResolverPipeline.js';
+import type { IFieldContext } from '../Selector/SelectorResolverPipeline.types.js';
 
 /**
  * Structured DOM identity captured during PRE resolution.

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 1,
+  "cycleCount": 2,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -14,24 +14,14 @@
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts",
       "src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts",
       "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts",
-      "src/Scrapers/Pipeline/Mediator/Elements/ElementMediator.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.forAttr.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.walkUp.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorLabelStrategies.xpath.ts",
+      "src/Scrapers/Pipeline/Types/PipelineContext.ts"
+    ],
+    [
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.entries.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.probe.log.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.probe.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.try.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.context.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.frames.ts",
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.main.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.notFound.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.ts",
-      "src/Scrapers/Pipeline/Types/LogEvent.ts",
-      "src/Scrapers/Pipeline/Types/Phase.ts",
-      "src/Scrapers/Pipeline/Types/PipelineContext.ts"
+      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.ts"
     ]
   ]
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | OK one logical change; `refactor(pipeline): redirect IFieldContext to leaf`; subject 50 chars, body <=72 |
| 2 | Selective staging, no `git add .` (before-commit s38) | OK staged exactly 2 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit s40) | OK all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | OK `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | OK `eslint` on the changed file exit 0; husky `eslint`/`biome` green |
| 6 | <=10-LoC functions / <=300-line files (CLEAN_CODE.md) | OK one-line import redirect; no function or file-size change |
| 7 | Acyclic-dependencies gate (cycle ratchet) | OK `npm run lint:cycles` green; 29-node SCC fragmented to [12, 5] (mass 29->17); subset split, baseline re-frozen |
| 8 | Tests pass (386, incl. architecture/cycle) | OK 34 suites green: LayerSeparationArchitecture/ImportCycles/CoreBankIndependence + all ElementMediator + SelectorResolver/SelectorLabel |
| 9 | Symbol identity unchanged (type-only redirect) | OK `IFieldContext` is the same interface (defined in `SelectorResolverPipeline.types.ts:16`); barrel untouched; consumers unaffected |
| 10 | Behaviour-preserving (no runtime change) | OK rubber-duck confirmed type-only import; zero value/runtime edges changed; lib unchanged |
| 11 | PII-free diff + commit message | OK no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines s3/s9) | OK rubber-duck GREEN, 0 RED; leaf-purity + single-edge + strict-subset baseline verified |

## Why

The campaign''s headline 29-node Mediator dependency cycle was bound together
because `ElementMediator.ts` imported the `IFieldContext` **type** through the
in-SCC `Selector/SelectorResolverPipeline.js` barrel. That was
`ElementMediator`''s only edge into `SelectorResolverPipeline`, and it stitched
the Selector / ApiMediator / `PipelineContext` clusters into a single 29-node
strongly-connected component.

`IFieldContext` is actually **defined** in the out-of-SCC leaf
`SelectorResolverPipeline.types.ts` and merely re-exported by the barrel - so
importing it from the barrel was an unnecessary back-edge into the core.

## What

Redirect `ElementMediator.ts:24` to import `IFieldContext` straight from its
definition leaf `Selector/SelectorResolverPipeline.types.ts` (out of the SCC;
imports only playwright types and `Base` `LoginConfig`) instead of the
`SelectorResolverPipeline.js` barrel.

- Type-only import means symbol identity unchanged (`tsc --noEmit` exit 0).
- The barrel is untouched, so every other consumer still resolves
  `IFieldContext` (and everything else) through it.
- The back-edge into the core is removed.

Result: cutting that single edge **fragments** the 29-node SCC into a 12-node
SCC and a 5-node SCC - coupling mass **29 -> 17**, the largest single-slice cut
of the campaign so far. `cycleCount` rises **1 -> 2**, but both new cycles are
strict subsets of the old frozen 29-node cycle, so the subset ratchet still
passes; the baseline is re-frozen to the two smaller cycles. This isolates the
residual ApiMediator and Selector knots for follow-up DIP work
(`PipelineContext` <-> mediator interface extraction).