### PR TITLE
refactor(selector): break resolver import cycle

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.frames.ts
+++ b/src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.frames.ts
@@ -7,7 +7,7 @@ import type { Frame, Page } from 'playwright-core';
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfig.js';
 import { getDebug } from '../../Types/Debug.js';
 import { maskVisibleText } from '../../Types/LogEvent.js';
-import { tryInContextInternal } from './SelectorResolver.js';
+import { tryInContextInternal } from './SelectorResolver.try.js';
 import { toFieldContext } from './SelectorResolverPipeline.context.js';
 import type {
   IFieldContext,

--- a/src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.main.ts
+++ b/src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.main.ts
@@ -6,7 +6,7 @@ import type { Frame, Page } from 'playwright-core';
 
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfig.js';
 import { getDebug } from '../../Types/Debug.js';
-import { tryInContextInternal } from './SelectorResolver.js';
+import { tryInContextInternal } from './SelectorResolver.try.js';
 import { toFieldContext } from './SelectorResolverPipeline.context.js';
 import type {
   IFieldContext,

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 2,
+  "cycleCount": 1,
   "cycles": [
     [
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
@@ -14,13 +14,6 @@
       "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts",
       "src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts",
       "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts"
-    ],
-    [
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.entries.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolver.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.frames.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.main.ts",
-      "src/Scrapers/Pipeline/Mediator/Selector/SelectorResolverPipeline.ts"
     ]
   ]
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | OK one logical change; `refactor(selector): break resolver import cycle`; subject 47 chars, body <=72 |
| 2 | Selective staging, no `git add .` (before-commit s38) | OK staged exactly 3 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit s40) | OK all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | OK `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | OK `eslint --fix` on changed files exit 0; husky `eslint`/`biome` green |
| 6 | <=10-LoC functions / file-size caps (CLEAN_CODE.md) | OK no function changed; only 2 import lines + baseline JSON edited |
| 7 | Acyclic-dependencies gate (cycle ratchet) | OK `npm run lint:cycles` green; 5-node Selector SCC dissolved, [11,5] -> [11] (mass 16->11); subtractive subset, baseline re-frozen |
| 8 | Tests pass (386, incl. architecture/cycle) | OK 34 suites green: LayerSeparationArchitecture/ImportCycles/CoreBankIndependence + SelectorResolver*/SelectorLabel*/ElementMediator |
| 9 | Leaky-barrel redirect, symbol identity sound | OK barrel `SelectorResolver.ts:14` re-exports the same `tryInContextInternal` binding defined in `SelectorResolver.try.ts:84`; no wrapper/alias |
| 10 | Behaviour-preserving (no runtime change) | OK rubber-duck GREEN 0 RED; same function binding; direct leaf import removes barrel circular-init risk; lib unchanged |
| 11 | PII-free diff + commit message | OK no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines s3/s9) | OK rubber-duck GREEN 0 RED; genuine dissolution (leaf out-of-SCC, no path back), not a relocated cycle |

## Why

The 5-node Selector dependency cycle (`SelectorResolver.ts` barrel,
`SelectorResolver.entries.ts`, `SelectorResolverPipeline.ts`,
`SelectorResolverPipeline.frames.ts`, `SelectorResolverPipeline.main.ts`)
was held closed by a leaky barrel. `SelectorResolverPipeline.frames.ts`
and `.main.ts` imported the value `tryInContextInternal` through the
`SelectorResolver.ts` barrel - a member of the SCC - rather than from
its definition. The forward chain was barrel -> entries -> pipeline ->
{frames, main}; those two `frames/main -> barrel` value imports were the
ONLY two back-edges into the barrel, closing the cycle.

`tryInContextInternal` is not even defined in the barrel: line 14 is a
re-export `export { ..., tryInContextInternal } from './SelectorResolver.try.js'`.
The real definition lives in `SelectorResolver.try.ts`, a clean leaf that
imports only playwright-core, `Base/Config/LoginConfig`, and the
out-of-SCC siblings `SelectorResolver.probe`/`SelectorResolver.types`.

## What

Redirect the two value imports from the barrel to the definition leaf
(the proven leaky-barrel fix, value-side):

- `SelectorResolverPipeline.frames.ts:10` and
  `SelectorResolverPipeline.main.ts:9`:
  `import { tryInContextInternal } from './SelectorResolver.js'`
  -> `from './SelectorResolver.try.js'`.

Because `SelectorResolver.try.ts` is out of the SCC and importing from it
creates no path back into the five former members, removing both back-edges
dissolves the entire cycle. Symbol identity is unchanged (the barrel merely
re-exported the same binding), so behavior is byte-identical.

Result: the 5-node Selector SCC is fully dissolved - cycle baseline
**[11, 5] -> [11]** (coupling mass **16 -> 11**, cycleCount **2 -> 1**),
a purely subtractive subset ratchet (baseline re-frozen; only the Selector
cycle removed, the 11-node ApiMediator cycle intact). A genuine peel, not a
relocated cycle.