### PR TITLE
feat(ci): guard cycle baseline against widening

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -230,6 +230,23 @@ jobs:
         if: needs.changes.outputs.src == 'true'
         run: npm run lint:cycles
 
+      # Tamper-guard: the ratchet above trusts the working-tree baseline, so a
+      # PR could add a cycle AND widen import-cycles.baseline.json in one diff.
+      # Assert the committed baseline only SHRINKS vs. the PR's base branch.
+      - name: Cycle baseline tamper-guard
+        if: github.event_name == 'pull_request' && needs.changes.outputs.src == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          base_file="${RUNNER_TEMP}/base-cycles-baseline.json"
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${BASE_REF}" || true
+          fi
+          git show "${BASE_SHA}:src/Tests/Tools/import-cycles.baseline.json" > "${base_file}" 2>/dev/null \
+            || echo '{"note":"absent on base","cycleCount":0,"cycles":[]}' > "${base_file}"
+          npx tsx src/Tests/Tools/lint-import-cycles.ts --guard-against "${base_file}"
+
       - name: Audit production dependencies
         if: needs.changes.outputs.src == 'true'
         run: npm audit --audit-level=high --omit=dev

--- a/src/Tests/Tools/lint-import-cycles.ts
+++ b/src/Tests/Tools/lint-import-cycles.ts
@@ -19,6 +19,12 @@
  *
  * Run `npm run lint:cycles` to check; `npm run lint:cycles -- --update-baseline`
  * to re-freeze after a deliberate, reviewed burn-down.
+ *
+ * TAMPER-GUARD: the working-tree baseline is itself trusted by the ratchet, so
+ * a PR could add a cycle AND widen `import-cycles.baseline.json` in one diff to
+ * hide it. Running with `--guard-against <base-baseline.json>` (CI passes the
+ * PR's base-branch copy) asserts the committed baseline only SHRINKS — it may
+ * never gain or grow a frozen cycle — closing that loophole.
  */
 
 import * as fs from 'node:fs';
@@ -30,6 +36,7 @@ const REPO_ROOT = process.cwd();
 const SRC_ROOT = path.join(REPO_ROOT, 'src');
 const BASELINE_PATH = path.join(SRC_ROOT, 'Tests', 'Tools', 'import-cycles.baseline.json');
 const UPDATE_FLAG = '--update-baseline';
+const GUARD_FLAG = '--guard-against';
 
 /** Sentinel returned by side-effecting helpers (no-void rule). */
 type Done = true;
@@ -323,16 +330,26 @@ export function findRegressions(current: readonly Cycle[], baseline: readonly Cy
 }
 
 /**
- * Read the committed cycle baseline, tolerating a missing file (treated
- * as "zero cycles allowed" so a fresh repo starts fully ratcheted).
+ * Read a cycle baseline payload's cycles from an explicit path, tolerating a
+ * missing file (treated as "zero cycles" so the most-ratcheted state wins).
+ * @param file - Absolute path to a baseline JSON file.
+ * @returns Frozen baseline cycles.
+ */
+function loadBaselineFrom(file: string): readonly Cycle[] {
+  const hasBaseline = fs.existsSync(file);
+  if (!hasBaseline) return [];
+  const raw = fs.readFileSync(file, 'utf8');
+  const parsed = JSON.parse(raw) as ICycleBaseline;
+  return parsed.cycles;
+}
+
+/**
+ * Read the committed cycle baseline from the working tree (tolerating a
+ * missing file so a fresh repo starts fully ratcheted).
  * @returns Frozen baseline cycles.
  */
 function loadBaseline(): readonly Cycle[] {
-  const hasBaseline = fs.existsSync(BASELINE_PATH);
-  if (!hasBaseline) return [];
-  const raw = fs.readFileSync(BASELINE_PATH, 'utf8');
-  const parsed = JSON.parse(raw) as ICycleBaseline;
-  return parsed.cycles;
+  return loadBaselineFrom(BASELINE_PATH);
 }
 
 /**
@@ -424,10 +441,91 @@ function evaluateGate(cycles: readonly Cycle[], baseline: readonly Cycle[]): Don
 }
 
 /**
+ * Read the `--guard-against <path>` flag value — the base-branch baseline the
+ * working-tree baseline must not have widened beyond.
+ * @returns The base baseline path, or '' when the flag is absent.
+ */
+function readGuardPath(): string {
+  const flagAt = process.argv.indexOf(GUARD_FLAG);
+  if (flagAt < 0) return '';
+  return process.argv[flagAt + 1] ?? '';
+}
+
+/**
+ * Whether the tamper-guard flag was supplied on the command line.
+ * @returns True when `--guard-against` is present in argv.
+ */
+function hasGuardFlag(): boolean {
+  return process.argv.includes(GUARD_FLAG);
+}
+
+/**
+ * Report a `--guard-against` flag supplied without a base baseline path and
+ * exit non-zero (never returns) so a mis-invocation fails loud instead of
+ * silently disabling the guard.
+ * @returns Completion sentinel (unreachable — the process exits first).
+ */
+function reportMissingGuardPath(): Done {
+  console.error(`❌ ${GUARD_FLAG} requires a base baseline file path.`);
+  process.exit(1);
+}
+
+/**
+ * Report a baseline that WIDENED versus the base branch and exit non-zero
+ * (never returns).
+ * @param widened - Baseline cycles new or grown relative to the base.
+ * @returns Completion sentinel (unreachable — the process exits first).
+ */
+function reportWidening(widened: readonly Cycle[]): Done {
+  console.error('❌ ACYCLIC-DEPENDENCIES — committed cycle baseline WIDENED vs. the base branch:');
+  for (const cycle of widened) printCycle(cycle);
+  console.error('');
+  console.error('   The baseline may only SHRINK (burn-down). A new or grown frozen entry');
+  console.error('   usually hides a freshly introduced import cycle. Revert the baseline');
+  console.error('   edit and break the back-edge instead of widening the ratchet.');
+  process.exit(1);
+}
+
+/**
+ * Assert the working-tree baseline did not widen against the base baseline.
+ * Widening is exactly a {@link findRegressions} of the PR baseline against the
+ * base baseline (a frozen entry that is neither absent nor a subset).
+ * @param prBaseline - Baseline committed on this branch.
+ * @param baseBaseline - Baseline on the PR's target branch.
+ * @returns Completion sentinel (only reached when the baseline did not widen).
+ */
+function evaluateGuard(prBaseline: readonly Cycle[], baseBaseline: readonly Cycle[]): Done {
+  const widened = findRegressions(prBaseline, baseBaseline);
+  if (widened.length > 0) return reportWidening(widened);
+  console.log(
+    '✅ Cycle baseline tamper-guard clean — baseline did not widen ' +
+      `(${String(prBaseline.length)} cycle(s) frozen)`,
+  );
+  return true;
+}
+
+/**
+ * Run the tamper-guard: compare the working-tree baseline against the base
+ * branch's baseline so a PR cannot loosen the ratchet to hide a new cycle.
+ * @param basePath - Path to the base branch's baseline JSON.
+ * @returns Completion sentinel.
+ */
+function runGuard(basePath: string): Done {
+  if (basePath === '') return reportMissingGuardPath();
+  const prBaseline = loadBaseline();
+  const baseBaseline = loadBaselineFrom(basePath);
+  return evaluateGuard(prBaseline, baseBaseline);
+}
+
+/**
  * Drive the gate: scan, then either re-freeze the baseline or evaluate it.
  * @returns Completion sentinel.
  */
 function runCycleGate(): Done {
+  if (hasGuardFlag()) {
+    const guardPath = readGuardPath();
+    return runGuard(guardPath);
+  }
   const cycles = currentCycles();
   const isUpdating = process.argv.includes(UPDATE_FLAG);
   if (isUpdating) return writeBaseline(cycles);

--- a/src/Tests/Unit/Tools/ImportCycles.test.ts
+++ b/src/Tests/Unit/Tools/ImportCycles.test.ts
@@ -100,3 +100,53 @@ describe('findRegressions — baseline ratchet', () => {
     expect(regressions).toEqual([]);
   });
 });
+
+describe('baseline tamper-guard — widening detection (PR-vs-base framing)', () => {
+  it('passes when the PR baseline equals the base baseline', () => {
+    const base = [['a', 'b']];
+    const pr = [['a', 'b']];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([]);
+  });
+
+  it('passes when the PR baseline shrinks a base cycle (burn-down)', () => {
+    const base = [['a', 'b', 'c']];
+    const pr = [['a', 'b']];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([]);
+  });
+
+  it('passes when the PR baseline drops a base cycle entirely', () => {
+    const base = [
+      ['a', 'b'],
+      ['c', 'd'],
+    ];
+    const pr = [['a', 'b']];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([]);
+  });
+
+  it('fails when the PR baseline adds a brand-new frozen cycle', () => {
+    const base = [['a', 'b']];
+    const pr = [
+      ['a', 'b'],
+      ['x', 'y'],
+    ];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([['x', 'y']]);
+  });
+
+  it('fails when the PR widens an empty base baseline (post-campaign lock)', () => {
+    const base: string[][] = [];
+    const pr = [['x', 'y']];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([['x', 'y']]);
+  });
+
+  it('fails when the PR grows a frozen cycle beyond the base members', () => {
+    const base = [['a', 'b']];
+    const pr = [['a', 'b', 'c']];
+    const regressions = findRegressions(pr, base);
+    expect(regressions).toEqual([['a', 'b', 'c']]);
+  });
+});


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verification |
|---|--------------------|--------------|
| 1 | CLEAN_CODE.md — function-size <=10 / complexity <=10 | OK new helpers (loadBaselineFrom, readGuardPath, hasGuardFlag, reportMissingGuardPath, reportWidening, evaluateGuard, runGuard) each <=10 lines; eslint max-lines-per-function/complexity passed |
| 2 | CLAUDE.md — ZERO CSS selectors / architecture rules | OK N/A — CI + test-tool only, no interaction/Pipeline code |
| 3 | before-commit-guidlines.md — 6-step checklist + husky gates | OK all 21 husky gates green on commit 1ded2891; selective staging, no `git add .`, no `--no-verify` |
| 4 | commit-guidlines.md — Conventional Commits + 50/72 | OK subject `feat(ci): guard cycle baseline against widening` = 47 chars; body wrapped <=72 |
| 5 | eslint-rules-guidlines.md — no rule relaxation | OK no ESLint rule changed; no file split / numeric cap added (tighten-when-split N/A) |
| 6 | test-guidlines.md — prove behavior at lowest level | OK 6 unit tests pin widening semantics (equal/shrink/drop pass; add/grow/widen-empty fail); ImportCycles suite 15/15 |
| 7 | j-doc-guidlines.md — @param/@returns full JSDoc | OK every new function fully documented |
| 8 | logging-pii-guidlines.md — no PII in output | OK guard prints only cycle file paths + counts; no secrets/credentials |
| 9 | pr-guidlines.md section 2 SRP — one logical change | OK single feature: cycle-baseline tamper-guard |
| 10 | pr-guidlines.md section 9 A3.5 exit gate (rubber-duck) | OK rubber-duck pass — 0 Critical / 0 Important; 1 Suggestion (fail-loud on missing path) applied |
| 11 | Public API byte-identical (lib/index.cjs) | OK N/A — no production source changed; lib/index.cjs bytes unchanged (1027729) |
| 12 | `npm run lint:cycles` returns zero cycles | OK gate green at 0 cycles; guard pass / widen-fail / missing-path-fail all verified locally |

## Why

The acyclic-dependencies cycle gate (`npm run lint:cycles`) ratchets the
import-graph against a committed frozen baseline
(`src/Tests/Tools/import-cycles.baseline.json`, now `{cycleCount: 0,
cycles: []}` after the decoupling campaign reached zero cycles). The ratchet
trusts the **working-tree** baseline, so a PR could introduce a new import
cycle **and** widen `import-cycles.baseline.json` in the same diff to keep the
gate green. Nothing locked the zero-cycle achievement against a self-approved
baseline edit. This closes that gap.

## What

- **Tool** (`src/Tests/Tools/lint-import-cycles.ts`): new `--guard-against
  <base-baseline>` mode. It loads the PR working-tree baseline and the base
  branch baseline, then reuses the existing `findRegressions(prBaseline,
  baseBaseline)` ratchet: the committed baseline may only **shrink** (drop or
  subset a frozen cycle); any brand-new or grown entry fails with exit 1.
  Small helpers (loadBaselineFrom, readGuardPath, hasGuardFlag,
  reportMissingGuardPath, reportWidening, evaluateGuard, runGuard) dispatched
  from `runCycleGate`. Fail-loud when the flag is supplied without a path
  (never silently disables the guard).
- **CI** (`.github/workflows/pr.yml`): PR-only step after the existing cycle
  gate (job `lint-and-types`, `fetch-depth: 0`). Runs when `src` changed,
  reads the base baseline via `git show "$BASE_SHA:..."` (fail-closed fallback
  to `{"cycles":[]}`), then `npx tsx ... --guard-against`.
- **Tests** (`src/Tests/Unit/Tools/ImportCycles.test.ts`): 6 cases covering
  equal/shrink/drop (pass) and add/grow/widen-empty (fail).

No production source, public API, or runtime behavior changes.
