### PR TITLE
refactor(pipeline): add ITokenContext ctx port

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts
@@ -11,7 +11,7 @@
 
 import type { WKQueryOperation } from '../../Registry/WK/QueriesWK.js';
 import type { WKUrlGroup } from '../../Registry/WK/UrlsWK.js';
-import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { apiGetOp, apiPostOp, apiQueryOp } from './ApiMediator.ops.js';
 import {
@@ -108,7 +108,7 @@ function bindWithTokenStrategy(
 ): IResolverMethods['withTokenStrategy'] {
   return <TCreds>(
     strategy: ITokenStrategy<TCreds>,
-    ctx: IPipelineContext,
+    ctx: ITokenContext,
     creds: TCreds,
   ): WasResolverSet => withTokenStrategyOp({ state, self, strategy, ctx, creds });
 }

--- a/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts
@@ -7,7 +7,7 @@ import type { WKQueryOperation } from '../../Registry/WK/QueriesWK.js';
 import type { WKUrlGroup } from '../../Registry/WK/UrlsWK.js';
 import type { IFetchStrategy } from '../../Strategy/Fetch/FetchStrategy.js';
 import type { GraphQLFetchStrategy } from '../../Strategy/Fetch/GraphQLFetchStrategy.js';
-import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import type { ITokenResolver } from './ITokenResolver.js';
 import type { ITokenStrategy } from './ITokenStrategy.js';
@@ -45,7 +45,7 @@ interface IApiMediator {
   withTokenResolver: (r: ITokenResolver) => WasResolverSet;
   withTokenStrategy: <TCreds>(
     strategy: ITokenStrategy<TCreds>,
-    ctx: IPipelineContext,
+    ctx: ITokenContext,
     creds: TCreds,
   ) => WasResolverSet;
   primeSession: () => Promise<Procedure<string>>;
@@ -109,7 +109,7 @@ interface IWithTokenStrategyOpArgs<TCreds> {
   readonly state: IMediatorState;
   readonly self: IApiMediator;
   readonly strategy: ITokenStrategy<TCreds>;
-  readonly ctx: IPipelineContext;
+  readonly ctx: ITokenContext;
   readonly creds: TCreds;
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts
@@ -10,7 +10,7 @@
  * generic architecture (spec.txt §B.7).
  */
 
-import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import type { IApiMediator } from './ApiMediator.js';
 
@@ -30,8 +30,8 @@ type TokenPrimeProcedure = Promise<Procedure<string>>;
  */
 interface ITokenStrategy<TCreds> {
   readonly name: string;
-  primeInitial(bus: IApiMediator, ctx: IPipelineContext, creds: TCreds): TokenPrimeProcedure;
-  primeFresh(bus: IApiMediator, ctx: IPipelineContext, creds: TCreds): TokenPrimeProcedure;
+  primeInitial(bus: IApiMediator, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
+  primeFresh(bus: IApiMediator, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
   hasWarmState(creds: TCreds): boolean;
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts
@@ -12,7 +12,7 @@
  *              retryOn401 wrapper on any 401 mid-session).
  */
 
-import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { isOk } from '../../Types/Procedure.js';
 import type { IApiMediator } from './ApiMediator.js';
@@ -23,7 +23,7 @@ import type { ITokenStrategy } from './ITokenStrategy.js';
 interface IBuilderDeps<TCreds> {
   readonly strategy: ITokenStrategy<TCreds>;
   readonly bus: IApiMediator;
-  readonly ctx: IPipelineContext;
+  readonly ctx: ITokenContext;
   readonly creds: TCreds;
 }
 
@@ -57,7 +57,7 @@ async function runInitial<TCreds>(deps: IBuilderDeps<TCreds>): Promise<Procedure
 interface IBuildResolverArgs<TCreds> {
   readonly strategy: ITokenStrategy<TCreds>;
   readonly bus: IApiMediator;
-  readonly ctx: IPipelineContext;
+  readonly ctx: ITokenContext;
   readonly creds: TCreds;
 }
 

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/TokenStrategyFromConfig.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/TokenStrategyFromConfig.types.ts
@@ -2,7 +2,7 @@
  * Type aliases + interfaces for the TokenStrategyFromConfig cluster.
  */
 
-import type { IPipelineContext } from '../../../Types/PipelineContext.js';
+import type { ITokenContext } from '../../../Types/Domain/TokenContext.js';
 import type { IApiMediator } from '../../Api/ApiMediator.js';
 import type { ITokenStrategy } from '../../Api/ITokenStrategy.js';
 import type { JsonValue } from '../Envelope/JsonPointer.js';
@@ -25,7 +25,7 @@ interface IRunFlowArgs {
   readonly config: IApiDirectCallConfig;
   readonly bus: IApiMediator;
   readonly creds: GenericCreds;
-  readonly companyId: IPipelineContext['companyId'];
+  readonly companyId: ITokenContext['companyId'];
   readonly initialCarry?: Readonly<Record<string, JsonValue>>;
   readonly startStepIndex?: number;
 }
@@ -48,14 +48,14 @@ interface IMakeWarmArgs {
   readonly bus: IApiMediator;
   readonly creds: GenericCreds;
   readonly stored: string;
-  readonly companyId: IPipelineContext['companyId'];
+  readonly companyId: ITokenContext['companyId'];
 }
 
 /** Args bundle for primeInitialImpl / primeFreshImpl. */
 interface IPrimeArgs {
   readonly config: IApiDirectCallConfig;
   readonly bus: IApiMediator;
-  readonly ctx: IPipelineContext;
+  readonly ctx: ITokenContext;
   readonly creds: GenericCreds;
   readonly slot: ILongTermTokenSlot;
 }

--- a/src/Scrapers/Pipeline/Types/Domain/TokenContext.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/TokenContext.ts
@@ -1,0 +1,19 @@
+/**
+ * ITokenContext — the narrow context port consumed by the token
+ * lifecycle (primeInitial / primeFresh). Token strategies need ONLY
+ * the resolved bank identity, never the whole IPipelineContext
+ * god-object. Defining this minimal port in the Types/Domain leaf lets
+ * the ApiMediator token surface depend on it instead of the concrete
+ * PipelineContext, breaking the Mediator ⟷ PipelineContext cycle (DIP).
+ * IPipelineContext structurally satisfies this port (it carries
+ * `companyId`), so existing call sites pass through unchanged.
+ */
+
+import type { CompanyTypes } from '../../../../Definitions.js';
+
+/** Minimal context surface required to prime a bank token. */
+interface ITokenContext {
+  readonly companyId: CompanyTypes;
+}
+
+export type { ITokenContext };

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -13,8 +13,7 @@
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ts",
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts",
       "src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts",
-      "src/Scrapers/Pipeline/Types/PipelineContext.ts"
+      "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts"
     ],
     [
       "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.entries.ts",


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | OK one logical change; `refactor(pipeline): add ITokenContext ctx port`; subject 46 chars, body <=72 |
| 2 | Selective staging, no `git add .` (before-commit s38) | OK staged exactly 7 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit s40) | OK all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | OK `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | OK `eslint --fix` on changed files exit 0; husky `eslint`/`biome` green |
| 6 | <=10-LoC functions / <=300-line files (CLEAN_CODE.md) | OK new 19-line type-only leaf; no function changed; no file over cap |
| 7 | Acyclic-dependencies gate (cycle ratchet) | OK `npm run lint:cycles` green; PipelineContext peeled, [12,5] -> [11,5] (mass 17->16); subtractive subset, baseline re-frozen |
| 8 | Tests pass (295, incl. architecture/cycle) | OK 31 suites green: LayerSeparationArchitecture/ImportCycles/CoreBankIndependence + ApiMediator(+retry-on-401)/TokenResolverBuilder/TokenStrategyFromConfig/ApiDirectCallActions |
| 9 | DIP narrow-port, symbol assignability sound | OK token strategies read only `ctx.companyId`; IPipelineContext structurally satisfies ITokenContext, so all call sites unchanged |
| 10 | Behaviour-preserving (no runtime change) | OK rubber-duck GREEN 0 RED; type-only ctx narrowing; zero value/runtime edges changed; lib unchanged |
| 11 | PII-free diff + commit message | OK no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines s3/s9) | OK rubber-duck GREEN 0 RED; honest cut (PipelineContext truly downstream, not a relocated cycle) verified |

## Why

The 12-node ApiMediator dependency cycle trapped `Types/PipelineContext.ts`
inside it. The binder was a needless heavyweight coupling: the ApiMediator
token surface (`ApiMediator.types`, `ApiMediator.builders`, `ITokenStrategy`,
`TokenResolverBuilder`) imported the whole `IPipelineContext` god-object purely
to type the token-prime `ctx` parameter (`withTokenStrategy` / `primeInitial`
/ `primeFresh`). Because `PipelineContext.ts` imports `IApiMediator` back, this
mutual edge kept `PipelineContext` strongly connected to the cluster.

In fact the token lifecycle reads only **one** field off that context:
`ctx.companyId` (verified in `TokenStrategyFromConfig.flow.ts:97,110` - the
sole concrete `ITokenStrategy` implementor; every other site merely passes the
ctx through without dereferencing it).

## What

Apply the Dependency-Inversion fix: depend on a minimal port, not the concrete
god-object.

- NEW leaf `Types/Domain/TokenContext.ts` defines
  `interface ITokenContext { readonly companyId: CompanyTypes }` (imports only
  `CompanyTypes` from `Definitions.js` -> pure out-of-SCC leaf; `Types/Domain/**`
  is the canonical home, exempt from `prefer-default-export`).
- Redirect the token-prime `ctx` type from `IPipelineContext` to `ITokenContext`
  in `ApiMediator.types`, `ApiMediator.builders`, `ITokenStrategy`,
  `TokenResolverBuilder`, and `TokenStrategyFromConfig.types`.
- `IPipelineContext` structurally satisfies the port (it carries `companyId`),
  so existing call sites (`ApiMediator.state.ts`, `ApiDirectCallActions`) pass
  through unchanged. All edits are `import type` / type-only.

Result: `PipelineContext` peels out of the SCC - cycle baseline **12 -> 11**
nodes (coupling mass **17 -> 16**), a purely subtractive subset ratchet
(baseline re-frozen to `[11, 5]`). `PipelineContext` still imports `IApiMediator`
but nothing in the 11-node cluster imports `PipelineContext` back, so it is now
a pure downstream consumer = a genuine peel, not a relocated cycle. This is the
honest break of the Mediator <-> PipelineContext entanglement that has been the
keystone of the monster across the whole campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal token handling architecture for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->