### PR TITLE
refactor(token): narrow bus to ITokenBus port

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts
@@ -7,6 +7,7 @@ import type { WKQueryOperation } from '../../Registry/WK/QueriesWK.js';
 import type { WKUrlGroup } from '../../Registry/WK/UrlsWK.js';
 import type { IFetchStrategy } from '../../Strategy/Fetch/FetchStrategy.js';
 import type { GraphQLFetchStrategy } from '../../Strategy/Fetch/GraphQLFetchStrategy.js';
+import type { IApiQueryOpts } from '../../Types/Domain/ApiQueryOpts.js';
 import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import type { ITokenResolver } from './ITokenResolver.js';
@@ -27,11 +28,7 @@ interface IGraphQLEnvelope<T> {
 }
 
 /** Per-call options — extraHeaders + optional URL query params + optional Set-Cookie hook. */
-interface IApiQueryOpts {
-  readonly extraHeaders?: Record<string, string>;
-  readonly query?: Record<string, string>;
-  readonly onSetCookie?: (setCookies: readonly string[]) => number;
-}
+// (definition lives in ../../Types/Domain/ApiQueryOpts.ts; re-exported below)
 
 /** Bus-level session-context snapshot. */
 type SessionContext = Readonly<Record<string, unknown>>;

--- a/src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts
@@ -10,9 +10,9 @@
  * generic architecture (spec.txt §B.7).
  */
 
+import type { ITokenBus } from '../../Types/Domain/TokenBus.js';
 import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
-import type { IApiMediator } from './ApiMediator.js';
 
 /**
  * Generic-parameter helper alias for ITokenStrategy callers — a synonym
@@ -30,8 +30,8 @@ type TokenPrimeProcedure = Promise<Procedure<string>>;
  */
 interface ITokenStrategy<TCreds> {
   readonly name: string;
-  primeInitial(bus: IApiMediator, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
-  primeFresh(bus: IApiMediator, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
+  primeInitial(bus: ITokenBus, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
+  primeFresh(bus: ITokenBus, ctx: ITokenContext, creds: TCreds): TokenPrimeProcedure;
   hasWarmState(creds: TCreds): boolean;
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts
+++ b/src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts
@@ -12,17 +12,17 @@
  *              retryOn401 wrapper on any 401 mid-session).
  */
 
+import type { ITokenBus } from '../../Types/Domain/TokenBus.js';
 import type { ITokenContext } from '../../Types/Domain/TokenContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { isOk } from '../../Types/Procedure.js';
-import type { IApiMediator } from './ApiMediator.js';
 import type { ITokenResolver } from './ITokenResolver.js';
 import type { ITokenStrategy } from './ITokenStrategy.js';
 
 /** Closure-only deps packed by the builder — never exported. */
 interface IBuilderDeps<TCreds> {
   readonly strategy: ITokenStrategy<TCreds>;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly ctx: ITokenContext;
   readonly creds: TCreds;
 }
@@ -56,7 +56,7 @@ async function runInitial<TCreds>(deps: IBuilderDeps<TCreds>): Promise<Procedure
 /** Args bundle for buildResolverFromStrategy — satisfies the 3-param cap. */
 interface IBuildResolverArgs<TCreds> {
   readonly strategy: ITokenStrategy<TCreds>;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly ctx: ITokenContext;
   readonly creds: TCreds;
 }

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/RunStep.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/RunStep.types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { resolveWkUrl } from '../../../Registry/WK/UrlsWK.js';
-import type { IApiMediator } from '../../Api/ApiMediator.js';
+import type { ITokenBus } from '../../../Types/Domain/TokenBus.js';
 import type { IGenericKeypair } from '../Crypto/CryptoKeyFactory.js';
 import type { JsonValue } from '../Envelope/JsonPointer.js';
 import type { IAsymmetricSignerConfig, IStepConfig } from '../IApiDirectCallConfig.js';
@@ -40,7 +40,7 @@ interface IStepCookieJar {
 /** Run-step args bundle — respects the 3-param ceiling. */
 interface IRunStepArgs {
   readonly step: IStepConfig;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly scope: ITemplateScope;
   readonly companyId: Parameters<typeof resolveWkUrl>[1];
   readonly signingKeypair?: IGenericKeypair;

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/SmsOtpFlow.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/SmsOtpFlow.types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { resolveWkUrl } from '../../../Registry/WK/UrlsWK.js';
-import type { IApiMediator } from '../../Api/ApiMediator.js';
+import type { ITokenBus } from '../../../Types/Domain/TokenBus.js';
 import type { IGenericKeypair } from '../Crypto/CryptoKeyFactory.js';
 import type { JsonValue } from '../Envelope/JsonPointer.js';
 import type { ICollectionResult } from '../Fingerprint/GenericFingerprintBuilder.js';
@@ -14,7 +14,7 @@ import type { IStepCookieJar } from './RunStep.js';
 /** Args bundle for runSmsOtpFlow — respects the 3-param ceiling. */
 interface IRunSmsOtpArgs {
   readonly config: IApiDirectCallConfig;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly creds: Readonly<Record<string, unknown>>;
   readonly companyId: Parameters<typeof resolveWkUrl>[1];
   /** Optional initial carry — used by warm-start short-circuit. */
@@ -62,7 +62,7 @@ interface IApplyPreHookArgs {
 
 /** Args-reducer bundle — passed through every step. */
 interface IStepReduceArgs {
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly companyId: Parameters<typeof resolveWkUrl>[1];
   readonly keypair: SigningKeypair;
   readonly creds: Readonly<Record<string, unknown>>;

--- a/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/TokenStrategyFromConfig.types.ts
+++ b/src/Scrapers/Pipeline/Mediator/ApiDirectCall/Flow/TokenStrategyFromConfig.types.ts
@@ -2,8 +2,8 @@
  * Type aliases + interfaces for the TokenStrategyFromConfig cluster.
  */
 
+import type { ITokenBus } from '../../../Types/Domain/TokenBus.js';
 import type { ITokenContext } from '../../../Types/Domain/TokenContext.js';
-import type { IApiMediator } from '../../Api/ApiMediator.js';
 import type { ITokenStrategy } from '../../Api/ITokenStrategy.js';
 import type { JsonValue } from '../Envelope/JsonPointer.js';
 import type { IApiDirectCallConfig } from '../IApiDirectCallConfig.js';
@@ -23,7 +23,7 @@ interface IConfigTokenStrategy extends ITokenStrategy<GenericCreds> {
 /** Args for runConfiguredFlow — respects 3-param ceiling. */
 interface IRunFlowArgs {
   readonly config: IApiDirectCallConfig;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly creds: GenericCreds;
   readonly companyId: ITokenContext['companyId'];
   readonly initialCarry?: Readonly<Record<string, JsonValue>>;
@@ -45,7 +45,7 @@ interface IFlowCapture {
 /** Args for makeWarmArgs — respects 3-param ceiling. */
 interface IMakeWarmArgs {
   readonly config: IApiDirectCallConfig;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly creds: GenericCreds;
   readonly stored: string;
   readonly companyId: ITokenContext['companyId'];
@@ -54,7 +54,7 @@ interface IMakeWarmArgs {
 /** Args bundle for primeInitialImpl / primeFreshImpl. */
 interface IPrimeArgs {
   readonly config: IApiDirectCallConfig;
-  readonly bus: IApiMediator;
+  readonly bus: ITokenBus;
   readonly ctx: ITokenContext;
   readonly creds: GenericCreds;
   readonly slot: ILongTermTokenSlot;

--- a/src/Scrapers/Pipeline/Types/Domain/ApiQueryOpts.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/ApiQueryOpts.ts
@@ -1,0 +1,16 @@
+/**
+ * IApiQueryOpts — per-call ApiMediator options (pure DTO leaf).
+ *
+ * Extracted to `Types/Domain` so narrow capability ports (e.g.
+ * {@link ITokenBus}) can reference it without importing the ApiMediator
+ * cluster, keeping those ports outside the ApiMediator dependency SCC.
+ */
+
+/** Per-call options — extraHeaders + optional URL query params + optional Set-Cookie hook. */
+interface IApiQueryOpts {
+  readonly extraHeaders?: Record<string, string>;
+  readonly query?: Record<string, string>;
+  readonly onSetCookie?: (setCookies: readonly string[]) => number;
+}
+
+export type { IApiQueryOpts };

--- a/src/Scrapers/Pipeline/Types/Domain/TokenBus.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/TokenBus.ts
@@ -1,0 +1,20 @@
+/**
+ * ITokenBus — the minimal ApiMediator capability the token lifecycle needs:
+ * a single authenticated POST. A narrow port (ISP/DIP) so token strategies and
+ * the config-driven flow depend on this one method rather than the full
+ * `IApiMediator` god-interface, keeping them outside the ApiMediator SCC.
+ */
+
+import type { WKUrlGroup } from '../../Registry/WK/UrlsWK.js';
+import type { Procedure } from '../Procedure.js';
+import type { IApiQueryOpts } from './ApiQueryOpts.js';
+
+interface ITokenBus {
+  apiPost: <T>(
+    wkUrl: WKUrlGroup,
+    body: Record<string, unknown>,
+    opts?: IApiQueryOpts,
+  ) => Promise<Procedure<T>>;
+}
+
+export type { ITokenBus };

--- a/src/Tests/Tools/import-cycles.baseline.json
+++ b/src/Tests/Tools/import-cycles.baseline.json
@@ -1,19 +1,5 @@
 {
   "note": "Frozen dependency cycles (Tarjan SCCs, size ≥ 2). A current cycle passes only when it is a subset of one listed here. Burn down toward [].",
-  "cycleCount": 1,
-  "cycles": [
-    [
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.builders.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.factories.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.factory.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ops.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.retry.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.state.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.transport.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ApiMediator.types.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/ITokenStrategy.ts",
-      "src/Scrapers/Pipeline/Mediator/Api/TokenResolverBuilder.ts"
-    ]
-  ]
+  "cycleCount": 0,
+  "cycles": []
 }


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | Atomic Conventional Commit (commit-guidlines.md) | OK one logical change (narrow token bus to ITokenBus); `refactor(token): narrow bus to ITokenBus port`; subject 45 chars, body <=72 |
| 2 | Selective staging, no `git add .` (before-commit s38) | OK staged exactly 9 files (`git diff --cached --stat`) |
| 3 | No hook bypass (before-commit s40) | OK all 21 husky gates ran; no `--no-verify` |
| 4 | Build + type-check clean | OK `tsc --noEmit` exit 0; husky `tsc` + `build` gates green |
| 5 | Lint clean (eslint, biome) | OK `eslint --fix` on all touched files exit 0; husky `eslint`/`biome` green |
| 6 | <=10-LoC functions / file-size caps (CLEAN_CODE.md) | OK no function changed; 2 small type-only leaves (16 + 20 LoC); only interface field/import edits elsewhere |
| 7 | Acyclic-dependencies gate (cycle ratchet) | OK `npm run lint:cycles` green; final 11-node ApiMediator SCC dissolved, [11] -> [] (mass 11->0, cycleCount 1->0); subtractive, baseline re-frozen to [] |
| 8 | Tests pass (295, incl. architecture/cycle) | OK 31 suites green: LayerSeparationArchitecture/ImportCycles/CoreBankIndependence + ApiMediator*/TokenStrategy*/TokenResolver*/ApiDirectCall* |
| 9 | ISP/DIP narrow port, symbol assignability sound | OK token lifecycle calls only `bus.apiPost`; IApiMediator structurally satisfies ITokenBus so call sites pass `self` unchanged; no `as`-cast added |
| 10 | Behaviour-preserving (no runtime change) | OK rubber-duck reviewed; all edits are `import type` / interface field types; lib bytes unchanged |
| 11 | PII-free diff + commit message | OK no credentials/paths/PII; `fixtures-pii` gate green |
| 12 | Self-review + rubber-duck (pr-guidlines s3/s9) | OK rubber-duck RED (TokenResolverBuilder still on god-interface) resolved in-slice; genuine dissolution (narrow leaf reaches nothing in cluster), not a relocated cycle |

## Why

The token lifecycle -- `ITokenStrategy`, the config-driven SMS/OTP flow
(`RunStep` / `SmsOtpFlow` / `TokenStrategyFromConfig`), and
`TokenResolverBuilder` -- imported the full `IApiMediator` god-interface
(10+ methods) through the `ApiMediator` barrel purely to type the `bus`
parameter. Yet it only ever calls a single method: `bus.apiPost`
(the sole `bus.apiPost` call site is `RunStep.dispatch.ts:30`).

Those barrel imports were the **last back-edges** holding the 11-node
`ApiMediator` Strongly-Connected Component together -- the final cycle
remaining in the whole source graph.

## What

Apply Interface-Segregation + Dependency-Inversion: depend on a minimal
capability port, not the concrete god-object.

- NEW leaf `Types/Domain/ApiQueryOpts.ts` -- the pure DTO `IApiQueryOpts`
  extracted out of `ApiMediator.types.ts` (zero imports) so a narrow port
  can reference it without pulling in the cluster.
- NEW leaf `Types/Domain/TokenBus.ts` -- `interface ITokenBus { apiPost }`,
  the one capability the token lifecycle needs. Imports only `WKUrlGroup`,
  `Procedure`, and the sibling `IApiQueryOpts` -- all out-of-cluster.
- Redirect the `bus` type from `IApiMediator` to `ITokenBus` in
  `ITokenStrategy`, `TokenResolverBuilder`, and the flow arg bundles
  (`IRunStepArgs`, `IRunSmsOtpArgs`/`IStepReduceArgs`,
  `IRunFlowArgs`/`IMakeWarmArgs`/`IPrimeArgs`). `IApiMediator`
  structurally satisfies `ITokenBus`, so call sites (e.g.
  `ApiMediator.state.ts` passing `self`) are unchanged -- no cast added.
- The ACTION layer (`ApiDirectCallActions.*`) keeps `IApiMediator`: it
  genuinely uses `setRawAuth` / `setSessionContext` / `apiGet` /
  `apiQuery` / `withTokenStrategy`, so narrowing it would be wrong.
- `ApiMediator.types` re-exports `IApiQueryOpts` from the leaf; the
  `ApiMediator.ts` barrel surface is unchanged.

Result: the final `ApiMediator` SCC dissolves -- cycle baseline
**[11] -> []** (coupling mass **11 -> 0**, cycleCount **1 -> 0**), a
purely subtractive ratchet (baseline re-frozen to `[]`). This **completes
the dependency-decoupling campaign**: the source graph is now fully
acyclic. The narrow leaves reach nothing in the former cluster, so this
is a genuine break, not a relocated cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal architecture to improve code organization and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->