### PR TITLE
feat(pipeline): config-driven balance-resolve + required balanceKind (FIBI bulk-seed fix)

### DIFF
--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -1188,5 +1188,5 @@ IWaitOptions
 IPageEvalOpts
 # Reason: Elements — multi-element page-eval options; framework-internal type relocated to the ElementsActionTypes leaf in the 12f cycle-break (was already exported from ElementsInteractions.ts, still re-exported there). Not user-facing.
 IPageEvalAllOpts
-# Reason: BalanceResolve — per-bank balance-resolution discriminant ('account' | 'card-cycle') on IPipelineBankConfig; framework-internal config knob that gates the balance-resolve live fetch. Deposit banks declare 'account'; card companies declare 'card-cycle'; absent = no-op. Not user-facing mkdocs surface (mirrors BalanceSlotKey/IDashboardTargets config types already allowlisted).
+# Reason: BalanceResolve — per-bank balance-resolution discriminant ('account' | 'card-cycle') on IPipelineBankConfig; framework-internal config knob that gates the balance-resolve live fetch. Deposit banks declare 'account'; card companies declare 'card-cycle'. REQUIRED — every bank states its kind explicitly; absence is a config error, not a silent no-op. Not user-facing mkdocs surface (mirrors BalanceSlotKey/IDashboardTargets config types already allowlisted).
 BalanceKind

--- a/.github/docs-coverage-allowlist.txt
+++ b/.github/docs-coverage-allowlist.txt
@@ -1188,3 +1188,5 @@ IWaitOptions
 IPageEvalOpts
 # Reason: Elements — multi-element page-eval options; framework-internal type relocated to the ElementsActionTypes leaf in the 12f cycle-break (was already exported from ElementsInteractions.ts, still re-exported there). Not user-facing.
 IPageEvalAllOpts
+# Reason: BalanceResolve — per-bank balance-resolution discriminant ('account' | 'card-cycle') on IPipelineBankConfig; framework-internal config knob that gates the balance-resolve live fetch. Deposit banks declare 'account'; card companies declare 'card-cycle'; absent = no-op. Not user-facing mkdocs surface (mirrors BalanceSlotKey/IDashboardTargets config types already allowlisted).
+BalanceKind

--- a/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts
+++ b/src/Scrapers/Pipeline/Core/PipelineContextFactory.ts
@@ -48,7 +48,7 @@ function resolveCoreDeps(
   const companyId = descriptor.options.companyId;
   const logger = createLogger(`pipeline-${companyId}`);
   const resolved = resolvePipelineBankConfig(companyId);
-  const config = resolved || { urls: { base: '' } };
+  const config = resolved || { urls: { base: '' }, balanceKind: 'card-cycle' as const };
   return { options: descriptor.options, credentials, companyId, logger, config };
 }
 
@@ -125,6 +125,7 @@ function emptyPhaseEmitOptions(): PhaseEmitOptions {
  */
 function emptyBalanceOptions(): BalanceOptions {
   return {
+    balanceAccountIdentities: none(),
     balanceFetchPlan: none(),
     balanceResponsesByBankAccount: none(),
     balanceExtracted: none(),

--- a/src/Scrapers/Pipeline/Core/PipelineContextSlotKeys.ts
+++ b/src/Scrapers/Pipeline/Core/PipelineContextSlotKeys.ts
@@ -26,6 +26,7 @@ export type PhaseEmitSlotKey = 'authDiscovery' | 'otpTrigger' | 'otpFill';
 
 /** Balance-pipeline slot keys (multi-stage balance resolution). */
 export type BalanceSlotKey =
+  | 'balanceAccountIdentities'
   | 'balanceFetchPlan'
   | 'balanceResponsesByBankAccount'
   | 'balanceExtracted'

--- a/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
+++ b/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
@@ -3,9 +3,16 @@
  * `awaitAndLog` race/telemetry helpers. Extracted from the
  * AccountResolveActions barrel so the per-file LoC cap is honoured
  * (phase-2e-residue).
+ *
+ * <p>PRE is passive-first: it waits for an id-bearing capture, and only
+ * when none arrives does it actively nudge a same-URL SPA to its cards
+ * view (clicking the well-known transactions link) so a navigation-gated
+ * accounts API such as Isracard `GetCardList` fires, then re-resolves.
  */
 
+import type { SelectorCandidate } from '../../../Base/Config/LoginConfig.js';
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
+import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import type { IActionContext, IPipelineContext } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail, succeed } from '../../Types/Procedure.js';
@@ -13,6 +20,9 @@ import type { IElementMediator } from '../Elements/ElementMediator.js';
 import type { IDiscoveredEndpoint } from '../Network/NetworkDiscoveryTypes.js';
 import { ACCOUNT_RESOLVE_BUDGET_MS } from '../Timing/TimingConfig.js';
 import { discoverAccountsInPool } from './AccountFromPool.js';
+
+/** Click timeout (ms) for the cards-view nudge — link is already visible post-login. */
+const NUDGE_CLICK_TIMEOUT_MS = 5000;
 
 /** Outcome label lookup for the wait result. */
 const WAIT_OUTCOME: Record<'true' | 'false', 'matched' | 'timeout'> = {
@@ -111,6 +121,49 @@ async function awaitAndLog(args: IAwaitArgs): Promise<true> {
 }
 
 /**
+ * Drive a same-URL SPA to its cards/transactions view by clicking the
+ * well-known transactions link, so an accounts API that only fires on
+ * navigation (e.g. Isracard `GetCardList`) finally fires, then re-runs
+ * the id-capture wait. The nudge click does NOT mark a dashboard click,
+ * so its capture lands in `getPreNavCaptures()` for POST to read.
+ * @param args - Bundled mediator + logger.
+ * @returns Always true once the click + re-wait completed.
+ */
+async function nudgeCardsViewAndReWait(args: IAwaitArgs): Promise<true> {
+  const candidates = WK_DASHBOARD.TRANSACTIONS as unknown as readonly SelectorCandidate[];
+  args.log.debug({ message: 'account-resolve.pre nudge → click transactions link' });
+  await args.mediator.resolveAndClick(candidates, NUDGE_CLICK_TIMEOUT_MS);
+  await awaitAndLog(args);
+  return true;
+}
+
+/**
+ * Nudge the SPA only when the passive wait produced no id-bearing
+ * capture. No-op for banks that already capture passively, so the
+ * behaviour stays generic and additive (zero blast radius elsewhere).
+ * @param args - Bundled mediator + logger.
+ * @returns Always true (sentinel for the chained call site).
+ */
+async function nudgeIfNoId(args: IAwaitArgs): Promise<true> {
+  const pool = args.mediator.network.getPreNavCaptures();
+  if (findFirstIdInPool(pool) !== false) return true;
+  return nudgeCardsViewAndReWait(args);
+}
+
+/**
+ * Passive-first pool resolution: wait for an id-bearing capture, then
+ * nudge the SPA only if none arrived. Keeps {@link executeAccountResolvePre}
+ * under the per-function LoC cap.
+ * @param args - Bundled mediator + logger.
+ * @returns Always true once the wait (+ optional nudge) completed.
+ */
+async function resolvePoolWithNudge(args: IAwaitArgs): Promise<true> {
+  await awaitAndLog(args);
+  await nudgeIfNoId(args);
+  return true;
+}
+
+/**
  * PRE — block on `waitForFirstId` so late-arriving auth-side id
  * captures make it into the pool before POST extracts.
  * @param input - Pipeline context.
@@ -123,7 +176,7 @@ async function executeAccountResolvePre(
   const mediator = input.mediator.value;
   const initialPool = mediator.network.getPreNavCaptures();
   input.logger.debug({ message: `account-resolve.pre pool=${String(initialPool.length)}` });
-  await awaitAndLog({ mediator, log: input.logger });
+  await resolvePoolWithNudge({ mediator, log: input.logger });
   return succeed(input);
 }
 

--- a/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
+++ b/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
@@ -10,7 +10,6 @@
  * accounts API such as Isracard `GetCardList` fires, then re-resolves.
  */
 
-import type { SelectorCandidate } from '../../../Base/Config/LoginConfig.js';
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
 import type { IActionContext, IPipelineContext } from '../../Types/PipelineContext.js';
@@ -130,7 +129,7 @@ async function awaitAndLog(args: IAwaitArgs): Promise<true> {
  * @returns Always true once the click + re-wait completed.
  */
 async function nudgeCardsViewAndReWait(args: IAwaitArgs): Promise<true> {
-  const candidates = WK_DASHBOARD.TRANSACTIONS as unknown as readonly SelectorCandidate[];
+  const candidates = WK_DASHBOARD.TRANSACTIONS;
   args.log.debug({ message: 'account-resolve.pre nudge → click transactions link' });
   await args.mediator.resolveAndClick(candidates, NUDGE_CLICK_TIMEOUT_MS);
   await awaitAndLog(args);

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Captured.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Captured.ts
@@ -1,0 +1,192 @@
+/**
+ * BalanceResolveActions.Captured — seed balance responses from the
+ * already-captured network pool (no extra request).
+ *
+ * <p>Some browser banks (e.g. Bank Leumi) fold the account balance into
+ * the SAME response that carried the transactions — Leumi's
+ * `UC_SO_27_GetBusinessAccountTrx` response exposes `BalanceDisplay`
+ * (and per-row `RunningBalance`) and there is no separately-addressable
+ * balance endpoint. SCRAPE.post therefore emits only the loose bulk
+ * fallback template, and the live BALANCE-RESOLVE re-fetch is
+ * quarantined. The authoritative balance is already in the captured
+ * pool, so read it there and let it fill genuine fetch misses.
+ *
+ * <p>Default-deny: returns an empty map when no captured body carries a
+ * balance. The result is keyed under {@link BULK_KEY} so the per-card
+ * extractor's bulk fallback finds it. The PRE caller gates this to the
+ * single-account case so a captured body is never mis-attributed across
+ * multiple accounts.
+ *
+ * <p>Body source: prefers the SCRAPE.post-carried snapshot
+ * ({@link IScrapeState.balanceResponseBodies}) — which survives onto the
+ * scrape slice after the live mediator/pool is gone at BALANCE-RESOLVE.pre
+ * — and falls back to the live mediator pool when the carried snapshot is
+ * absent (preserves the pre-existing unit-test contract).
+ */
+
+import type { IPipelineContext } from '../../Types/PipelineContext.js';
+import type { IDiscoveredEndpoint } from '../Network/Types/Endpoint.js';
+import { runBalanceExtractor } from './BalanceExtractor.js';
+import { BULK_KEY } from './BalanceFetchPlanner.js';
+
+/** Empty captured-response sentinel — exported so callers branch-free. */
+const EMPTY_CAPTURED: ReadonlyMap<string, unknown> = new Map();
+
+/** Empty body-pool sentinel for absent-state paths. */
+const EMPTY_BODIES: readonly unknown[] = [];
+
+/**
+ * Does this captured response body carry a resolvable balance?
+ * @param body - Captured endpoint response body.
+ * @returns True when {@link runBalanceExtractor} finds a finite balance.
+ */
+function hasBalance(body: unknown): boolean {
+  return runBalanceExtractor(body) !== false;
+}
+
+/**
+ * Pick the first response body that carries a balance.
+ * @param bodies - Captured response bodies.
+ * @returns The balance-bearing body, or undefined when none match.
+ */
+function firstBalanceBody(bodies: readonly unknown[]): unknown {
+  return bodies.find((body): boolean => hasBalance(body));
+}
+
+/**
+ * Read the SCRAPE.post-carried response-body snapshot (mediator-independent,
+ * survives into BALANCE-RESOLVE.pre). Empty when no snapshot was stamped.
+ * @param input - Pipeline context (PRE).
+ * @returns Carried bodies, or the empty sentinel.
+ */
+function readCarriedSnapshot(input: IPipelineContext): readonly unknown[] {
+  if (!input.scrape.has) return EMPTY_BODIES;
+  return input.scrape.value.balanceResponseBodies ?? EMPTY_BODIES;
+}
+
+/**
+ * Read the live mediator network pool's response bodies. The pool is
+ * cumulative across phases (the mediator is created once at INIT), so it
+ * still holds the dashboard-phase balance response at BALANCE-RESOLVE.pre.
+ * Empty when the mediator is absent.
+ * @param input - Pipeline context (PRE).
+ * @returns Mediator-pool bodies, or the empty sentinel.
+ */
+function readMediatorBodies(input: IPipelineContext): readonly unknown[] {
+  if (!input.mediator.has) return EMPTY_BODIES;
+  return input.mediator.value.network.getAllEndpoints().map((ep): unknown => ep.responseBody);
+}
+
+/**
+ * Read the captured response bodies for the balance seed. Prefers the
+ * SCRAPE.post-carried snapshot, but RESCUES from the live cumulative mediator
+ * pool when the carried snapshot carries NO balance (the folded balance was
+ * captured in an earlier phase and did not survive into the snapshot).
+ * Strictly additive — it can only find MORE balance bodies, never fewer.
+ * @param input - Pipeline context (PRE).
+ * @returns Captured response bodies (possibly empty).
+ */
+function readPoolBodies(input: IPipelineContext): readonly unknown[] {
+  const carried = readCarriedSnapshot(input);
+  if (firstBalanceBody(carried) !== undefined) return carried;
+  const live = readMediatorBodies(input);
+  if (firstBalanceBody(live) !== undefined) return live;
+  return carried.length > 0 ? carried : live;
+}
+
+/**
+ * Build the single-entry captured-response map from response bodies. Pure
+ * — unit-testable without a mediator.
+ * @param bodies - Captured response bodies.
+ * @returns Map keyed by {@link BULK_KEY}, or the empty sentinel.
+ */
+function buildCapturedFromBodies(bodies: readonly unknown[]): ReadonlyMap<string, unknown> {
+  const body = firstBalanceBody(bodies);
+  if (body === undefined) return EMPTY_CAPTURED;
+  return new Map<string, unknown>([[BULK_KEY, body]]);
+}
+
+/**
+ * Build the single-entry captured-response map from an endpoint pool.
+ * Thin adapter over {@link buildCapturedFromBodies} retained for the
+ * pure-pool unit tests.
+ * @param pool - Captured endpoints.
+ * @returns Map keyed by {@link BULK_KEY}, or the empty sentinel.
+ */
+function buildCapturedFromPool(pool: readonly IDiscoveredEndpoint[]): ReadonlyMap<string, unknown> {
+  const bodies = pool.map((ep): unknown => ep.responseBody);
+  return buildCapturedFromBodies(bodies);
+}
+
+/**
+ * Read a balance-bearing response from the captured pool (carried snapshot
+ * preferred, live mediator pool as fallback).
+ * @param input - Pipeline context (PRE).
+ * @returns Single-entry map keyed by {@link BULK_KEY}, or empty (default-deny).
+ */
+function readCapturedBalanceResponses(input: IPipelineContext): ReadonlyMap<string, unknown> {
+  const bodies = readPoolBodies(input);
+  return buildCapturedFromBodies(bodies);
+}
+
+/** PII-safe seed-source forensics emitted at BALANCE-RESOLVE.pre. */
+interface ISeedForensics {
+  readonly mediatorPresent: boolean;
+  readonly carriedBalanceCount: number;
+  readonly poolLen: number;
+  readonly poolBalanceCount: number;
+}
+
+/**
+ * Count response bodies that carry a resolvable balance.
+ * @param bodies - Response bodies.
+ * @returns Balance-bearing count.
+ */
+function countBalanceBodies(bodies: readonly unknown[]): number {
+  return bodies.filter((body): boolean => hasBalance(body)).length;
+}
+
+/**
+ * Build PII-safe seed forensics (counts/booleans only — never balance values,
+ * account numbers, or URLs) so a live BALANCE-RESOLVE miss is root-causable
+ * from the structured log without another blind run.
+ * @param input - Pipeline context (PRE).
+ * @returns Seed-source forensics bag.
+ */
+function diagnoseSeed(input: IPipelineContext): ISeedForensics {
+  const carried = readCarriedSnapshot(input);
+  const live = readMediatorBodies(input);
+  return {
+    mediatorPresent: input.mediator.has,
+    carriedBalanceCount: countBalanceBodies(carried),
+    poolLen: live.length,
+    poolBalanceCount: countBalanceBodies(live),
+  };
+}
+
+/**
+ * Should PRE suppress a live balance re-fetch for this bank? True unless the
+ * bank is declared a real account-balance bank (`config.balanceKind ===
+ * 'account'`). Card companies (`'card-cycle'`) and not-yet-declared banks
+ * (absent) are a deterministic no-op — they expose no account balance, so a
+ * live re-fetch could only ever universal-miss. This per-bank declaration
+ * replaces the earlier pool-shape inference: it cannot misread a credit-card
+ * billing aggregate (e.g. `totalDebit`) as an account balance, which is what
+ * drove the multi-account card-bank universal-miss regression.
+ * @param input - Pipeline context (PRE).
+ * @returns True when the bank has no declared account balance.
+ */
+function poolDisprovesBalance(input: IPipelineContext): boolean {
+  return input.config.balanceKind !== 'account';
+}
+
+export {
+  buildCapturedFromPool,
+  diagnoseSeed,
+  EMPTY_CAPTURED,
+  hasBalance,
+  poolDisprovesBalance,
+  readCapturedBalanceResponses,
+};
+
+export type { ISeedForensics };

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Extract.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Extract.ts
@@ -108,7 +108,32 @@ function extractPerCardBalance(body: unknown, identity: IAccountIdentity): numbe
 }
 
 /**
- * Extract one card's balance from its bank-account response (if present).
+ * Extract a card's balance from one response body (undefined-safe).
+ * @param body - Candidate response body (keyed or bulk), may be undefined.
+ * @param identity - Card identity.
+ * @returns Finite balance, or `false` when absent / carries no balance.
+ */
+function extractFromBody(body: unknown, identity: IAccountIdentity): number | false {
+  if (body === undefined) return false;
+  return extractPerCardBalance(body, identity);
+}
+
+/**
+ * Choose the keyed-response balance, else the captured BULK_KEY balance.
+ * @param keyed - Balance from the card's own keyed response, or false.
+ * @param bulk - Balance from the captured BULK_KEY body, or false.
+ * @returns The first finite balance, else 'MISS'.
+ */
+function pickKeyedOrBulk(keyed: number | false, bulk: number | false): BalanceExtractionOutcome {
+  if (keyed !== false) return keyed;
+  return bulk === false ? 'MISS' : bulk;
+}
+
+/**
+ * Extract one card's balance: prefer its own keyed response, then fall
+ * back to the captured BULK_KEY body when the keyed response is absent
+ * OR carries no balance — e.g. a wrong-endpoint live fetch that 200s
+ * without a balance must not shadow the captured pool's real balance.
  * @param identity - Card identity.
  * @param responses - Responses keyed by bankAccountUniqueId.
  * @returns Outcome.
@@ -117,11 +142,11 @@ function extractOneCard(
   identity: IAccountIdentity,
   responses: ReadonlyMap<string, unknown>,
 ): BalanceExtractionOutcome {
-  const body = responses.get(identity.bankAccountUniqueId) ?? responses.get(BULK_KEY);
-  if (body === undefined) return 'MISS';
-  const got = extractPerCardBalance(body, identity);
-  if (got === false) return 'MISS';
-  return got;
+  const keyedBody = responses.get(identity.bankAccountUniqueId);
+  const bulkBody = responses.get(BULK_KEY);
+  const fromKeyed = extractFromBody(keyedBody, identity);
+  const fromBulk = extractFromBody(bulkBody, identity);
+  return pickKeyedOrBulk(fromKeyed, fromBulk);
 }
 
 /** Bundled args for {@link extractAllCards}. */

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Pre.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Pre.ts
@@ -14,32 +14,38 @@ import type {
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail, succeed } from '../../Types/Procedure.js';
 import { buildBalanceFetchPlan } from './BalanceFetchPlanner.js';
-import { readAccountIdentities, readBalanceFetchTemplate } from './BalanceResolveActions.Shared.js';
+import {
+  diagnoseSeed,
+  EMPTY_CAPTURED,
+  poolDisprovesBalance,
+  readCapturedBalanceResponses,
+} from './BalanceResolveActions.Captured.js';
+import {
+  EMPTY_TEMPLATE,
+  readAccountIdentities,
+  readBalanceFetchTemplate,
+} from './BalanceResolveActions.Shared.js';
 
-/** Failure-procedure builder for empty SCRAPE-emitted state. */
-const PRE_EMPTY_FAILS: Record<'identities' | 'template', Procedure<IPipelineContext>> = {
-  identities: fail(
-    ScraperErrorTypes.Generic,
-    'balance-resolve.pre: SCRAPE emitted no accountIdentities',
-  ),
-  template: fail(
-    ScraperErrorTypes.Generic,
-    'balance-resolve.pre: SCRAPE emitted no balanceFetchTemplate',
-  ),
-};
+/** Failure procedure for the empty-identities PRE state. */
+const PRE_NO_IDENTITIES: Procedure<IPipelineContext> = fail(
+  ScraperErrorTypes.Generic,
+  'balance-resolve.pre: SCRAPE emitted no accountIdentities',
+);
 
 /**
- * Pick the empty-state failure procedure when SCRAPE produced nothing usable.
+ * Pick the empty-state failure procedure when SCRAPE resolved no
+ * account identities. An empty fetch template is NOT a failure: it
+ * means the bank has no balance-bearing endpoint, so PRE commits an
+ * empty plan (→ ACTION soft no-op → POST total=0 → PASS) rather than
+ * hard-failing. The universal-miss POST gate still catches the real
+ * failure (identities resolved but every live balance fetch missed).
  * @param identities - Account identity map.
- * @param template - Balance fetch template.
  * @returns Pre-built failure procedure, or `false` to continue.
  */
 function pickPreEmptyFailure(
   identities: ReadonlyMap<string, IAccountIdentity>,
-  template: IBalanceFetchTemplate,
 ): Procedure<IPipelineContext> | false {
-  if (identities.size === 0) return PRE_EMPTY_FAILS.identities;
-  if (template.url.length === 0) return PRE_EMPTY_FAILS.template;
+  if (identities.size === 0) return PRE_NO_IDENTITIES;
   return false;
 }
 
@@ -48,6 +54,7 @@ interface IPrePlanArgs {
   readonly input: IPipelineContext;
   readonly identities: ReadonlyMap<string, IAccountIdentity>;
   readonly template: IBalanceFetchTemplate;
+  readonly captured: ReadonlyMap<string, unknown>;
 }
 
 /**
@@ -64,29 +71,86 @@ function logPrePlanSize(input: IPipelineContext, idCount: number, planCount: num
 }
 
 /**
+ * Emit PII-safe seed forensics (counts/booleans only) so a live
+ * BALANCE-RESOLVE miss is root-causable from the log without another run.
+ * @param input - Pipeline context (PRE).
+ * @param seedResolved - Whether the captured seed produced a balance body.
+ * @returns Always true (sentinel for callers).
+ */
+function logSeedForensics(input: IPipelineContext, seedResolved: boolean): true {
+  const f = diagnoseSeed(input);
+  const message =
+    `balance-resolve.pre seed mediator=${String(f.mediatorPresent)} ` +
+    `carriedBal=${String(f.carriedBalanceCount)} ` +
+    `pool=${String(f.poolLen)}/${String(f.poolBalanceCount)} resolved=${String(seedResolved)}`;
+  input.logger.debug({ message });
+  return true;
+}
+
+/**
  * Build the success continuation for BALANCE-RESOLVE.pre — emit size
- * debug + commit `balanceFetchPlan`.
- * @param args - Bundled input + identities + template.
+ * debug + commit `balanceFetchPlan` and the captured-pool seed.
+ * @param args - Bundled input + identities + template + captured seed.
  * @returns Updated context with `balanceFetchPlan` populated.
  */
 function buildPrePlanResult(args: IPrePlanArgs): Procedure<IPipelineContext> {
   const plan = buildBalanceFetchPlan(args.identities, args.template);
   logPrePlanSize(args.input, args.identities.size, plan.length);
-  return succeed({ ...args.input, balanceFetchPlan: some(plan) });
+  return succeed({
+    ...args.input,
+    balanceAccountIdentities: some(args.identities),
+    balanceFetchPlan: some(plan),
+    balanceResponsesByBankAccount: some(args.captured),
+  });
+}
+
+/**
+ * Read the captured-pool balance seed — only for the single-account
+ * case, so a captured body is never mis-attributed across accounts.
+ * @param input - Pipeline context (PRE — has the mediator).
+ * @param identities - Resolved account identities.
+ * @returns Captured balance responses, or the empty sentinel.
+ */
+function readCapturedSeed(
+  input: IPipelineContext,
+  identities: ReadonlyMap<string, IAccountIdentity>,
+): ReadonlyMap<string, unknown> {
+  if (identities.size !== 1) return EMPTY_CAPTURED;
+  return readCapturedBalanceResponses(input);
+}
+
+/**
+ * Resolve the live fetch template — suppressing it unless the bank is
+ * declared a real account-balance bank (`config.balanceKind === 'account'`,
+ * via {@link poolDisprovesBalance}). Card companies (`'card-cycle'`) and
+ * not-yet-declared banks no-op: the suppressed template yields an empty plan
+ * → ACTION soft no-op → POST total=0 → PASS, instead of a futile non-balance
+ * live re-fetch that would universal-miss. Declared account banks honour the
+ * SCRAPE-emitted template, so the real live fetch (and its tests) keep
+ * working. Balance recognition still uses the in-cluster {@link
+ * runBalanceExtractor} superset, so a folded `BalanceDisplay` is honoured.
+ * @param input - Pipeline context (PRE).
+ * @returns SCRAPE template, or EMPTY_TEMPLATE when balance is not declared.
+ */
+function resolveFetchTemplate(input: IPipelineContext): IBalanceFetchTemplate {
+  if (poolDisprovesBalance(input)) return EMPTY_TEMPLATE;
+  return readBalanceFetchTemplate(input);
 }
 
 /**
  * BALANCE-RESOLVE.pre — build the per-bank-account fetch plan from
- * SCRAPE-emitted identities + template.
+ * SCRAPE-emitted identities + a response-aware template.
  * @param input - Pipeline context after SCRAPE.
  * @returns Updated context with balanceFetchPlan committed, or Procedure fail.
  */
 function executeBalanceResolvePre(input: IPipelineContext): Promise<Procedure<IPipelineContext>> {
   const identities = readAccountIdentities(input);
-  const template = readBalanceFetchTemplate(input);
-  const emptyFailure = pickPreEmptyFailure(identities, template);
+  const template = resolveFetchTemplate(input);
+  const emptyFailure = pickPreEmptyFailure(identities);
   if (emptyFailure !== false) return Promise.resolve(emptyFailure);
-  const next = buildPrePlanResult({ input, identities, template });
+  const captured = readCapturedSeed(input, identities);
+  logSeedForensics(input, captured.size > 0);
+  const next = buildPrePlanResult({ input, identities, template, captured });
   return Promise.resolve(next);
 }
 

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Run.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Run.ts
@@ -15,13 +15,14 @@ import type {
 import type { Procedure } from '../../Types/Procedure.js';
 import { succeed } from '../../Types/Procedure.js';
 import { EMPTY_PLAN } from './BalanceFetchPlanner.js';
+import { hasBalance } from './BalanceResolveActions.Captured.js';
 import { fetchAllPlanEntries } from './BalanceResolveActions.Dispatch.js';
 import { extractAllCards } from './BalanceResolveActions.Extract.js';
 import type { IFetchExecCtx } from './BalanceResolveActions.Fetch.js';
 import {
   EMPTY_EXTRACTED,
   EMPTY_RESPONSES,
-  readAccountIdentities,
+  readCarriedIdentities,
 } from './BalanceResolveActions.Shared.js';
 
 /**
@@ -77,13 +78,72 @@ function commitDispatchResult(args: ICommitDispatchArgs): Procedure<IActionConte
 }
 
 /**
+ * Read the captured-pool seed committed by PRE (single-account rescue).
+ * @param input - Action context.
+ * @returns Captured responses, or the empty sentinel.
+ */
+function readSeededCaptured(input: IActionContext): ReadonlyMap<string, unknown> {
+  const seed = input.balanceResponsesByBankAccount;
+  return seed.has ? seed.value : EMPTY_RESPONSES;
+}
+
+/** Response map keyed by bankAccountUniqueId (or BULK_KEY for the bulk seed). */
+type ResponseMap = ReadonlyMap<string, unknown>;
+
+/**
+ * Choose the merged body for a key present in BOTH the captured seed and the
+ * live fetch: the live fetch wins ONLY when it carries a balance. A
+ * wrong-endpoint / 4xx live response (captured as a "success" with a
+ * balance-less body) therefore can never shadow the captured pool's real
+ * balance at the shared {@link BULK_KEY} — the FIBI/Beinleumi universal-miss.
+ * @param capturedBody - Captured-seed body for this key (undefined when none).
+ * @param fetchedBody - Live fetch body for this key.
+ * @returns The body to keep for this key.
+ */
+function pickMergedBody(capturedBody: unknown, fetchedBody: unknown): unknown {
+  if (capturedBody === undefined) return fetchedBody;
+  return hasBalance(fetchedBody) ? fetchedBody : capturedBody;
+}
+
+/**
+ * Apply live fetches onto the captured-seed copy, balance-aware per key.
+ * @param out - Mutable copy of the captured seed (mutated in place).
+ * @param fetched - Live fetch responses.
+ * @returns The merged map (same reference as `out`).
+ */
+function applyFetched(out: Map<string, unknown>, fetched: ResponseMap): Map<string, unknown> {
+  for (const [key, body] of fetched) {
+    const existing = out.get(key);
+    const merged = pickMergedBody(existing, body);
+    out.set(key, merged);
+  }
+  return out;
+}
+
+/**
+ * Merge captured-pool seed with live fetches — a live fetch wins only when it
+ * carries a balance, else the captured balance is preserved (fills genuine
+ * fetch misses AND balance-less "successful" responses at the shared key).
+ * @param captured - Captured-pool seed.
+ * @param fetched - Live fetch responses.
+ * @returns Merged response map.
+ */
+function mergeCaptured(captured: ResponseMap, fetched: ResponseMap): ResponseMap {
+  if (captured.size === 0) return fetched;
+  const out = new Map<string, unknown>(captured);
+  return applyFetched(out, fetched);
+}
+
+/**
  * Run the dispatch + extract pipeline for the populated-plan path.
  * @param args - Bundled input + fetchCtx + plan.
  * @returns Action context with responses + extracted committed.
  */
 async function executeDispatchChain(args: IDispatchChainArgs): Promise<Procedure<IActionContext>> {
-  const identities = readAccountIdentities(args.input);
-  const responses = await fetchAllPlanEntries(args.fetchCtx, args.plan);
+  const identities = readCarriedIdentities(args.input);
+  const fetched = await fetchAllPlanEntries(args.fetchCtx, args.plan);
+  const captured = readSeededCaptured(args.input);
+  const responses = mergeCaptured(captured, fetched);
   const extracted = extractAllCards({ identities, responses });
   return commitDispatchResult({ input: args.input, responses, extracted });
 }

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Shared.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Shared.ts
@@ -47,6 +47,19 @@ function readBalanceFetchTemplate(input: IPipelineContext | IActionContext): IBa
   return opt.value.balanceFetchTemplate ?? EMPTY_TEMPLATE;
 }
 
+/**
+ * Read PRE-carried account identities from the sealed action context.
+ * The seal drops `scrape`, so ACTION reads identities from the balance
+ * slot PRE stashed them in (default-deny to the empty sentinel).
+ * @param input - Sealed action context.
+ * @returns Identity map keyed by cardDisplayId.
+ */
+function readCarriedIdentities(input: IActionContext): ReadonlyMap<string, IAccountIdentity> {
+  const opt = input.balanceAccountIdentities;
+  if (!opt.has) return EMPTY_IDENTITIES;
+  return opt.value;
+}
+
 export {
   EMPTY_EXTRACTED,
   EMPTY_IDENTITIES,
@@ -54,4 +67,5 @@ export {
   EMPTY_TEMPLATE,
   readAccountIdentities,
   readBalanceFetchTemplate,
+  readCarriedIdentities,
 };

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardHrefExtraction.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardHrefExtraction.ts
@@ -156,7 +156,7 @@ async function extractHrefLayer3(mediator: IElementMediator): Promise<string> {
  * @returns Extracted href (empty if not found).
  */
 async function extractTransactionHref(mediator: IElementMediator): Promise<string> {
-  const candidates = WK_DASHBOARD.TRANSACTIONS as unknown as readonly SelectorCandidate[];
+  const candidates = WK_DASHBOARD.TRANSACTIONS;
   const l1 = await extractHrefLayer1(mediator, candidates);
   if (l1) return l1;
   const l2 = await extractHrefLayer2(mediator, candidates);

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.sequential.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.sequential.ts
@@ -194,7 +194,7 @@ function assembleSequentialTargets(targets: IAssembleSequentialArgs): IDashboard
  * @returns Matching candidate or false when no WK_TRANSACTIONS entry exists.
  */
 function probeSequentialChild(page: Page): Promise<SelectorCandidate | false> {
-  const txnWk = WK_DASHBOARD.TRANSACTIONS as unknown as readonly SelectorCandidate[];
+  const txnWk = WK_DASHBOARD.TRANSACTIONS;
   return findFirstChildInDom(page, txnWk);
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.targets.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.targets.ts
@@ -47,7 +47,7 @@ function buildHrefOnlyTargets(hrefTarget: string): IDashboardTargets {
  * @returns Race result or false on probe error.
  */
 async function probeTxnTrigger(mediator: IElementMediator): Promise<IRaceResult | false> {
-  const txnWk = WK_DASHBOARD.TRANSACTIONS as unknown as readonly SelectorCandidate[];
+  const txnWk = WK_DASHBOARD.TRANSACTIONS;
   const result = mediator.resolveVisible(txnWk, DASHBOARD_TRIGGER_PROBE_TIMEOUT_MS);
   return result.catch((): false => false);
 }

--- a/src/Scrapers/Pipeline/Mediator/Home/HomeActions.Navigate.ts
+++ b/src/Scrapers/Pipeline/Mediator/Home/HomeActions.Navigate.ts
@@ -70,6 +70,29 @@ function didReallyNavigate(urlBefore: string, urlAfter: string): boolean {
 }
 
 /**
+ * Max trigger-click attempts for an `<a href="#">` login control whose
+ * async click handler may not be bound yet under heavy CI throttling
+ * (1 initial click + up to 2 re-clicks once the handler has settled).
+ */
+const MAX_TRIGGER_CLICK_ATTEMPTS = 3;
+
+/**
+ * Detect a bare-`#` hash fall-through: the click only appended an empty
+ * fragment (real URL unchanged) — the signature of an `<a href="#"
+ * onclick="">` trigger clicked before its async handler bound (see the
+ * {@link HomePhase} prelude doc). Real navigations and non-empty
+ * fragment routes (`#/login`) are excluded.
+ * @param urlBefore - Page URL before the click.
+ * @param urlAfter - Page URL after the click + settle.
+ * @returns True iff the click only added a trailing bare `#`.
+ */
+function isHashFallthrough(urlBefore: string, urlAfter: string): boolean {
+  if (urlAfter === urlBefore) return false;
+  if (stripFragment(urlBefore) !== stripFragment(urlAfter)) return false;
+  return urlAfter.endsWith('#');
+}
+
+/**
  * Wait for SPA route + network settle after click.
  * @param executor - Sealed action mediator.
  * @param isSequential - Whether to settle before URL wait.
@@ -113,16 +136,54 @@ async function fireTriggerAction(args: IDirectNavArgs): Promise<void> {
 }
 
 /**
+ * Re-fire the trigger click once and re-settle. Recovers an
+ * `<a href="#">` fall-through after the async handler has had time to
+ * bind; the resulting URL is read by the caller via `getCurrentUrl`.
+ * @param args - Bundled executor + target + sequencing flag + logger.
+ * @param attempt - 1-based re-click attempt (for the debug trace).
+ */
+async function refireTrigger(args: IDirectNavArgs, attempt: number): Promise<void> {
+  args.logger.debug({ event: 'home.trigger.fallthrough.reclick', attempt });
+  await fireTriggerAction(args);
+  await settleAfterClick(args.executor, args.isSequential);
+}
+
+/**
+ * Re-click the trigger while the click keeps degrading to a bare-`#`
+ * hash fall-through, bounded by {@link MAX_TRIGGER_CLICK_ATTEMPTS}.
+ * Returns as soon as a real navigation / fragment route is observed, so
+ * triggers that bind on the first click pay no extra cost. Recurses
+ * (no loop) to honour the no-await-in-loop rule.
+ * @param args - Bundled executor + target + sequencing flag + logger.
+ * @param urlBefore - Page URL captured before the first click.
+ * @param attempt - 1-based attempt counter (seed with 1).
+ * @returns The settled URL (recovered when a re-click navigated).
+ */
+async function reclickWhileFallthrough(
+  args: IDirectNavArgs,
+  urlBefore: string,
+  attempt: number,
+): Promise<string> {
+  const url = args.executor.getCurrentUrl();
+  if (attempt >= MAX_TRIGGER_CLICK_ATTEMPTS || !isHashFallthrough(urlBefore, url)) return url;
+  await refireTrigger(args, attempt);
+  return reclickWhileFallthrough(args, urlBefore, attempt + 1);
+}
+
+/**
  * Perform the direct/sequential click + settle + URL probe path that
- * both NAV_STRATEGY.DIRECT and NAV_STRATEGY.SEQUENTIAL share.
+ * both NAV_STRATEGY.DIRECT and NAV_STRATEGY.SEQUENTIAL share. When the
+ * first click degrades to a bare-`#` hash fall-through (async handler
+ * not yet bound under heavy throttling) the trigger is re-clicked once
+ * the page has settled — see {@link isHashFallthrough}.
  * @param args - Bundle of executor, target, sequencing flag, logger.
- * @returns True iff `page.url()` changed after the click.
+ * @returns True iff `page.url()` changed after the click(s).
  */
 async function executeDirectNavigation(args: IDirectNavArgs): Promise<boolean> {
   const urlBefore = args.executor.getCurrentUrl();
   await fireTriggerAction(args);
   await settleAfterClick(args.executor, args.isSequential);
-  const currentUrl = args.executor.getCurrentUrl();
+  const currentUrl = await reclickWhileFallthrough(args, urlBefore, 1);
   const didNavigate = didReallyNavigate(urlBefore, currentUrl);
   args.logger.debug({ url: maskVisibleText(currentUrl), didNavigate });
   return didNavigate;
@@ -171,4 +232,4 @@ async function executeHomeNavigation(
   return dispatchNavStrategy({ executor, discovery, target, logger });
 }
 
-export { didReallyNavigate, executeHomeNavigation };
+export { didReallyNavigate, executeHomeNavigation, isHashFallthrough };

--- a/src/Scrapers/Pipeline/Mediator/Home/HomeActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Home/HomeActions.ts
@@ -12,6 +12,10 @@
  */
 
 export { executeModalClick, tryClickLoginLink, waitForAnyLoginLink } from './HomeActions.Modal.js';
-export { didReallyNavigate, executeHomeNavigation } from './HomeActions.Navigate.js';
+export {
+  didReallyNavigate,
+  executeHomeNavigation,
+  isHashFallthrough,
+} from './HomeActions.Navigate.js';
 export { executeStoreLoginSignal } from './HomeActions.Signal.js';
 export { executeValidateLoginArea } from './HomeActions.Validate.js';

--- a/src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/PhaseActions.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/ScrapePhase/PhaseActions.ts
@@ -124,8 +124,24 @@ function auditPostScrape(input: IPipelineContext): boolean {
 }
 
 /**
+ * Snapshot the captured network response bodies so BALANCE-RESOLVE can
+ * detect / seed a folded balance after the live mediator/pool is gone.
+ * Read at SCRAPE.post where the mediator is present; carried as opaque
+ * bodies on scrape state (no Mediator type leaks downstream).
+ *
+ * @param input - Pipeline context (SCRAPE.post — mediator present).
+ * @returns Response bodies, or undefined when no mediator / empty pool.
+ */
+function snapshotBalancePool(input: IPipelineContext): readonly unknown[] | undefined {
+  if (!input.mediator.has) return undefined;
+  const pool = input.mediator.value.network.getAllEndpoints();
+  if (pool.length === 0) return undefined;
+  return pool.map((endpoint): unknown => endpoint.responseBody);
+}
+
+/**
  * Build the scrape state with BALANCE-RESOLVE emit fields attached
- * (identities + balance template).
+ * (identities + balance template + carried response-body pool).
  *
  * @param args - Bundled input + diagnostics.
  * @returns Updated context with emit fields on scrape state.
@@ -137,6 +153,7 @@ function buildEmitScrape(args: IStampedScrapeArgs): IScrapeStateValue {
     ...args.scrape,
     accountIdentities: identities.size > 0 ? identities : undefined,
     balanceFetchTemplate: template.url === '' ? undefined : template,
+    balanceResponseBodies: snapshotBalancePool(args.input),
   };
 }
 

--- a/src/Scrapers/Pipeline/Phases/Base/BalanceContextSlice.ts
+++ b/src/Scrapers/Pipeline/Phases/Base/BalanceContextSlice.ts
@@ -1,20 +1,21 @@
 /**
- * BALANCE-RESOLVE slot slice — the five context keys both
+ * BALANCE-RESOLVE slot slice — the six context keys both
  * {@link "./ActionContextBuilder.ts" | buildBootstrapContext} and
  * {@link "./ActionContextBuilder.ts" | buildActionContext} carry forward.
  *
  * <p>Hoisted into its own module during Phase 12b so the two builders
  * can share the slot list without forming an import cycle. The
  * "Generic over duplication" project rule explicitly prefers this
- * shared-helper shape over inlining the five keys at each builder.
+ * shared-helper shape over inlining the six keys at each builder.
  *
  * @see "../../Types/PipelineContext.ts" — full IPipelineContext shape.
  */
 
 import type { IPipelineContext } from '../../Types/PipelineContext.js';
 
-/** The five BALANCE-RESOLVE slot keys both bootstrap and sealed action contexts carry. */
+/** The six BALANCE-RESOLVE slot keys both bootstrap and sealed action contexts carry. */
 export const BALANCE_SLOT_KEYS = [
+  'balanceAccountIdentities',
   'balanceFetchPlan',
   'balanceResponsesByBankAccount',
   'balanceExtracted',
@@ -22,7 +23,7 @@ export const BALANCE_SLOT_KEYS = [
   'balanceResolution',
 ] as const;
 
-/** Pick-typed alias for the five BALANCE-RESOLVE slots. */
+/** Pick-typed alias for the six BALANCE-RESOLVE slots. */
 export type BalanceContextSlice = Pick<IPipelineContext, (typeof BALANCE_SLOT_KEYS)[number]>;
 
 /**

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
@@ -7,7 +7,7 @@
 
 import { CompanyTypes } from '../../../../Definitions.js';
 import { seedWkFromPipelineConfig } from './PipelineBankConfigSeeder.js';
-import type { IPipelineBankConfig } from './PipelineBankConfigTypes.js';
+import type { BalanceKind, IPipelineBankConfig } from './PipelineBankConfigTypes.js';
 
 export type {
   AuthPathKey,
@@ -15,43 +15,61 @@ export type {
   IPipelineBankConfig,
 } from './PipelineBankConfigTypes.js';
 
+/** Billing-cycle banks (credit-card companies) expose no account balance. */
+const CARD_CYCLE: BalanceKind = 'card-cycle';
+
+/** Deposit/checking banks expose a real account balance resolved live. */
+const ACCOUNT: BalanceKind = 'account';
+
 /** Pipeline bank registry — migrated banks only. */
 const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> = {
   [CompanyTypes.Beinleumi]: {
     urls: { base: 'https://www.fibi.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.Discount]: {
     urls: { base: 'https://www.discountbank.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.Hapoalim]: {
     urls: { base: 'https://www.bankhapoalim.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.Massad]: {
     urls: { base: 'https://www.bankmassad.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.OtsarHahayal]: {
     urls: { base: 'https://www.bankotsar.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.Pagi]: {
     urls: { base: 'https://www.pagi.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.VisaCal]: {
     urls: { base: 'https://www.cal-online.co.il/' },
+    balanceKind: CARD_CYCLE,
   },
   [CompanyTypes.Amex]: {
     urls: { base: 'https://americanexpress.co.il' },
+    balanceKind: CARD_CYCLE,
   },
   [CompanyTypes.Max]: {
     urls: { base: 'https://www.max.co.il' },
+    balanceKind: CARD_CYCLE,
   },
   [CompanyTypes.Mercantile]: {
     urls: { base: 'https://www.mercantile.co.il' },
+    balanceKind: ACCOUNT,
   },
   [CompanyTypes.Isracard]: {
     urls: { base: 'https://www.isracard.co.il' },
+    balanceKind: CARD_CYCLE,
   },
   [CompanyTypes.OneZero]: {
     urls: { base: 'https://www.onezerobank.com' },
+    balanceKind: ACCOUNT,
     headless: {
       identityBase: 'https://identity.tfd-bank.com/v1/',
       graphql: 'https://mobile.tfd-bank.com/mobile-graph/graphql',
@@ -68,6 +86,7 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
   },
   [CompanyTypes.PayBox]: {
     urls: { base: 'https://www.payboxapp.com/' },
+    balanceKind: ACCOUNT,
     headless: {
       identityBase: 'https://apipin.payboxapp.com/api/2.0/',
       // PayBox has no GraphQL — set graphql to identityBase to satisfy the
@@ -96,6 +115,7 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
   },
   [CompanyTypes.Pepper]: {
     urls: { base: 'https://www.pepper.co.il' },
+    balanceKind: ACCOUNT,
     headless: {
       identityBase: 'https://sa.pepper.co.il/',
       graphql: 'https://fe-sec.pepper.co.il/graphql',

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
@@ -35,13 +35,12 @@ export type PhoneNumberFormatTag =
   | 'local-only';
 
 /**
- * Balance semantics for a bank — an OPTIONAL, explicit per-bank declaration.
+ * Balance semantics for a bank — an explicit, REQUIRED per-bank declaration.
  * `'account'` banks expose a real account balance (deposit/checking banks)
  * and trigger a live BALANCE-RESOLVE; `'card-cycle'` banks expose only
  * per-cycle credit-card billing aggregates (VisaCal, Max, Amex, Isracard) and
- * have no account balance to resolve (deterministic no-op). ABSENT ⇒ dormant
- * no-op (main parity) — a bank is activated only once its balance resolution
- * is proven offline + live, one bank at a time.
+ * have no account balance to resolve (deterministic no-op). Never inferred
+ * from absence — an unstated kind is a config error, not a dormant no-op.
  */
 export type BalanceKind = 'account' | 'card-cycle';
 

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
@@ -34,6 +34,17 @@ export type PhoneNumberFormatTag =
   | 'international-flat'
   | 'local-only';
 
+/**
+ * Balance semantics for a bank — an OPTIONAL, explicit per-bank declaration.
+ * `'account'` banks expose a real account balance (deposit/checking banks)
+ * and trigger a live BALANCE-RESOLVE; `'card-cycle'` banks expose only
+ * per-cycle credit-card billing aggregates (VisaCal, Max, Amex, Isracard) and
+ * have no account balance to resolve (deterministic no-op). ABSENT ⇒ dormant
+ * no-op (main parity) — a bank is activated only once its balance resolution
+ * is proven offline + live, one bank at a time.
+ */
+export type BalanceKind = 'account' | 'card-cycle';
+
 /** Headless-strategy URL block — populates ctx.apiMediator at build time. */
 export interface IHeadlessUrlsConfig {
   readonly identityBase: string;
@@ -88,4 +99,11 @@ export interface IPipelineBankConfig {
   readonly transactionsPath?: string;
   /** Headless-strategy URLs — populated for API-native banks (no browser). */
   readonly headless?: IHeadlessUrlsConfig;
+  /**
+   * Balance semantics — see {@link BalanceKind}. REQUIRED: every bank states
+   * its kind explicitly — `'account'` (live balance resolved) or `'card-cycle'`
+   * (deterministic no-op). Never inferred from absence — an unstated kind is a
+   * config error, not a silent dormant no-op.
+   */
+  readonly balanceKind: BalanceKind;
 }

--- a/src/Scrapers/Pipeline/Registry/WK/BalanceResolveWK.ts
+++ b/src/Scrapers/Pipeline/Registry/WK/BalanceResolveWK.ts
@@ -19,6 +19,12 @@
  *   - `billingSumSekel`     — Amex data.billingSumSekel (aggregate)
  *   - `totalIlsBillingDate` — Amex per-card vouchers.totalForStatement
  *
+ * Plus one v6 addition for browser banks that fold the balance into the
+ * transactions response (no separate balance endpoint):
+ *   - `BalanceDisplay`      — Bank Leumi UC_SO_27 top-level balance
+ *                             (essential for zero-txn checking accounts
+ *                             where `runningBalance` is absent)
+ *
  * Legacy SCRAPE-zone code continues to use the narrower
  * `PIPELINE_WELL_KNOWN_TXN_FIELDS.balance` list via the v3 fallback
  * paths; the v4 BALANCE-RESOLVE phase uses this widened list.
@@ -39,6 +45,7 @@ export const PIPELINE_BALANCE_ALIASES: readonly string[] = [
   'totalAmount',
   'billingSumSekel',
   'totalIlsBillingDate',
+  'BalanceDisplay',
 ] as const;
 
 /**

--- a/src/Scrapers/Pipeline/Registry/WK/DashboardWK.ts
+++ b/src/Scrapers/Pipeline/Registry/WK/DashboardWK.ts
@@ -3,6 +3,8 @@
  * Isolated: NO imports from Home, Login, or Scrape WK.
  */
 
+import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
+
 /** Selector-kind discriminator strings, lifted out of every literal entry. */
 const KIND_TEXT_CONTENT = 'textContent' as const;
 const KIND_ARIA_LABEL = 'ariaLabel' as const;
@@ -11,6 +13,38 @@ const KIND_REGEX = 'regex' as const;
 /** Hebrew label "transactions and charges" — appears in REVEAL, MENU_EXPAND,
  *  TRANSACTIONS, and SUCCESS lists as a dashboard signal. */
 const LABEL_TXN_AND_CHARGES = 'עסקאות וחיובים' as const;
+
+/** Transactions/charges navigation candidates, priority-ordered: bank-account
+ *  intent → card transactions → medium → generic. The exact-text
+ *  "פירוט החיובים והעסקאות" (with definite articles) sits at the top to
+ *  disambiguate Max's two near-identical dropdown items — "פירוט החיובים
+ *  והעסקאות" (My Info → Charge details and transactions, the correct one) vs
+ *  "פירוט חיובים ועסקאות" (My Card → wrong twin matched by the existing
+ *  substring further down). Verified offline against captured dashboard HTML
+ *  for all 7 banks: only Max has this element; no overlap. */
+const DASHBOARD_TRANSACTIONS: readonly SelectorCandidate[] = [
+  { kind: 'exactText', value: 'פירוט החיובים והעסקאות' },
+  { kind: KIND_ARIA_LABEL, value: 'תנועות בחשבון' },
+  { kind: 'clickableText', value: 'תנועות בחשבון' },
+  { kind: 'clickableText', value: 'תנועות עו"ש' },
+  { kind: 'clickableText', value: 'פירוט תנועות' },
+  { kind: 'clickableText', value: 'לכל התנועות' },
+  { kind: 'clickableText', value: 'תנועות אחרונות' },
+  { kind: 'clickableText', value: 'לעובר ושב' },
+  { kind: KIND_ARIA_LABEL, value: 'עסקאות בכרטיס לפי מועד חיוב' },
+  { kind: KIND_TEXT_CONTENT, value: 'עסקאות בכרטיס לפי מועד חיוב' },
+  { kind: 'clickableText', value: 'פירוט חיובים' },
+  { kind: 'clickableText', value: 'חיובים ועסקאות' },
+  { kind: KIND_TEXT_CONTENT, value: 'פירוט חיובים' },
+  { kind: KIND_TEXT_CONTENT, value: LABEL_TXN_AND_CHARGES },
+  { kind: 'clickableText', value: 'כל העסקאות' },
+  { kind: 'clickableText', value: 'פירוט עסקאות' },
+  { kind: KIND_TEXT_CONTENT, value: 'עסקאות אחרונות' },
+  { kind: KIND_ARIA_LABEL, value: 'עסקאות' },
+  { kind: KIND_ARIA_LABEL, value: 'תנועות' },
+  { kind: 'clickableText', value: 'עסקאות' },
+  { kind: 'clickableText', value: 'תנועות' },
+];
 
 /** Dashboard phase WK — post-authentication UI helpers. */
 export const WK_DASHBOARD = {
@@ -62,36 +96,7 @@ export const WK_DASHBOARD = {
     { kind: KIND_ARIA_LABEL, value: 'עוד' },
     { kind: KIND_ARIA_LABEL, value: 'menu' },
   ],
-  // Priority order: bank-account intent → card transactions → medium → generic.
-  // The exact-text "פירוט החיובים והעסקאות" (with definite articles) sits at
-  // the top to disambiguate Max's two near-identical dropdown items —
-  // "פירוט החיובים והעסקאות" (My Info → Charge details and transactions, the
-  // correct one) vs "פירוט חיובים ועסקאות" (My Card → wrong twin matched by
-  // the existing substring further down). Verified offline against captured
-  // dashboard HTML for all 7 banks: only Max has this element; no overlap.
-  TRANSACTIONS: [
-    { kind: 'exactText', value: 'פירוט החיובים והעסקאות' },
-    { kind: KIND_ARIA_LABEL, value: 'תנועות בחשבון' },
-    { kind: 'clickableText', value: 'תנועות בחשבון' },
-    { kind: 'clickableText', value: 'תנועות עו"ש' },
-    { kind: 'clickableText', value: 'פירוט תנועות' },
-    { kind: 'clickableText', value: 'לכל התנועות' },
-    { kind: 'clickableText', value: 'תנועות אחרונות' },
-    { kind: 'clickableText', value: 'לעובר ושב' },
-    { kind: KIND_ARIA_LABEL, value: 'עסקאות בכרטיס לפי מועד חיוב' },
-    { kind: KIND_TEXT_CONTENT, value: 'עסקאות בכרטיס לפי מועד חיוב' },
-    { kind: 'clickableText', value: 'פירוט חיובים' },
-    { kind: 'clickableText', value: 'חיובים ועסקאות' },
-    { kind: KIND_TEXT_CONTENT, value: 'פירוט חיובים' },
-    { kind: KIND_TEXT_CONTENT, value: LABEL_TXN_AND_CHARGES },
-    { kind: 'clickableText', value: 'כל העסקאות' },
-    { kind: 'clickableText', value: 'פירוט עסקאות' },
-    { kind: KIND_TEXT_CONTENT, value: 'עסקאות אחרונות' },
-    { kind: KIND_ARIA_LABEL, value: 'עסקאות' },
-    { kind: KIND_ARIA_LABEL, value: 'תנועות' },
-    { kind: 'clickableText', value: 'עסקאות' },
-    { kind: 'clickableText', value: 'תנועות' },
-  ],
+  TRANSACTIONS: DASHBOARD_TRANSACTIONS,
   SKIP: [
     { kind: KIND_TEXT_CONTENT, value: 'דלג' },
     { kind: KIND_TEXT_CONTENT, value: 'דלג לחשבון' },

--- a/src/Scrapers/Pipeline/Types/Domain/ScrapeState.ts
+++ b/src/Scrapers/Pipeline/Types/Domain/ScrapeState.ts
@@ -29,6 +29,24 @@ interface IScrapeState {
    * (no per-card POST observed). Downstream consumers default-deny.
    */
   readonly balanceFetchTemplate?: IBalanceFetchTemplate;
+  /**
+   * Captured balance-bearing response bodies snapshotted by SCRAPE.post —
+   * v6 carried-pool channel.
+   *
+   * <p>The browser network pool is read during SCRAPE.post (where the
+   * mediator is present) and the response bodies are carried on scrape
+   * state. BALANCE-RESOLVE.pre runs after the mediator/pool may already be
+   * unavailable, but the scrape slice survives — so the captured-pool seed
+   * ({@link readCapturedBalanceResponses}) reads these carried bodies
+   * instead of the absent live pool. Without this channel an account bank
+   * whose live re-fetch is quarantined has no BULK_KEY fallback and
+   * universal-misses.
+   *
+   * <p>Carried as opaque bodies (`unknown[]`, no Mediator type) to keep the
+   * Types layer free of a Mediator import. Absent (`undefined`) when SCRAPE
+   * had no mediator / an empty pool.
+   */
+  readonly balanceResponseBodies?: readonly unknown[];
 }
 
 export type { IScrapeState };

--- a/src/Scrapers/Pipeline/Types/PipelineContext.ts
+++ b/src/Scrapers/Pipeline/Types/PipelineContext.ts
@@ -15,6 +15,7 @@ import type { IAccountDiscovery } from './Domain/AccountDiscoveryTypes.js';
 import type { IApiFetchContext } from './Domain/ApiFetchContext.js';
 import type { IAuthDiscovery } from './Domain/AuthDiscoveryTypes.js';
 import type {
+  IAccountIdentity,
   IBalanceExtracted,
   IBalanceFetchPlanEntry,
   IBalanceValidation,
@@ -90,6 +91,12 @@ export interface IActionContext {
   readonly api: Option<IApiFetchContext>;
   /** Login area ready signal. */
   readonly loginAreaReady: boolean;
+  /**
+   * BALANCE-RESOLVE.pre output (v6) — SCRAPE's account identities
+   * carried through the seal. The sealed action context drops `scrape`,
+   * so PRE stashes the identity map here for ACTION to extract per-card.
+   */
+  readonly balanceAccountIdentities: Option<ReadonlyMap<string, IAccountIdentity>>;
   /** BALANCE-RESOLVE.pre output (v6) — per-bank-account fetch plan. */
   readonly balanceFetchPlan: Option<readonly IBalanceFetchPlanEntry[]>;
   /** BALANCE-RESOLVE.action output (v6) — responses keyed by bankAccountUniqueId. */
@@ -191,6 +198,12 @@ interface IPipelineContext {
    * reads the SAME shape across all 5 auth-ladder flows.
    */
   readonly otpFill: Option<IOtpFill>;
+  /**
+   * BALANCE-RESOLVE.pre output (v6) — SCRAPE's account identities
+   * carried through the seal. The sealed action context drops `scrape`,
+   * so PRE stashes the identity map here for ACTION to extract per-card.
+   */
+  readonly balanceAccountIdentities: Option<ReadonlyMap<string, IAccountIdentity>>;
   /**
    * BALANCE-RESOLVE.pre output (v6) — per-bank-account fetch plan.
    * One entry per unique bankAccountUniqueId derived from SCRAPE's

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeDeepLoginPhaseContext.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeDeepLoginPhaseContext.ts
@@ -88,9 +88,20 @@ function composeDeepLoginContext(args: IDeepLoginContextArgs): IPipelineContext 
   const browser = buildDeepLoginBrowser(page);
   const mediator = buildDeepLoginMediator(page, args.loginUrl, args.cookies);
   const credentials = synthesizeCredentials(args.loginConfig);
-  const config: IPipelineContext['config'] = { urls: { base: args.loginUrl } };
+  const config = buildDeepLoginConfig(args.loginUrl);
   const base = makeMockContext({ browser, mediator });
   return { ...base, credentials, config };
+}
+
+/**
+ * Build the deep LOGIN pipeline config. Extracted so the composer stays
+ * under the 10-line cap now that `balanceKind` is a required field.
+ *
+ * @param loginUrl - Base URL for the pipeline config.
+ * @returns Pipeline config with a required account `balanceKind`.
+ */
+function buildDeepLoginConfig(loginUrl: string): IPipelineContext['config'] {
+  return { urls: { base: loginUrl }, balanceKind: 'account' };
 }
 
 /**

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeHomePhaseContext.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeHomePhaseContext.ts
@@ -130,7 +130,7 @@ function buildHomeContext(
   homepageUrl: string,
 ): IPipelineContext {
   const base = makeMockContext({ browser, mediator });
-  return { ...base, config: { urls: { base: homepageUrl } } };
+  return { ...base, config: { urls: { base: homepageUrl }, balanceKind: 'account' } };
 }
 
 /**

--- a/src/Tests/Unit/Pipeline/Infrastructure/HomePhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/HomePhase.test.ts
@@ -25,7 +25,7 @@ import { makeMockContext, makeMockPage } from './MockFactories.js';
 const PHASE = new HomePhase();
 
 /** Minimal bank config with urls.base for HOME phase. */
-const MOCK_CONFIG = { urls: { base: 'https://test.bank.co.il' } };
+const MOCK_CONFIG = { urls: { base: 'https://test.bank.co.il' }, balanceKind: 'account' as const };
 
 /**
  * Build a mock page with goto + url tracking.
@@ -275,6 +275,7 @@ function toActionCtx(ctx: IPipelineContext, pageUrl?: string): IActionContext {
     api: ctx.api,
 
     loginAreaReady: ctx.loginAreaReady,
+    balanceAccountIdentities: ctx.balanceAccountIdentities,
     balanceFetchPlan: ctx.balanceFetchPlan,
     balanceResponsesByBankAccount: ctx.balanceResponsesByBankAccount,
     balanceExtracted: ctx.balanceExtracted,

--- a/src/Tests/Unit/Pipeline/Infrastructure/MockFactories.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/MockFactories.ts
@@ -120,6 +120,7 @@ function makeMockContext(overrides: Partial<IPipelineContext> = {}): IPipelineCo
     },
     config: {
       urls: { base: 'https://test.bank' },
+      balanceKind: 'account',
     },
     fetchStrategy: none(),
     mediator: none(),
@@ -139,6 +140,7 @@ function makeMockContext(overrides: Partial<IPipelineContext> = {}): IPipelineCo
     authDiscovery: none(),
     otpTrigger: none(),
     otpFill: none(),
+    balanceAccountIdentities: none(),
     balanceFetchPlan: none(),
     balanceResponsesByBankAccount: none(),
     balanceExtracted: none(),

--- a/src/Tests/Unit/Pipeline/Infrastructure/ScrapePhaseActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/ScrapePhaseActions.test.ts
@@ -2,6 +2,8 @@
  * Unit tests for ScrapePhaseActions — PRE/ACTION/POST/FINAL orchestration.
  */
 
+import type { IElementMediator } from '../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { IDiscoveredEndpoint } from '../../../../Scrapers/Pipeline/Mediator/Network/Types/Endpoint.js';
 import {
   executeForensicPre,
   executeMatrixLoop,
@@ -13,7 +15,11 @@ import type { IScrapeDiscovery } from '../../../../Scrapers/Pipeline/Types/Pipel
 import { API_STRATEGY } from '../../../../Scrapers/Pipeline/Types/PipelineContext.js';
 import { isOk } from '../../../../Scrapers/Pipeline/Types/Procedure.js';
 import type { ITransaction } from '../../../../Transactions.js';
-import { makeMockContext } from '../../Scrapers/Pipeline/MockPipelineFactories.js';
+import { makePool } from '../../Pipeline/Mediator/BalanceResolve/BalancePoolHelpers.js';
+import {
+  makeMockContext,
+  makeMockMediator,
+} from '../../Scrapers/Pipeline/MockPipelineFactories.js';
 import { makeMockActionExecutor, toActionCtx } from './TestHelpers.js';
 
 /**
@@ -244,6 +250,28 @@ describe('executeStampAccounts', () => {
     expect(isOkResult15).toBe(true);
     if (isOk(result)) {
       expect(result.value.diagnostics.lastAction).toContain('1 accounts');
+    }
+  });
+
+  it('carries the captured balance response-body pool onto scrape state', async () => {
+    const base = makeMockMediator();
+    const pool = makePool([{ BalanceDisplay: 150 }]);
+    const network: IElementMediator['network'] = {
+      ...base.network,
+      /**
+       * Return the carried captured pool.
+       * @returns The synthetic endpoint pool.
+       */
+      getAllEndpoints: (): readonly IDiscoveredEndpoint[] => pool,
+    };
+    const mediator = some<IElementMediator>({ ...base, network });
+    const scrape = some({ accounts: [{ accountNumber: 'A1', balance: 0, txns: [] }] });
+    const ctx = makeMockContext({ scrape, mediator });
+    const result = await executeStampAccounts(ctx);
+    const isStampOk = isOk(result);
+    expect(isStampOk).toBe(true);
+    if (isOk(result) && result.value.scrape.has) {
+      expect(result.value.scrape.value.balanceResponseBodies).toEqual([{ BalanceDisplay: 150 }]);
     }
   });
 });

--- a/src/Tests/Unit/Pipeline/Infrastructure/ScrapePhaseActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/ScrapePhaseActions.test.ts
@@ -270,8 +270,11 @@ describe('executeStampAccounts', () => {
     const result = await executeStampAccounts(ctx);
     const isStampOk = isOk(result);
     expect(isStampOk).toBe(true);
-    if (isOk(result) && result.value.scrape.has) {
-      expect(result.value.scrape.value.balanceResponseBodies).toEqual([{ BalanceDisplay: 150 }]);
+    if (isOk(result)) {
+      expect(result.value.scrape.has).toBe(true);
+      if (result.value.scrape.has) {
+        expect(result.value.scrape.value.balanceResponseBodies).toEqual([{ BalanceDisplay: 150 }]);
+      }
     }
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
@@ -27,6 +27,12 @@ interface IPoolMediatorArgs {
   readonly waitMatch?: IDiscoveredEndpoint | false;
   /** Bumps `captures` to `lateCaptures` after `waitForFirstId` resolves. */
   readonly lateCaptures?: readonly IDiscoveredEndpoint[];
+  /**
+   * Captures revealed by the PRE nudge click — simulates a nav-gated
+   * accounts API (e.g. Isracard `GetCardList`) firing only after the
+   * transactions link is clicked.
+   */
+  readonly onClickCaptures?: readonly IDiscoveredEndpoint[];
 }
 
 /**
@@ -72,6 +78,16 @@ function makePoolMediator(args: IPoolMediatorArgs): IElementMediator {
         /* swallow */
       }
       return true as const;
+    },
+    /**
+     * Best-effort PRE nudge click. When `onClickCaptures` is supplied
+     * the pool is swapped to it, modelling a same-URL SPA that only
+     * fetches the accounts API once the transactions link is clicked.
+     * @returns Resolved best-effort click sentinel.
+     */
+    resolveAndClick: (): Promise<unknown> => {
+      if (args.onClickCaptures) pool = args.onClickCaptures;
+      return Promise.resolve(true);
     },
   } as unknown as IElementMediator;
 }
@@ -133,22 +149,29 @@ describe('executeAccountResolvePre', () => {
 
 describe('executeAccountResolvePre', () => {
   it('invokes waitForFirstId exactly once and returns the input context', async () => {
+    // Pool already carries an id-bearing capture, so the PRE nudge is
+    // correctly SKIPPED → a single passive wait (no post-nudge re-wait).
+    const idCapture = makeCapture({
+      url: 'https://web.isracard.example/ocp/statuspage/DigitalV3.StatusPage/GetCardList',
+      method: 'POST',
+      responseBody: { data: { cardsList: [{ accountNumber: '111' }] } },
+    });
     let callCount = 0;
     const mediator = {
       network: {
         /**
          * Counter for assertion.
-         * @returns False (no match needed for this test).
+         * @returns The id-bearing match so the passive wait resolves.
          */
-        waitForFirstId: (): Promise<false> => {
+        waitForFirstId: (): Promise<IDiscoveredEndpoint> => {
           callCount += 1;
-          return Promise.resolve(false);
+          return Promise.resolve(idCapture);
         },
         /**
-         * Empty pool stub.
-         * @returns Empty array.
+         * Id-bearing pool stub (keeps the nudge skipped).
+         * @returns Single id-bearing capture.
          */
-        getPreNavCaptures: (): readonly IDiscoveredEndpoint[] => [],
+        getPreNavCaptures: (): readonly IDiscoveredEndpoint[] => [idCapture],
       },
       /**
        * Never resolves so the race in `awaitAndLog` is decided by
@@ -486,6 +509,12 @@ describe('executeAccountResolvePre — wait outcome telemetry', () => {
         }
         return true as const;
       },
+      /**
+       * Best-effort PRE nudge click stub — the empty pool drives the
+       * nudge, which re-waits (and re-rejects, still caught) → success.
+       * @returns Resolved click sentinel.
+       */
+      resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
     } as unknown as IElementMediator;
     const baseCtx = makeMockContext();
     const ctx = {
@@ -504,6 +533,69 @@ describe('executeAccountResolvePost — boundary case', () => {
     expect(result.success).toBe(true);
     if (isOk(result)) {
       expect(result.value.accountDiscovery.has).toBe(false);
+    }
+  });
+});
+
+describe('executeAccountResolvePre — same-URL SPA cards-view nudge', () => {
+  // Isracard's modern id-bearing endpoint (GetCardList) only fires once
+  // the visible transactions link is clicked — the same-URL SPA never
+  // auto-navigates to the cards view. The PRE nudge clicks it when passive
+  // discovery yields no id, so the live capture lands in the pre-nav pool
+  // POST reads. These two tests reproduce that live scenario offline.
+  const idCapture = makeCapture({
+    url: 'https://web.isracard.example/ocp/statuspage/DigitalV3.StatusPage/GetCardList',
+    method: 'POST',
+    responseBody: { data: { cardsList: [{ cardSuffix: 'FAKE_C01', accountNumber: '111' }] } },
+  });
+  const noiseCapture = makeCapture({
+    url: 'https://api.bank.example/marketing/banner',
+    method: 'GET',
+    responseBody: { promotion: { title: 'Some banner' } },
+  });
+
+  /**
+   * Wrap a pool mediator in a has:true pipeline context.
+   * @param mediator - Pool mediator stub.
+   * @returns Context with the mediator present.
+   */
+  function ctxWith(mediator: IElementMediator): IPipelineContext {
+    return { ...makeMockContext(), mediator: { has: true, value: mediator } };
+  }
+
+  it('nudges the cards view when passive discovery finds no id, then resolves the revealed accounts', async () => {
+    // Empty passive pool → nudge clicks → onClickCaptures reveals the
+    // GetCardList capture → POST resolves. A non-firing nudge would leave
+    // the pool empty and POST would fail loud — so a passing POST is proof.
+    const mediator = makePoolMediator({ captures: [], onClickCaptures: [idCapture] });
+    const ctx = ctxWith(mediator);
+    const pre = await executeAccountResolvePre(ctx);
+    expect(pre.success).toBe(true);
+    const post = await executeAccountResolvePost(ctx);
+    expect(post.success).toBe(true);
+    if (isOk(post)) {
+      expect(post.value.accountDiscovery.has).toBe(true);
+      if (post.value.accountDiscovery.has) {
+        expect(post.value.accountDiscovery.value.ids.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('does NOT click when passive discovery already found an id (zero blast radius for passive banks)', async () => {
+    // onClickCaptures is a POISON pool with no id — were the nudge to fire
+    // it would erase the real id and POST would fail loud. A passing POST
+    // therefore proves the click was correctly skipped.
+    const mediator = makePoolMediator({ captures: [idCapture], onClickCaptures: [noiseCapture] });
+    const ctx = ctxWith(mediator);
+    const pre = await executeAccountResolvePre(ctx);
+    expect(pre.success).toBe(true);
+    const post = await executeAccountResolvePost(ctx);
+    expect(post.success).toBe(true);
+    if (isOk(post)) {
+      expect(post.value.accountDiscovery.has).toBe(true);
+      if (post.value.accountDiscovery.has) {
+        expect(post.value.accountDiscovery.value.ids.length).toBeGreaterThan(0);
+      }
     }
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
@@ -15,11 +15,20 @@ import {
   executeAccountResolvePost,
   executeAccountResolvePre,
 } from '../../../../../Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.js';
-import type { IElementMediator } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import {
+  type IElementMediator,
+  type IRaceResult,
+  NOT_FOUND_RESULT,
+} from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
 import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 import type { IPipelineContext } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
-import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { isOk, type Procedure, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+
+/** Shared no-op nudge result — a `found:false` success matching the real
+ *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
+ *  driving an id into the pool. */
+const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
 
 /** Args bundle for the synthetic-pool mediator factory. */
 interface IPoolMediatorArgs {
@@ -85,9 +94,9 @@ function makePoolMediator(args: IPoolMediatorArgs): IElementMediator {
      * fetches the accounts API once the transactions link is clicked.
      * @returns Resolved best-effort click sentinel.
      */
-    resolveAndClick: (): Promise<unknown> => {
+    resolveAndClick: (): Promise<Procedure<IRaceResult>> => {
       if (args.onClickCaptures) pool = args.onClickCaptures;
-      return Promise.resolve(true);
+      return Promise.resolve(NUDGE_NOOP_RESULT);
     },
   } as unknown as IElementMediator;
 }
@@ -514,7 +523,7 @@ describe('executeAccountResolvePre — wait outcome telemetry', () => {
        * nudge, which re-waits (and re-rejects, still caught) → success.
        * @returns Resolved click sentinel.
        */
-      resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
+      resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
     } as unknown as IElementMediator;
     const baseCtx = makeMockContext();
     const ctx = {

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
@@ -17,13 +17,22 @@ import {
   executeAccountResolvePost,
   executeAccountResolvePre,
 } from '../../../../../Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.js';
-import type { IElementMediator } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import {
+  type IElementMediator,
+  type IRaceResult,
+  NOT_FOUND_RESULT,
+} from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
 import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 import { none, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
 import type { IPipelineContext } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
-import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { isOk, type Procedure, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 import { makeMockContext } from '../../Infrastructure/MockFactories.js';
 import { toActionCtx } from '../../Infrastructure/TestHelpers.js';
+
+/** Shared no-op nudge result — a `found:false` success matching the real
+ *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
+ *  driving an id into the pool. */
+const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
 
 /**
  * Build a stub element mediator whose pool/wait surface is fully
@@ -86,7 +95,7 @@ function makeMediatorStub(
      * that PRE succeeds, not that the nudge yields an id.
      * @returns Resolved click sentinel.
      */
-    resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
+    resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
   } as unknown as IElementMediator;
 }
 

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
@@ -80,6 +80,13 @@ function makeMediatorStub(
       }
       return true as const;
     },
+    /**
+     * Best-effort PRE nudge click stub (no pool mutation) — present so
+     * the no-id path's nudge resolves; these edge-case tests assert only
+     * that PRE succeeds, not that the nudge yields an id.
+     * @returns Resolved click sentinel.
+     */
+    resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
   } as unknown as IElementMediator;
 }
 

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceExtractor.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceExtractor.test.ts
@@ -310,3 +310,43 @@ describe('BalanceExtractor — F5 ILS-first per-currency selection', () => {
     expect(got).toBe(0);
   });
 });
+
+describe('BalanceExtractor — FIBI/Beinleumi accountSummary (records before arrays)', () => {
+  // Faithful to the real prod trace (dashboard-ACTION accountSummary):
+  // `currentBalances` lists `other` (an array of supplementary ZERO rows)
+  // BEFORE `local` (the record holding the real ILS balance). PII-scrubbed:
+  // balances replaced with synthetic FAKE values; the SHAPE + KEY ORDER are
+  // verbatim from C:\tmp\runs\pipeline\beinleumi\...\accountSummary.json.
+  const accountSummary: JsonValue = {
+    currentBalances: {
+      other: [
+        { totalAmount: 0, title: 'FAKE', date: '', sugBaka: '031', priority: 0, kodNose: 22 },
+        { totalAmount: 0, title: 'FAKE', date: '', sugBaka: '031', priority: 0, kodNose: 25 },
+      ],
+      local: {
+        totalAmount: 12345.67,
+        title: 'FAKE',
+        date: '',
+        sugBaka: '077',
+        priority: 1,
+        kodNose: 1,
+      },
+      foreign: {
+        totalAmount: 678.9,
+        title: 'FAKE',
+        date: '',
+        sugBaka: '031',
+        priority: 180,
+        kodNose: 21,
+      },
+    },
+    recentTransactions: [],
+    creditCards: [],
+    status: {},
+  };
+
+  it('resolves the real balance from currentBalances.local, not the zero other[] rows', () => {
+    const got = runBalanceExtractor(accountSummary);
+    expect(got).toBe(12345.67);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalancePoolHelpers.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalancePoolHelpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared BALANCE-RESOLVE test factories — captured-pool mediator + api
+ * stubs. Extracted so the captured-pool rescue test and the evidence-gate
+ * regression test consume one source of truth (no duplicated test mocks).
+ * Fake values only — no PII.
+ */
+
+import { ScraperErrorTypes } from '../../../../../Scrapers/Base/ErrorTypes.js';
+import type { IElementMediator } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/Types/Endpoint.js';
+import { type Option, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type { IApiFetchContext } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { fail, type Procedure, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+
+/**
+ * Build a fake endpoint pool wrapping the given response bodies.
+ * @param bodies - Response bodies to wrap as captured endpoints.
+ * @returns Array typed as discovered endpoints.
+ */
+function makePool(bodies: readonly unknown[]): readonly IDiscoveredEndpoint[] {
+  return bodies.map((responseBody): IDiscoveredEndpoint => {
+    return { responseBody } as unknown as IDiscoveredEndpoint;
+  });
+}
+
+/**
+ * Build a network stub whose pool returns the given endpoints.
+ * @param pool - Captured endpoints.
+ * @returns Network stub exposing getAllEndpoints.
+ */
+function makeNetworkStub(pool: readonly IDiscoveredEndpoint[]): IElementMediator['network'] {
+  const stub = {
+    /**
+     * Return the captured endpoint pool.
+     * @returns The pool.
+     */
+    getAllEndpoints: (): readonly IDiscoveredEndpoint[] => pool,
+  };
+  return stub as unknown as IElementMediator['network'];
+}
+
+/**
+ * Build a mediator whose network pool returns the given endpoints.
+ * @param pool - Captured endpoints.
+ * @returns `some(mediator)` option for the context override.
+ */
+function makeMediatorWithPool(pool: readonly IDiscoveredEndpoint[]): Option<IElementMediator> {
+  const network = makeNetworkStub(pool);
+  return some({ network } as unknown as IElementMediator);
+}
+
+/**
+ * Fetch stub that always fails (quarantine simulation).
+ * @returns A failed procedure.
+ */
+function failingFetch(): Promise<Procedure<unknown>> {
+  const failure = fail(ScraperErrorTypes.Generic, 'quarantined');
+  return Promise.resolve(failure);
+}
+
+/**
+ * Build an API context whose every fetch fails (quarantine simulation).
+ * @returns Fake API context returning failures.
+ */
+function makeFailingApi(): IApiFetchContext {
+  const stub = {
+    fetchPost: failingFetch,
+    fetchGet: failingFetch,
+    transactionsUrl: false,
+    balanceUrl: false,
+    pendingUrl: false,
+  };
+  return stub as unknown as IApiFetchContext;
+}
+
+/**
+ * Build a per-URL-validating fetch context: returns the mapped body for an
+ * EXACT synthesized URL (models a live 200) and a 4xx fail otherwise
+ * (models the live server rejecting a replay / a quarantined redirect).
+ * @param success - Map of exact live URL → 200 response body.
+ * @returns Fake API context that validates per endpoint.
+ */
+function makePerUrlApi(success: ReadonlyMap<string, unknown>): IApiFetchContext {
+  /**
+   * Resolve one fetch by exact URL match.
+   * @param url - Synthesized request URL.
+   * @returns Mapped body as success, or a 4xx fail.
+   */
+  const run = (url: string): Promise<Procedure<unknown>> => {
+    const hit = success.get(url);
+    if (hit !== undefined) {
+      const ok = succeed(hit);
+      return Promise.resolve(ok);
+    }
+    const miss = fail(ScraperErrorTypes.Generic, `live 4xx ${url}`);
+    return Promise.resolve(miss);
+  };
+  const stub = { fetchPost: run, fetchGet: run };
+  return stub as unknown as IApiFetchContext;
+}
+
+export { makeFailingApi, makeMediatorWithPool, makePerUrlApi, makePool };

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts
@@ -174,7 +174,9 @@ describe('BALANCE-RESOLVE v6 — pre/action contract', () => {
     const result = await executeBalanceResolvePre(ctx);
     const isSuccess = isOk(result);
     expect(isSuccess).toBe(true);
-    if (isSuccess && result.value.balanceFetchPlan.has) {
+    if (!isSuccess) throw new ScraperError('PRE must succeed');
+    expect(result.value.balanceFetchPlan.has).toBe(true);
+    if (result.value.balanceFetchPlan.has) {
       expect(result.value.balanceFetchPlan.value.length).toBe(0);
     }
   });

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveActionsV6.test.ts
@@ -12,7 +12,12 @@
  *           entry, collects balanceResponsesByBankAccount, then
  *           extracts per-card balance via runBalanceExtractor and
  *           emits balanceExtracted
- *   - .pre fails closed (Procedure fail) on absent inputs
+ *   - .pre fails closed (Procedure fail) only on absent accountIdentities;
+ *           an absent balanceFetchTemplate is a soft no-op (succeed with an
+ *           empty plan) because card flows (Beinleumi/Max/VisaCal/Isracard)
+ *           legitimately have no balance-bearing endpoint. The universal-miss
+ *           POST gate still catches a real failure (identities resolved but
+ *           every live balance fetch missed).
  *   - .action quarantines per-entry fetch failures (single failure
  *           does NOT abort the phase)
  */
@@ -160,7 +165,7 @@ describe('BALANCE-RESOLVE v6 — pre/action contract', () => {
     expect(isSuccess).toBe(false);
   });
 
-  it('PRE: default-deny when balanceFetchTemplate absent → Procedure fail', async () => {
+  it('PRE: absent balanceFetchTemplate → soft no-op (succeed, empty plan)', async () => {
     const scrape = some({
       accounts: [],
       accountIdentities: FAKE_IDENTITIES_VISACAL_SHAPE,
@@ -168,7 +173,10 @@ describe('BALANCE-RESOLVE v6 — pre/action contract', () => {
     const ctx = makeMockContext({ scrape });
     const result = await executeBalanceResolvePre(ctx);
     const isSuccess = isOk(result);
-    expect(isSuccess).toBe(false);
+    expect(isSuccess).toBe(true);
+    if (isSuccess && result.value.balanceFetchPlan.has) {
+      expect(result.value.balanceFetchPlan.value.length).toBe(0);
+    }
   });
 
   it('ACTION: issues one fetchPost per plan entry; extracts per-card balance', async () => {

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveBulkSeedShadow.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveBulkSeedShadow.test.ts
@@ -1,0 +1,121 @@
+/**
+ * BALANCE-RESOLVE — bulk-seed shadow regression lock (FIBI/Beinleumi).
+ *
+ * <p>Reproduces the REAL FIBI/Beinleumi universal-miss root cause OFFLINE.
+ * FIBI's SCRAPE emits a BULK balance template (no per-account substitution),
+ * so {@link buildBalanceFetchPlan} produces a single plan entry keyed by
+ * {@link BULK_KEY} — the SAME key the captured-pool seed
+ * ({@link readCapturedBalanceResponses}) uses. The live re-fetch hits a
+ * wrong endpoint (`/api/v2/auth/assert`) and returns HTTP 400 with a JSON
+ * error body. The fetch layer captures any HTTP response as a "success"
+ * (status recorded ⇒ `isOk`), so the 400 error body is stored under
+ * {@link BULK_KEY} in the fetched map.
+ *
+ * <p>THE BUG: `mergeCaptured` merged as `new Map([...captured, ...fetched])`,
+ * so the (balance-less) fetched error body OVERWROTE the captured seed's real
+ * balance at {@link BULK_KEY}. By the time `extractOneCard` ran, the seed was
+ * already gone — its keyed-vs-bulk fallback never fired — and every account
+ * universal-missed (`resolved=0 missed=1 total=1`). That is the exact live
+ * regression observed on 2026-06-19. The fix makes the merge balance-aware: a
+ * fetched body overrides the captured seed only when it actually carries a
+ * balance, so a wrong-endpoint / 4xx live response can never shadow the real
+ * captured balance.
+ *
+ * <p>True regression lock: drives the REAL PRE → seal
+ * ({@link buildActionContext}) → ACTION → POST chain and FAILS (universal-miss)
+ * on the pre-fix `[...captured, ...fetched]` merge. Fake values only — no PII.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePost,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { buildActionContext } from '../../../../../Scrapers/Pipeline/Phases/Base/ActionContextBuilder.js';
+import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+  IPipelineContext,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk, type Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makeMediatorWithPool, makePerUrlApi, makePool } from './BalancePoolHelpers.js';
+
+/** FAKE clean FIBI balance body (mirrors the `transactions/balances` shape). No PII. */
+const CLEAN_BALANCE = { withdrawableBalance: 12345.67, currentBalance: 12345.67 };
+
+/** FAKE wrong-endpoint 400 body — captured as "success", carries NO balance. */
+const AUTH_ASSERT_400 = {
+  error_code: 11,
+  error_message: "Parameter 'aid' was not found in 'query'",
+  headers: [],
+};
+
+/** BULK template (no per-account substitution) — plan keys by BULK_KEY. */
+const BULK_TEMPLATE: IBalanceFetchTemplate = {
+  url: 'https://fibi.test/api/v2/auth/assert',
+  method: 'POST',
+};
+
+/** The single bank-account id under test. */
+const BA = 'BA-FIBI1';
+
+/**
+ * Build a one-account identity map.
+ * @param ba - bankAccountUniqueId.
+ * @returns Single-entry identity map keyed by the id.
+ */
+function oneIdentity(ba: string): ReadonlyMap<string, IAccountIdentity> {
+  return new Map([[ba, { cardDisplayId: ba, cardUniqueId: `UID-${ba}`, bankAccountUniqueId: ba }]]);
+}
+
+/**
+ * Build the PRE context: carried snapshot carries the real balance, the live
+ * BULK re-fetch "succeeds" with the balance-less 400 body (mapped per-URL).
+ * @returns Mock pipeline context for the bulk-seed shadow scenario.
+ */
+function makeCtx(): IPipelineContext {
+  const accountIdentities = oneIdentity(BA);
+  const scrape = some({
+    accounts: [],
+    accountIdentities,
+    balanceFetchTemplate: BULK_TEMPLATE,
+    balanceResponseBodies: [CLEAN_BALANCE] as readonly unknown[],
+  });
+  const pool = makePool([CLEAN_BALANCE]);
+  const mediator = makeMediatorWithPool(pool);
+  const liveBodies = new Map<string, unknown>([[BULK_TEMPLATE.url, AUTH_ASSERT_400]]);
+  const perUrlApi = makePerUrlApi(liveBodies);
+  const api = some(perUrlApi);
+  const config = { urls: { base: 'https://fibi.test' }, balanceKind: 'account' as const };
+  return makeMockContext({ scrape, api, mediator, config });
+}
+
+/**
+ * Drive the REAL PRE → seal → ACTION → POST chain.
+ * @returns POST procedure (success or universal-miss failure).
+ */
+async function drivePost(): Promise<Procedure<IPipelineContext>> {
+  const ctx = makeCtx();
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const sealed = buildActionContext(pre.value);
+  const action = await executeBalanceResolveAction(sealed);
+  if (!isOk(action)) throw new ScraperError('ACTION must succeed');
+  const acted = action.value as unknown as IPipelineContext;
+  return executeBalanceResolvePost(acted);
+}
+
+describe('BALANCE-RESOLVE bulk-seed shadow (FIBI/Beinleumi)', () => {
+  it('keeps the captured BULK_KEY balance when the live BULK re-fetch returns a balance-less body', async () => {
+    const post = await drivePost();
+    if (!isOk(post))
+      throw new ScraperError('POST must succeed — captured balance must survive the merge');
+    const report = post.value.balanceValidation;
+    if (!report.has) throw new ScraperError('POST must commit a balanceValidation report');
+    expect(report.value.totalAccounts).toBe(1);
+    expect(report.value.resolvedIds.length).toBe(1);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCaptured.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCaptured.test.ts
@@ -1,0 +1,157 @@
+/**
+ * BALANCE-RESOLVE — captured-pool seed (v6 single-account rescue).
+ *
+ * <p>Covers the path where a browser bank (e.g. Bank Leumi) folds the
+ * balance into the transactions response and has no separately-fetchable
+ * balance endpoint. The live BALANCE-RESOLVE re-fetch is quarantined, so
+ * PRE seeds the balance from the already-captured network pool and the
+ * extractor resolves it. Fake values only — no PII.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import { BULK_KEY } from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceFetchPlanner.js';
+import { buildCapturedFromPool } from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Captured.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { buildActionContext } from '../../../../../Scrapers/Pipeline/Phases/Base/ActionContextBuilder.js';
+import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makeFailingApi, makeMediatorWithPool, makePool } from './BalancePoolHelpers.js';
+
+/** Leumi-shaped UC_SO_27 body: balance folded in, no card record. */
+const LEUMI_BODY = {
+  HistoryTransactionsItems: [{ DateUTC: '2026-06-17', Amount: 150, Description: 'salary' }],
+  TodayTransactionsItems: null,
+  BalanceDisplay: 150,
+};
+
+/** A body with no resolvable balance field. */
+const NO_BALANCE_BODY = { foo: 'bar', items: [] };
+
+/** Single Leumi checking-account identity (fake ids). */
+const SINGLE_IDENTITY: ReadonlyMap<string, IAccountIdentity> = new Map([
+  ['ACCT-1', { cardDisplayId: 'ACCT-1', cardUniqueId: 'UID-1', bankAccountUniqueId: 'BA-1' }],
+]);
+
+const TEMPLATE: IBalanceFetchTemplate = {
+  url: 'https://fake.bank/getBalance',
+  method: 'POST',
+  postBodyKey: 'bankAccountUniqueId',
+  headers: { 'content-type': 'application/json' },
+};
+
+describe('BALANCE-RESOLVE captured-pool — buildCapturedFromPool', () => {
+  it('keys the first balance-bearing body under BULK_KEY', () => {
+    const pool = makePool([LEUMI_BODY]);
+    const captured = buildCapturedFromPool(pool);
+    expect(captured.size).toBe(1);
+    const bulk = captured.get(BULK_KEY);
+    expect(bulk).toBe(LEUMI_BODY);
+  });
+
+  it('skips bodies with no balance and picks the first that has one', () => {
+    const pool = makePool([NO_BALANCE_BODY, LEUMI_BODY]);
+    const captured = buildCapturedFromPool(pool);
+    const bulk = captured.get(BULK_KEY);
+    expect(bulk).toBe(LEUMI_BODY);
+  });
+
+  it('returns empty when no captured body carries a balance', () => {
+    const pool = makePool([NO_BALANCE_BODY]);
+    const captured = buildCapturedFromPool(pool);
+    expect(captured.size).toBe(0);
+  });
+
+  it('returns empty for an empty pool', () => {
+    const pool = makePool([]);
+    const captured = buildCapturedFromPool(pool);
+    expect(captured.size).toBe(0);
+  });
+});
+
+describe('BALANCE-RESOLVE captured-pool — single-account rescue', () => {
+  it('resolves balance from the captured pool when the live fetch is quarantined', async () => {
+    const scrape = some({
+      accounts: [{ accountNumber: 'ACCT-1', balance: 0, txns: [] }],
+      accountIdentities: SINGLE_IDENTITY,
+      balanceFetchTemplate: TEMPLATE,
+    });
+    const pool = makePool([LEUMI_BODY]);
+    const mediator = makeMediatorWithPool(pool);
+    const failingApi = makeFailingApi();
+    const api = some(failingApi);
+    const preCtx = makeMockContext({ scrape, api, mediator });
+    const preResult = await executeBalanceResolvePre(preCtx);
+    const isPrePassed = isOk(preResult);
+    expect(isPrePassed).toBe(true);
+    if (!isPrePassed) throw new ScraperError('PRE must succeed');
+    const actionCtx = preResult.value as unknown as Parameters<
+      typeof executeBalanceResolveAction
+    >[0];
+    const result = await executeBalanceResolveAction(actionCtx);
+    const isSuccess = isOk(result);
+    expect(isSuccess).toBe(true);
+    if (!isSuccess) throw new ScraperError('ACTION must succeed');
+    const { balanceExtracted } = result.value;
+    expect(balanceExtracted.has).toBe(true);
+    if (!balanceExtracted.has) throw new ScraperError('balance must be extracted');
+    const acct = balanceExtracted.value.get('ACCT-1');
+    expect(acct).toBe(150);
+  });
+
+  it('does NOT seed the captured pool for multi-account banks', async () => {
+    const identities: ReadonlyMap<string, IAccountIdentity> = new Map([
+      ['ACCT-1', { cardDisplayId: 'ACCT-1', cardUniqueId: 'UID-1', bankAccountUniqueId: 'BA-1' }],
+      ['ACCT-2', { cardDisplayId: 'ACCT-2', cardUniqueId: 'UID-2', bankAccountUniqueId: 'BA-2' }],
+    ]);
+    const scrape = some({
+      accounts: [],
+      accountIdentities: identities,
+      balanceFetchTemplate: TEMPLATE,
+    });
+    const pool = makePool([LEUMI_BODY]);
+    const mediator = makeMediatorWithPool(pool);
+    const failingApi = makeFailingApi();
+    const api = some(failingApi);
+    const preCtx = makeMockContext({ scrape, api, mediator });
+    const preResult = await executeBalanceResolvePre(preCtx);
+    if (!isOk(preResult)) throw new ScraperError('PRE must succeed');
+    const seeded = preResult.value.balanceResponsesByBankAccount;
+    const seededSize = seeded.has ? seeded.value.size : -1;
+    expect(seededSize).toBe(0);
+  });
+});
+
+describe('BALANCE-RESOLVE sealed action context — identities carried through the seal', () => {
+  it('resolves balance after buildActionContext strips scrape', async () => {
+    const scrape = some({
+      accounts: [{ accountNumber: 'ACCT-1', balance: 0, txns: [] }],
+      accountIdentities: SINGLE_IDENTITY,
+      balanceFetchTemplate: TEMPLATE,
+    });
+    const pool = makePool([LEUMI_BODY]);
+    const mediator = makeMediatorWithPool(pool);
+    const failingApi = makeFailingApi();
+    const api = some(failingApi);
+    const preCtx = makeMockContext({ scrape, api, mediator });
+    const preResult = await executeBalanceResolvePre(preCtx);
+    if (!isOk(preResult)) throw new ScraperError('PRE must succeed');
+    const sealed = buildActionContext(preResult.value);
+    // The real seal drops `scrape` — the exact reason ACTION cannot read
+    // identities from it; they must arrive via the carried balance slot.
+    expect((sealed as { readonly scrape?: unknown }).scrape).toBeUndefined();
+    expect(sealed.balanceAccountIdentities.has).toBe(true);
+    const result = await executeBalanceResolveAction(sealed);
+    if (!isOk(result)) throw new ScraperError('ACTION must succeed');
+    const extracted = result.value.balanceExtracted;
+    const got = extracted.has ? extracted.value.get('ACCT-1') : false;
+    expect(got).toBe(150);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBankSim.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveCrossBankSim.test.ts
@@ -1,0 +1,218 @@
+/**
+ * BALANCE-RESOLVE — cross-bank Mode B simulator (full-chain regression).
+ *
+ * <p>Drives the REAL production PRE → seal ({@link buildActionContext}) →
+ * ACTION → POST chain for four faithful single-account bank shapes, through
+ * a per-URL-validating fetch context that 200s ONLY for the exact synthesized
+ * live URL and 4xxs otherwise (modelling the live server rejecting a replay /
+ * a quarantined redirect).
+ *
+ * <p>CRITICAL — faithful live condition: the mediator is withheld at
+ * BALANCE-RESOLVE.pre (mediator: none) exactly as production does (the seal /
+ * phase boundary drops the live network pool), and the captured response
+ * bodies are carried on the SCRAPE-emitted scrape slice
+ * ({@link IScrapeState.balanceResponseBodies}) — the channel SCRAPE.post
+ * stamps. An earlier version of this simulator wired the mediator INTO the
+ * PRE context, so the captured-seed fired off the live pool and the test
+ * passed while production (no live pool at PRE) universal-missed.
+ * Withholding the mediator here is what makes this a TRUE regression lock: the
+ * `LIVE REGRESSION` case below proves that WITHOUT the carried pool the very
+ * same chain universal-misses. Fake values only — no PII.
+ *
+ * <p>Expected per-bank outcomes (all PASS under the carried-pool fix):
+ *   - Discount  — `'account'`; keyed 200 shadows balance; keyed-miss falls
+ *                 back to the carried BULK_KEY balance → resolved=1.
+ *   - VisaCal   — `'card-cycle'`; credit-card billing aggregates only, no
+ *                 account balance → config gate suppresses → empty plan →
+ *                 soft no-op → total=0 (the regression fix; balance stays
+ *                 undefined, exact main-parity).
+ *   - Leumi     — `'account'`; folded balance, live re-fetch quarantined →
+ *                 BULK_KEY rescue → resolved=1.
+ *   - Hapoalim  — `'account'`; separate balance endpoint, live re-fetch 4xx →
+ *                 BULK_KEY rescue → resolved=1.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePost,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { buildActionContext } from '../../../../../Scrapers/Pipeline/Phases/Base/ActionContextBuilder.js';
+import { none, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+  IBalanceValidation,
+  IPipelineContext,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk, type Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makePerUrlApi } from './BalancePoolHelpers.js';
+
+/** One faithful single-account bank shape. */
+interface IBankShape {
+  readonly ba: string;
+  readonly template: IBalanceFetchTemplate;
+  readonly pool: readonly unknown[];
+  readonly success: ReadonlyMap<string, unknown>;
+  /** Declared balance semantics — required (every bank states its kind). */
+  readonly balanceKind: 'account' | 'card-cycle';
+}
+
+/**
+ * Build a one-account identity map for a bank-account id.
+ * @param ba - bankAccountUniqueId.
+ * @returns Single-entry identity map keyed by the id.
+ */
+function oneIdentity(ba: string): ReadonlyMap<string, IAccountIdentity> {
+  return new Map([[ba, { cardDisplayId: ba, cardUniqueId: `UID-${ba}`, bankAccountUniqueId: ba }]]);
+}
+
+/**
+ * Build the PRE context for one bank shape — faithful live condition:
+ * mediator ABSENT (the seal drops the live pool), with the captured bodies
+ * carried on the scrape slice (the SCRAPE.post channel).
+ * @param shape - Faithful bank shape.
+ * @param carryPool - Whether to carry the captured pool on scrape state.
+ * @returns Mock pipeline context wired with the shape's carried pool + api.
+ */
+function makeShapeCtx(shape: IBankShape, carryPool: boolean): IPipelineContext {
+  const accountIdentities = oneIdentity(shape.ba);
+  const scrape = some({
+    accounts: [],
+    accountIdentities,
+    balanceFetchTemplate: shape.template,
+    balanceResponseBodies: carryPool ? shape.pool : undefined,
+  });
+  const perUrlApi = makePerUrlApi(shape.success);
+  const api = some(perUrlApi);
+  const config = { urls: { base: 'https://test.bank' }, balanceKind: shape.balanceKind };
+  return makeMockContext({ scrape, api, mediator: none(), config });
+}
+
+/**
+ * Run the REAL PRE → seal → ACTION stages for one bank shape.
+ * @param shape - Faithful bank shape.
+ * @param carryPool - Whether to carry the captured pool on scrape state.
+ * @returns Post-action context (throws if PRE or ACTION fails).
+ */
+async function runPreSealAction(shape: IBankShape, carryPool: boolean): Promise<IPipelineContext> {
+  const ctx = makeShapeCtx(shape, carryPool);
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const sealed = buildActionContext(pre.value);
+  const action = await executeBalanceResolveAction(sealed);
+  if (!isOk(action)) throw new ScraperError('ACTION must succeed');
+  return action.value as unknown as IPipelineContext;
+}
+
+/**
+ * Drive the REAL PRE → seal → ACTION → POST chain, returning the raw POST
+ * procedure (so a universal-miss can be asserted, not thrown).
+ * @param shape - Faithful bank shape.
+ * @param carryPool - Whether to carry the captured pool on scrape state.
+ * @returns POST procedure (success or universal-miss failure).
+ */
+async function drivePost(
+  shape: IBankShape,
+  carryPool: boolean,
+): Promise<Procedure<IPipelineContext>> {
+  const acted = await runPreSealAction(shape, carryPool);
+  return executeBalanceResolvePost(acted);
+}
+
+/**
+ * Drive the chain and unwrap the committed POST validation report.
+ * @param shape - Faithful bank shape.
+ * @returns POST validation report (throws if any stage fails).
+ */
+async function drive(shape: IBankShape): Promise<IBalanceValidation> {
+  const post = await drivePost(shape, true);
+  if (!isOk(post)) throw new ScraperError('POST must succeed (not universal-miss)');
+  const report = post.value.balanceValidation;
+  if (!report.has) throw new ScraperError('POST must commit a balanceValidation report');
+  return report.value;
+}
+
+const DISCOUNT: IBankShape = {
+  ba: 'BA-8812',
+  balanceKind: 'account',
+  template: {
+    url: 'https://start.telebank.discountbank.co.il/getUserProfile/<ID>',
+    method: 'GET',
+    urlPathInterpolation: true,
+  },
+  pool: [
+    { GetUserProfileEvent: { ProfileNo: 1 } },
+    { CurrentAccountInfo: { AccountBalance: 19308.48 } },
+  ],
+  success: new Map<string, unknown>([
+    [
+      'https://start.telebank.discountbank.co.il/getUserProfile/BA-8812',
+      { GetUserProfileEvent: { ProfileNo: 1 } },
+    ],
+  ]),
+};
+
+const VISACAL: IBankShape = {
+  ba: 'BA-VC1',
+  balanceKind: 'card-cycle',
+  template: { url: 'https://api.cal-online.co.il/Transactions/getMonthlyDebits', method: 'POST' },
+  pool: [{ totalDebit: 1234.5, billingSumSekel: 1234.5 }],
+  success: new Map<string, unknown>(),
+};
+
+const LEUMI: IBankShape = {
+  ba: 'BA-LE1',
+  balanceKind: 'account',
+  template: { url: 'https://hb2.bankleumi.co.il/UC_SO_27', method: 'POST' },
+  pool: [
+    { HistoryTransactionsItems: [{ DateUTC: '2026-06-17', Amount: 150 }], BalanceDisplay: 150 },
+  ],
+  success: new Map<string, unknown>(),
+};
+
+const HAPOALIM: IBankShape = {
+  ba: 'BA-6347',
+  balanceKind: 'account',
+  template: {
+    url: 'https://login.bankhapoalim.co.il/balanceAndCreditLimit?partyCurrentAccount=<ID>',
+    method: 'GET',
+    urlQueryKey: 'partyCurrentAccount',
+  },
+  pool: [{ currentBalance: 5000 }],
+  success: new Map<string, unknown>(),
+};
+
+describe('BALANCE-RESOLVE cross-bank Mode B simulator', () => {
+  it('Discount — keyed 200 without balance falls back to the captured balance', async () => {
+    const report = await drive(DISCOUNT);
+    expect(report.totalAccounts).toBe(1);
+    expect(report.resolvedIds.length).toBe(1);
+  });
+
+  it('VisaCal — card-cycle bank → deterministic no-op (total=0, no miss)', async () => {
+    const report = await drive(VISACAL);
+    expect(report.totalAccounts).toBe(0);
+    expect(report.missedIds.length).toBe(0);
+  });
+
+  it('Leumi — folded balance with a quarantined re-fetch resolves via BULK_KEY', async () => {
+    const report = await drive(LEUMI);
+    expect(report.totalAccounts).toBe(1);
+    expect(report.resolvedIds.length).toBe(1);
+  });
+
+  it('Hapoalim — separate balance endpoint, 4xx re-fetch resolves via BULK_KEY', async () => {
+    const report = await drive(HAPOALIM);
+    expect(report.totalAccounts).toBe(1);
+    expect(report.resolvedIds.length).toBe(1);
+  });
+
+  it('LIVE REGRESSION — an account bank without the carried pool universal-misses', async () => {
+    const post = await drivePost(LEUMI, false);
+    const isPostOk = isOk(post);
+    expect(isPostOk).toBe(false);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveEvidenceGate.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveEvidenceGate.test.ts
@@ -1,0 +1,163 @@
+/**
+ * BALANCE-RESOLVE — evidence-gated regression locks.
+ *
+ * <p>Two regressions this branch introduced + fixed in-cluster:
+ *
+ * <p><b>Part A (Extract):</b> a wrong-endpoint live re-fetch that 200s
+ * WITHOUT a balance must NOT shadow the captured pool's real balance.
+ * The per-card extractor prefers the keyed response but falls back to the
+ * captured BULK_KEY body whenever the keyed response carries no balance
+ * (the Discount scenario: a non-balance 200 alongside a captured balance).
+ *
+ * <p><b>Part B (Pre config gate):</b> the live-fetch template is suppressed
+ * unless the bank is declared a real account-balance bank
+ * (`config.balanceKind === 'account'`). Card companies (`'card-cycle'`:
+ * VisaCal/Max/Amex/Isracard) and not-yet-declared banks (absent) are a
+ * deterministic no-op, so a credit-card billing aggregate can never be
+ * misread as an account balance. This proves the gate fires on the
+ * regression yet leaves the real live-fetch path (and its tests) intact.
+ * Fake values only — no PII.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IApiFetchContext,
+  IBalanceFetchTemplate,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk, type Procedure, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makeMediatorWithPool, makePool } from './BalancePoolHelpers.js';
+
+/** Captured body carrying a real balance (folded, no card record). */
+const BALANCE_BODY = { BalanceDisplay: 150, items: [] };
+
+/** A live 200 body from a wrong endpoint — carries no balance. */
+const NO_BALANCE_BODY = { foo: 'bar', items: [] };
+
+/** A live re-fetch body that DOES carry a (differing) balance. */
+const KEYED_BALANCE_BODY = { BalanceDisplay: 200, items: [] };
+
+const TEMPLATE: IBalanceFetchTemplate = {
+  url: 'https://fake.bank/getBalance',
+  method: 'POST',
+  postBodyKey: 'bankAccountUniqueId',
+  headers: { 'content-type': 'application/json' },
+};
+
+/** Single checking-account identity (fake ids). */
+const SINGLE_IDENTITY: ReadonlyMap<string, IAccountIdentity> = new Map([
+  ['ACCT-1', { cardDisplayId: 'ACCT-1', cardUniqueId: 'UID-1', bankAccountUniqueId: 'BA-1' }],
+]);
+
+/** SCRAPE state for the single-account fixtures (balance template present). */
+const SINGLE_SCRAPE = some({
+  accounts: [{ accountNumber: 'ACCT-1', balance: 0, txns: [] }],
+  accountIdentities: SINGLE_IDENTITY,
+  balanceFetchTemplate: TEMPLATE,
+});
+
+/** Action-context shape that {@link executeBalanceResolveAction} consumes. */
+type ActionCtx = Parameters<typeof executeBalanceResolveAction>[0];
+
+/**
+ * Build an API whose every fetch SUCCEEDS with the given body (a wrong
+ * endpoint that 200s but carries no balance).
+ * @param body - Response body returned for every fetch.
+ * @returns Fake API context returning the body.
+ */
+function makeOkApi(body: unknown): IApiFetchContext {
+  const result = succeed(body);
+  /**
+   * Return the scripted body as a successful procedure.
+   * @returns A succeeded procedure wrapping the body.
+   */
+  const ok = (): Promise<Procedure<unknown>> => Promise.resolve(result);
+  const stub = { fetchPost: ok, fetchGet: ok, transactionsUrl: false, balanceUrl: false };
+  return stub as unknown as IApiFetchContext;
+}
+
+/**
+ * Run PRE then ACTION over a single-account context with the given pool +
+ * api, returning the resolved balance for ACCT-1 (or 'MISS').
+ * @param pool - Captured endpoint bodies.
+ * @param api - API context for the live re-fetch.
+ * @returns Resolved balance for ACCT-1, or 'MISS'.
+ */
+async function resolveSingle(pool: readonly unknown[], api: IApiFetchContext): Promise<unknown> {
+  const endpoints = makePool(pool);
+  const mediator = makeMediatorWithPool(endpoints);
+  const ctx = makeMockContext({ scrape: SINGLE_SCRAPE, api: some(api), mediator });
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const action = await executeBalanceResolveAction(pre.value as unknown as ActionCtx);
+  if (!isOk(action)) throw new ScraperError('ACTION must succeed');
+  const extracted = action.value.balanceExtracted;
+  return extracted.has ? extracted.value.get('ACCT-1') : 'MISS';
+}
+
+describe('BALANCE-RESOLVE Part A — keyed 200 without balance falls back to BULK_KEY', () => {
+  it('resolves the captured balance when the live re-fetch 200s with no balance', async () => {
+    const api = makeOkApi(NO_BALANCE_BODY);
+    const got = await resolveSingle([BALANCE_BODY], api);
+    expect(got).toBe(150);
+  });
+
+  it('prefers the keyed balance over a differing captured pool balance', async () => {
+    const api = makeOkApi(KEYED_BALANCE_BODY);
+    const got = await resolveSingle([BALANCE_BODY], api);
+    expect(got).toBe(200);
+  });
+});
+
+/** SCRAPE state for the Part-B PRE fixtures (no accounts needed). */
+const PLAN_SCRAPE = some({
+  accounts: [],
+  accountIdentities: SINGLE_IDENTITY,
+  balanceFetchTemplate: TEMPLATE,
+});
+
+/** Mock pipeline context type returned by {@link makeMockContext}. */
+type MockCtx = ReturnType<typeof makeMockContext>;
+
+/**
+ * Build a single-account PRE context declared with the given balance-kind.
+ * The captured pool is irrelevant to the config gate, so none is wired.
+ * @param balanceKind - Declared balance semantics ('account' resolves;
+ *   'card-cycle' suppresses). Required — every bank states its kind.
+ * @returns Mock pipeline context for PRE.
+ */
+function makeKindCtx(balanceKind: 'account' | 'card-cycle'): MockCtx {
+  const config = { urls: { base: 'https://fake.bank' }, balanceKind };
+  return makeMockContext({ scrape: PLAN_SCRAPE, config });
+}
+
+/**
+ * Run PRE for the given balance-kind and report the committed plan length.
+ * @param balanceKind - Declared balance semantics.
+ * @returns Committed plan length (-1 when the plan option is absent).
+ */
+async function planLengthForKind(balanceKind: 'account' | 'card-cycle'): Promise<number> {
+  const ctx = makeKindCtx(balanceKind);
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const plan = pre.value.balanceFetchPlan;
+  return plan.has ? plan.value.length : -1;
+}
+
+describe('BALANCE-RESOLVE Part B — config-driven balance-kind gate', () => {
+  it('honours the template when the bank is declared an account bank', async () => {
+    const length = await planLengthForKind('account');
+    expect(length).toBeGreaterThan(0);
+  });
+
+  it('suppresses the template for a card-cycle bank', async () => {
+    const length = await planLengthForKind('card-cycle');
+    expect(length).toBe(0);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveMultiAccountCard.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveMultiAccountCard.test.ts
@@ -1,0 +1,168 @@
+/**
+ * BALANCE-RESOLVE — multi-account card-bank regression lock (Mode B).
+ *
+ * <p>Reproduces the LIVE cross-bank regression that every offline/CI gate
+ * missed: multi-account card banks (VisaCal, Isracard) whose captured pool
+ * carries ONLY debit/billing AGGREGATES (`totalDebit`, `billingSumSekel`,
+ * `totalIlsBillingDate`) and NO true account balance. Those aggregates are in
+ * the broad {@link PIPELINE_BALANCE_ALIASES} list, so the broad evidence check
+ * wrongly concluded a balance exists, HONOURED the SCRAPE live-fetch template,
+ * and the per-account live re-fetch (a request-shape-picked endpoint that
+ * either 200s with an unextractable deep body — VisaCal `getMonthlyDebitsSummary`
+ * — or is rejected/quarantined — Isracard) resolved NOTHING → universal-miss
+ * (total=N, missed=N) → BALANCE-RESOLVE POST FAIL under live E2E Real.
+ *
+ * <p>Faithful live condition (mirrors {@link BalanceResolveCrossBankSim}): the
+ * mediator is withheld at BALANCE-RESOLVE.pre and the captured bodies are
+ * carried on the SCRAPE-emitted scrape slice. Multi-account ⇒ the single-account
+ * captured-seed rescue does NOT apply, so the futile re-fetch is the only path.
+ *
+ * <p>DESIRED post-fix behaviour (these banks NEVER had a true balance on main):
+ * the narrow true-balance evidence check disproves a balance from the
+ * aggregate-only pool → the template is suppressed → empty plan → soft no-op
+ * (total=0, no miss) — main parity. This test FAILS on the pre-fix HEAD
+ * (universal-miss) and PASSES after the narrow-evidence fix. Fake values only —
+ * no PII; shapes derived from C:\tmp\runs\pipeline real captures.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePost,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { buildActionContext } from '../../../../../Scrapers/Pipeline/Phases/Base/ActionContextBuilder.js';
+import { none, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+  IBalanceValidation,
+  IPipelineContext,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk, type Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makePerUrlApi } from './BalancePoolHelpers.js';
+
+/** One faithful multi-account card-bank shape. */
+interface ICardBankShape {
+  readonly bas: readonly string[];
+  readonly template: IBalanceFetchTemplate;
+  readonly pool: readonly unknown[];
+  readonly success: ReadonlyMap<string, unknown>;
+}
+
+/**
+ * Build a multi-account identity map keyed by bankAccountUniqueId.
+ * @param bas - bankAccountUniqueId list.
+ * @returns Identity map (one entry per id).
+ */
+function manyIdentities(bas: readonly string[]): ReadonlyMap<string, IAccountIdentity> {
+  const entries = bas.map((ba): [string, IAccountIdentity] => [
+    ba,
+    { cardDisplayId: ba, cardUniqueId: `UID-${ba}`, bankAccountUniqueId: ba },
+  ]);
+  return new Map(entries);
+}
+
+/**
+ * Build the PRE context for a multi-account card shape — mediator absent,
+ * captured pool carried on the scrape slice (faithful live condition).
+ * @param shape - Faithful card-bank shape.
+ * @returns Mock pipeline context.
+ */
+function makeCardCtx(shape: ICardBankShape): IPipelineContext {
+  const accountIdentities = manyIdentities(shape.bas);
+  const scrape = some({
+    accounts: [],
+    accountIdentities,
+    balanceFetchTemplate: shape.template,
+    balanceResponseBodies: shape.pool,
+  });
+  const perUrlApi = makePerUrlApi(shape.success);
+  const api = some(perUrlApi);
+  return makeMockContext({
+    scrape,
+    api,
+    mediator: none(),
+    config: { urls: { base: 'https://test.bank' }, balanceKind: 'card-cycle' },
+  });
+}
+
+/**
+ * Drive the REAL PRE → seal → ACTION → POST chain, returning the raw POST
+ * procedure (so a universal-miss can be asserted, not thrown).
+ * @param shape - Faithful card-bank shape.
+ * @returns POST procedure (success or universal-miss failure).
+ */
+async function drivePost(shape: ICardBankShape): Promise<Procedure<IPipelineContext>> {
+  const ctx = makeCardCtx(shape);
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const sealed = buildActionContext(pre.value);
+  const action = await executeBalanceResolveAction(sealed);
+  if (!isOk(action)) throw new ScraperError('ACTION must succeed');
+  return executeBalanceResolvePost(action.value as unknown as IPipelineContext);
+}
+
+/**
+ * Drive the chain and unwrap the committed POST validation report. Throws
+ * when the POST universal-misses (the pre-fix HEAD behaviour) so the soft
+ * no-op assertions in each `it` only see the desired post-fix outcome.
+ * @param shape - Faithful card-bank shape.
+ * @returns POST validation report.
+ */
+async function drive(shape: ICardBankShape): Promise<IBalanceValidation> {
+  const post = await drivePost(shape);
+  if (!isOk(post)) throw new ScraperError('POST must succeed (not universal-miss)');
+  const report = post.value.balanceValidation;
+  if (!report.has) throw new ScraperError('POST must commit a balanceValidation report');
+  return report.value;
+}
+
+/** VisaCal — pool carries only `totalDebit` (getBigNumberAndDetails). */
+const VISACAL: ICardBankShape = {
+  bas: ['VC-3201', 'VC-3202', 'VC-3203'],
+  template: {
+    url: 'https://api.cal-online.co.il/Card/getMonthlyDebitsSummary',
+    method: 'POST',
+    postBodyKey: 'bankAccountUniqueId',
+  },
+  pool: [
+    {
+      result: { bigNumbers: [{ totalDebits: [{ currencyCode: 376, totalDebit: 4107.44 }] }] },
+      statusCode: 1,
+    },
+  ],
+  success: new Map<string, unknown>([
+    [
+      'https://api.cal-online.co.il/Card/getMonthlyDebitsSummary',
+      { result: { bankAccounts: [{ months: [{ totalDebits: [{ totalDebit: 4107.44 }] }] }] } },
+    ],
+  ]),
+};
+
+/** Isracard — pool carries only `billingSumSekel`; live re-fetch quarantined. */
+const ISRACARD: ICardBankShape = {
+  bas: ['IS-7701', 'IS-7702', 'IS-7703', 'IS-7704'],
+  template: {
+    url: 'https://web.isracard.co.il/ocp/transactions/DigitalV3',
+    method: 'POST',
+    postBodyKey: 'bankAccountUniqueId',
+  },
+  pool: [{ data: { billingSumSekel: 3500.5 }, statusCode: 200 }],
+  success: new Map<string, unknown>(),
+};
+
+describe('BALANCE-RESOLVE multi-account card-bank regression lock', () => {
+  it('VisaCal — aggregate-only pool + unextractable 200 re-fetch → soft no-op', async () => {
+    const report = await drive(VISACAL);
+    expect(report.totalAccounts).toBe(0);
+    expect(report.missedIds.length).toBe(0);
+  });
+
+  it('Isracard — aggregate-only pool + quarantined re-fetch → soft no-op', async () => {
+    const report = await drive(ISRACARD);
+    expect(report.totalAccounts).toBe(0);
+    expect(report.missedIds.length).toBe(0);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveSeedRescue.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceResolveSeedRescue.test.ts
@@ -1,0 +1,135 @@
+/**
+ * BALANCE-RESOLVE — captured-seed rescue regression lock (FIBI/Beinleumi).
+ *
+ * <p>Reproduces the real FIBI/Beinleumi (Massad/OtsarHahayal/Pagi) balance
+ * miss OFFLINE. Those banks fold the account balance into the dashboard
+ * `accountSummary` response, which is captured into the CUMULATIVE network
+ * pool (the mediator is created once at INIT, so the pool spans every phase)
+ * BEFORE BALANCE-RESOLVE — but the SCRAPE.post snapshot carried on the scrape
+ * slice ({@link IScrapeState.balanceResponseBodies}) was taken from a
+ * transactions-only scrape and does NOT contain the balance. The mediator is
+ * still present at BALANCE-RESOLVE.pre.
+ *
+ * <p>WITHOUT the rescue (carried snapshot preferred unconditionally) the
+ * carried transactions-only bodies SHADOW the live cumulative pool → the
+ * captured seed is empty → the live re-fetch hits a leverage facility (not a
+ * balance) and misses → universal-miss hard-fail. That is the exact live
+ * regression (`resolved=0 missed=1 total=1`). WITH the rescue (the carried
+ * snapshot is honoured only when it actually carries a balance, else fall
+ * back to the cumulative mediator pool) the folded `accountSummary` balance
+ * resolves → resolved=1.
+ *
+ * <p>This is a TRUE regression lock: it drives the REAL production
+ * PRE → seal ({@link buildActionContext}) → ACTION → POST chain and FAILS on
+ * the pre-rescue carried-only seed. Fake values only — no PII.
+ */
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import {
+  executeBalanceResolveAction,
+  executeBalanceResolvePost,
+  executeBalanceResolvePre,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import { buildActionContext } from '../../../../../Scrapers/Pipeline/Phases/Base/ActionContextBuilder.js';
+import { some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+  IPipelineContext,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk, type Procedure } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+import { makeMediatorWithPool, makePerUrlApi, makePool } from './BalancePoolHelpers.js';
+
+/**
+ * FAKE FIBI/Beinleumi `accountSummary` — faithful shape + key order
+ * (`other` shaarukh rows → `local` → `foreign`), shaarukh rows zero, the real
+ * ILS balance under `currentBalances.local.totalAmount`. No PII.
+ */
+const ACCOUNT_SUMMARY = {
+  currentBalances: {
+    other: [{ totalAmount: 0 }, { totalAmount: 0 }],
+    local: { totalAmount: 12345.67 },
+    foreign: { totalAmount: 678.9 },
+  },
+};
+
+/** Transactions-only body — what the SCRAPE.post snapshot carried (NO balance). */
+const TXN_ONLY: readonly unknown[] = [{ transactions: [{ date: '2026-06-17', amount: -50 }] }];
+
+/** Live re-fetch hits a leverage facility (not a balance) — modelled all-4xx. */
+const LEVERAGED_TEMPLATE: IBalanceFetchTemplate = {
+  url: 'https://al-online.fibi.co.il/rest/utils/leveragedAccount',
+  method: 'GET',
+};
+
+/** The single bank-account id under test. */
+const BA = 'BA-FIBI1';
+
+/**
+ * Build a one-account identity map.
+ * @param ba - bankAccountUniqueId.
+ * @returns Single-entry identity map keyed by the id.
+ */
+function oneIdentity(ba: string): ReadonlyMap<string, IAccountIdentity> {
+  return new Map([[ba, { cardDisplayId: ba, cardUniqueId: `UID-${ba}`, bankAccountUniqueId: ba }]]);
+}
+
+/**
+ * Build the PRE context — mediator PRESENT (cumulative pool), carried snapshot
+ * transactions-only, live re-fetch all-4xx (the leverage facility misses).
+ * @param poolBodies - Cumulative mediator-pool bodies.
+ * @returns Mock pipeline context for the FIBI/Beinleumi rescue scenario.
+ */
+function makeCtx(poolBodies: readonly unknown[]): IPipelineContext {
+  const accountIdentities = oneIdentity(BA);
+  const scrape = some({
+    accounts: [],
+    accountIdentities,
+    balanceFetchTemplate: LEVERAGED_TEMPLATE,
+    balanceResponseBodies: TXN_ONLY,
+  });
+  const pool = makePool(poolBodies);
+  const mediator = makeMediatorWithPool(pool);
+  const emptySuccess = new Map<string, unknown>();
+  const perUrlApi = makePerUrlApi(emptySuccess);
+  const api = some(perUrlApi);
+  const config = {
+    urls: { base: 'https://al-online.fibi.co.il' },
+    balanceKind: 'account' as const,
+  };
+  return makeMockContext({ scrape, api, mediator, config });
+}
+
+/**
+ * Drive the REAL PRE → seal → ACTION → POST chain.
+ * @param poolBodies - Cumulative mediator-pool bodies.
+ * @returns POST procedure (success or universal-miss failure).
+ */
+async function drivePost(poolBodies: readonly unknown[]): Promise<Procedure<IPipelineContext>> {
+  const ctx = makeCtx(poolBodies);
+  const pre = await executeBalanceResolvePre(ctx);
+  if (!isOk(pre)) throw new ScraperError('PRE must succeed');
+  const sealed = buildActionContext(pre.value);
+  const action = await executeBalanceResolveAction(sealed);
+  if (!isOk(action)) throw new ScraperError('ACTION must succeed');
+  const acted = action.value as unknown as IPipelineContext;
+  return executeBalanceResolvePost(acted);
+}
+
+describe('BALANCE-RESOLVE captured-seed rescue (FIBI/Beinleumi)', () => {
+  it('resolves the folded accountSummary from the cumulative pool when the carried snapshot lacks it', async () => {
+    const post = await drivePost([...TXN_ONLY, ACCOUNT_SUMMARY]);
+    if (!isOk(post)) throw new ScraperError('POST must succeed (not universal-miss)');
+    const report = post.value.balanceValidation;
+    if (!report.has) throw new ScraperError('POST must commit a balanceValidation report');
+    expect(report.value.totalAccounts).toBe(1);
+    expect(report.value.resolvedIds.length).toBe(1);
+  });
+
+  it('honest failure — when neither carried snapshot nor pool carries a balance, universal-misses', async () => {
+    const post = await drivePost([...TXN_ONLY]);
+    const isPostOk = isOk(post);
+    expect(isPostOk).toBe(false);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/Credentials/PhoneNormalisation.integration.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Credentials/PhoneNormalisation.integration.test.ts
@@ -44,6 +44,7 @@ type PhoneNumberFormatTag =
 /** Local mirror of the registry's `IPipelineBankConfig` shape — see above. */
 interface IPipelineBankConfig {
   readonly urls: { readonly base: string };
+  readonly balanceKind: 'account' | 'card-cycle';
   readonly headless?: {
     readonly identityBase: string;
     readonly graphql: string;
@@ -132,6 +133,7 @@ function makeCapturingBus(capture: ICredsCapture): IApiMediator {
 function makeBankConfig(format: PhoneNumberFormatTag): IPipelineBankConfig {
   return {
     urls: { base: 'https://example.invalid' },
+    balanceKind: 'account',
     headless: {
       identityBase: 'https://identity.example.invalid/',
       graphql: 'https://graph.example.invalid/graphql',
@@ -186,6 +188,7 @@ describe('Phone normalisation — pipeline integration', () => {
     const bank = CompanyTypes.OneZero;
     const configNoFormat: IPipelineBankConfig = {
       urls: { base: 'https://example.invalid' },
+      balanceKind: 'account',
       headless: {
         identityBase: 'https://identity.example.invalid/',
         graphql: 'https://graph.example.invalid/graphql',

--- a/src/Tests/Unit/Pipeline/Mediator/Home/HashFallthroughReclick.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Home/HashFallthroughReclick.test.ts
@@ -1,0 +1,105 @@
+/**
+ * HOME.ACTION — bare-`#` hash fall-through re-click recovery.
+ *
+ * Visacal's `<a id="ccLoginDesktopBtn" href="#" onclick="">` login
+ * trigger binds its open-login handler asynchronously. Under heavy CI
+ * throttling the first click can fire before the handler binds, so the
+ * anchor's default action runs, the URL degrades to a bare `#` (hash
+ * fall-through), and no login modal/iframe renders — the pipeline then
+ * fails at PRE-LOGIN (E2E run 27848824404, job 82429668784).
+ * `executeDirectNavigation` now re-clicks the trigger (bounded) once the
+ * page has settled and the handler has had time to bind.
+ *
+ * Test Case IDs:
+ *   - HOME-FALLTHRU-001..005: `isHashFallthrough` predicate.
+ *   - HOME-FALLTHRU-010: bare-`#` first click → re-click recovers (2 clicks).
+ *   - HOME-FALLTHRU-011: persistent fall-through is bounded (3 clicks).
+ *   - HOME-FALLTHRU-012: clean first-click navigation → no re-click.
+ */
+
+import {
+  executeHomeNavigation,
+  isHashFallthrough,
+} from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeActions.js';
+import type { IHomeDiscovery } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { NAV_STRATEGY } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import type { IResolvedTarget } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { SILENT_LOG as LOG } from './HomeActionsExtraHelpers.js';
+import { makeRecordingExecutor } from './HomeActionSrpRecorder.js';
+
+const BASE = 'https://www.cal-online.co.il/';
+
+/**
+ * Build a SEQUENTIAL discovery on Visacal's identity trigger selector
+ * (the bank whose `<a href="#">` login control reproduces the bug).
+ * @returns IHomeDiscovery with strategy=SEQUENTIAL.
+ */
+function makeSeqDiscovery(): IHomeDiscovery {
+  const triggerTarget: IResolvedTarget = {
+    contextId: 'main',
+    selector: '[id="ccLoginDesktopBtn"]',
+    kind: 'attribute',
+    candidateValue: 'ccLoginDesktopBtn',
+  };
+  return { strategy: NAV_STRATEGY.SEQUENTIAL, triggerText: 'כניסה לחשבון', triggerTarget };
+}
+
+describe('isHashFallthrough — bare-# hash fall-through predicate', () => {
+  it('HOME-FALLTHRU-001: bare # appended → true', () => {
+    const isFallthrough = isHashFallthrough(BASE, `${BASE}#`);
+    expect(isFallthrough).toBe(true);
+  });
+
+  it('HOME-FALLTHRU-002: real path navigation → false', () => {
+    const isFallthrough = isHashFallthrough(BASE, `${BASE}login`);
+    expect(isFallthrough).toBe(false);
+  });
+
+  it('HOME-FALLTHRU-003: non-empty fragment route (#/login) → false', () => {
+    const isFallthrough = isHashFallthrough(BASE, `${BASE}#/login`);
+    expect(isFallthrough).toBe(false);
+  });
+
+  it('HOME-FALLTHRU-004: identical URL → false', () => {
+    const isFallthrough = isHashFallthrough(BASE, BASE);
+    expect(isFallthrough).toBe(false);
+  });
+
+  it('HOME-FALLTHRU-005: query-string change → false', () => {
+    const isFallthrough = isHashFallthrough(BASE, `${BASE}?ref=login`);
+    expect(isFallthrough).toBe(false);
+  });
+});
+
+describe('HOME.ACTION — re-clicks a bare-# hash fall-through trigger', () => {
+  it('HOME-FALLTHRU-010: recovers when the handler binds on the 2nd click', async () => {
+    const recorder = makeRecordingExecutor({ initialUrl: BASE });
+    let clicks = 0;
+    recorder.setOnClick((): true => {
+      clicks += 1;
+      return recorder.setUrl(clicks >= 2 ? `${BASE}login` : `${BASE}#`);
+    });
+    const discovery = makeSeqDiscovery();
+    const didNavigate = await executeHomeNavigation(recorder.executor, discovery, LOG);
+    expect(recorder.clickLog).toHaveLength(2);
+    expect(didNavigate).toBe(true);
+  });
+
+  it('HOME-FALLTHRU-011: bounds persistent fall-through to MAX attempts', async () => {
+    const recorder = makeRecordingExecutor({ initialUrl: BASE });
+    recorder.setOnClick((): true => recorder.setUrl(`${BASE}#`));
+    const discovery = makeSeqDiscovery();
+    const didNavigate = await executeHomeNavigation(recorder.executor, discovery, LOG);
+    expect(recorder.clickLog).toHaveLength(3);
+    expect(didNavigate).toBe(false);
+  });
+
+  it('HOME-FALLTHRU-012: no re-click when the first click navigates cleanly', async () => {
+    const recorder = makeRecordingExecutor({ initialUrl: BASE });
+    recorder.setOnClick((): true => recorder.setUrl(`${BASE}login`));
+    const discovery = makeSeqDiscovery();
+    const didNavigate = await executeHomeNavigation(recorder.executor, discovery, LOG);
+    expect(recorder.clickLog).toHaveLength(1);
+    expect(didNavigate).toBe(true);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
@@ -53,6 +53,13 @@ function makeStubMediator(idCapture: IDiscoveredEndpoint | false): IElementMedia
       }
       return true as const;
     },
+    /**
+     * Best-effort PRE nudge click stub (no pool mutation). On the empty
+     * pool the nudge fires, finds no id on re-wait, and POST then fails
+     * loud — exactly the honest-failure path this phase test asserts.
+     * @returns Resolved click sentinel.
+     */
+    resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
   } as unknown as IElementMediator;
 }
 

--- a/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
@@ -6,15 +6,24 @@
  * lives in `AccountResolveActions.test.ts`.
  */
 
-import type { IElementMediator } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import {
+  type IElementMediator,
+  type IRaceResult,
+  NOT_FOUND_RESULT,
+} from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
 import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/NetworkDiscoveryTypes.js';
 import {
   AccountResolvePhase,
   createAccountResolvePhase,
 } from '../../../../../Scrapers/Pipeline/Phases/AccountResolve/AccountResolvePhase.js';
 import type { IPipelineContext } from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
-import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { isOk, type Procedure, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
 import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+
+/** Shared no-op nudge result — a `found:false` success matching the real
+ *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
+ *  driving an id into the pool. */
+const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
 
 /**
  * Build a stub mediator whose pre-nav pool yields the given account
@@ -59,7 +68,7 @@ function makeStubMediator(idCapture: IDiscoveredEndpoint | false): IElementMedia
      * loud — exactly the honest-failure path this phase test asserts.
      * @returns Resolved click sentinel.
      */
-    resolveAndClick: (): Promise<unknown> => Promise.resolve(true),
+    resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
   } as unknown as IElementMediator;
 }
 


### PR DESCRIPTION
## Why

Activating the BALANCE-RESOLVE phase for deposit banks surfaced a real,
**live-only** regression on FIBI / Beinleumi: the phase reported a universal
balance miss (`resolved=0 missed=1 total=1`) even though the real balance had
already been captured during SCRAPE.

Root cause: FIBI emits a **bulk** balance template (no per-account key), so both
the live fetch plan and the captured-pool seed are keyed by the same
`__BULK__` key. The live re-fetch POSTs the wrong endpoint and gets an HTTP 400,
but the fetch layer records *any* HTTP response as a success — so the
balance-less 400 body was stored under `__BULK__`. The old merge
(`new Map([...captured, ...fetched])`) then let that 400 body **overwrite** the
captured seed's real balance, and the extractor returned `false` → universal
miss. Offline tests never caught it because no test drove the bulk-key
captured-vs-fetched collision.

## What

- `BalanceResolveActions.Run.ts` — **the fix:** balance-aware `mergeCaptured`
  (`pickMergedBody` / `applyFetched`). A live-fetched body overrides the captured
  seed **only when it actually carries a balance**; wrong-endpoint / 4xx
  responses can no longer shadow a real captured balance. Multi-account banks
  (empty seed) and per-account-keyed plans are unaffected — only the bulk-key
  collision is fixed.
- `BalanceResolveActions.Captured.ts` — export `hasBalance`; PII-safe
  `diagnoseSeed` forensic + carried-vs-pool seed rescue.
- `PipelineBankConfigTypes.ts` — `balanceKind` is now a **required** field; every
  bank declares `'account' | 'card-cycle'` (never inferred from absence).
- `PipelineBankConfig.ts` — all 14 banks declare `balanceKind` explicitly.
- `PipelineContextFactory.ts` / context + types — carry the captured pool across
  the seal boundary; config-driven PRE gate (`poolDisprovesBalance`).
- Tests — new failing-first `BalanceResolveBulkSeedShadow.test.ts` (PROVEN to
  FAIL on the buggy merge and PASS after the fix — reproduces the live miss
  offline) + `BalanceResolveSeedRescue` / `CrossBankSim` / `EvidenceGate` /
  `MultiAccountCard` + shared `BalancePoolHelpers` factories.

## Guideline compliance

| Guideline | How this PR complies |
| --- | --- |
| `coding-principle-guidlines.md` — ≤10-line functions | New helpers (`pickMergedBody`, `applyFetched`, `buildDeepLoginConfig`) each ≤10 lines; `lint:phases:strict` green |
| `coding-principle-guidlines.md` — OCP / no `any` | Balance-aware merge is data-driven via `hasBalance`; `tsc` strict, zero new `any` |
| ZERO CSS selectors in interaction code | No interaction-code selectors touched; balance merge is pure data |
| `test-guidlines.md` — tests are proof | Failing-first regression test reproduces the live miss offline (FAIL→PASS across the fix); shared factories, no duplicated production logic |
| `before-commit-guidlines.md` — never bypass gates | Committed through all 21 husky gates (incl. live Hapoalim e2e PASS); no `--no-verify`, no `git add .` |
| Acyclic deps | `lint:cycles` = 0 (the `Run → Captured` import edge is acyclic) |

### Validation

- **Live Beinleumi e2e:** `balance-resolve.post resolved=1 missed=0 total=1`,
  suite PASS — was `resolved=0` before the fix. Hapoalim + Discount `resolved=1`.
- **Offline:** `tsc` 0, eslint 0, prettier 0, `lint:cycles` 0, 41 suites /
  355 tests pass; dead-code / guideline-coverage / bank-coverage / fixtures-pii /
  biome all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-bank balance semantics (`account` vs `card-cycle`) and support for the `BalanceDisplay` balance alias.

* **Improvements**
  * Balance resolution now seeds from previously captured evidence when live refetch is unavailable or returns no balance.
  * Extraction now reliably prefers keyed balances and falls back to captured bulk data.
  * Reduced unnecessary live balance refetches for `card-cycle` banks and improved multi-account handling.
  * Account resolution may perform a best-effort same-URL transactions click nudge when needed.

* **Tests**
  * Expanded v6 captured-seed, cross-bank, and dashboard/account-resolution regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->