### PR TITLE
fix(pipeline): decouple shared regressions from Leumi migration (R1-R5)

### DIFF
--- a/docs/architecture/balance-resolve.md
+++ b/docs/architecture/balance-resolve.md
@@ -75,6 +75,26 @@ Source: [`BalanceResolveActions.ts`](https://github.com/sergienko4/israeli-bank-
 
 Builds `Map<accountNumber, number>` (legitimate `0` preserved; `'MISS'` → `0`). Writes to `ctx.balanceResolution` which [`PipelineResult`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts) reads when assembling the final accounts array.
 
+## Balance-kind scoping (R1 hardening)
+
+Every bank config declares a mandatory `balanceKind` — a `BalanceKind` of either `account` or `card-cycle` (the canonical constants `ACCOUNT_KIND` and `CARD_CYCLE_KIND`). The declared kind scopes balance discovery to **one** alias family, so a card bank can never resolve an incidental account-style field and an account bank never a card-cycle debit total.
+
+| Kind | Constant | Alias family | Example aliases |
+|---|---|---|---|
+| `account` | `ACCOUNT_KIND` | `ACCOUNT_BALANCE_FAMILY` | `AccountBalance`, `currentBalance`, `runningBalance` |
+| `card-cycle` | `CARD_CYCLE_KIND` | `CARD_CYCLE_BALANCE_FAMILY` | `nextTotalDebit`, `totalDebit`, `billingSumSekel` |
+
+The two families are **disjoint** and together partition the full WK balance-alias surface. `scopeAliasesByKind(aliases, kind)` is the single filter both seams share — it returns the order-preserving **subset** of `aliases` that belongs to the kind's family, never adding an alias the base list lacked (a behaviour-preserving restriction, not a new lookup).
+
+Two seams consume it, one per balance path — each pairs a kind-scoped alias resolver with its extractor entry point:
+
+| Seam | Kind-scoped resolver | Extractor entry |
+|---|---|---|
+| BALANCE-RESOLVE (primary, live fetch) | `scopedResolveBalanceAliases(kind)` | `runBalanceExtractorWith(body, aliases)` |
+| SCRAPE → DASHBOARD.FINAL (txn field-map) | `scopedTxnBalanceAliases(kind)` | `resolveFieldMapOrEmpty` |
+
+Source: [`BalanceKind.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Registry/WK/BalanceKind.ts), [`BalanceResolveWK.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Registry/WK/BalanceResolveWK.ts), [`EndpointFieldMap.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointFieldMap.ts).
+
 ## Observability
 
 | Event | Level | When |

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceExtractor.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceExtractor.ts
@@ -206,11 +206,25 @@ function descendArray(arr: readonly JsonValue[], args: IDescendArgs): number | f
  * @returns Finite balance number, or `false` when nothing matched.
  */
 export function runBalanceExtractor(body: JsonValue): number | false {
-  const args: IDescendArgs = {
-    aliases: PIPELINE_BALANCE_ALIASES,
-    depth: 0,
-    maxDepth: MAX_BFS_DEPTH,
-  };
+  return runBalanceExtractorWith(body, PIPELINE_BALANCE_ALIASES);
+}
+
+/**
+ * Family-scoped variant of {@link runBalanceExtractor}. Runs the same
+ * bounded-depth BFS but restricts the scan to `aliases` — the bank's
+ * declared balance-kind family — so a card bank never resolves an
+ * account alias (and an account bank never a card-cycle debit).
+ *
+ * Pure function — no side effects, never throws.
+ * @param body - JSON response body (or arbitrary JsonValue).
+ * @param aliases - Family-scoped balance-alias list.
+ * @returns Finite balance number, or `false` when nothing matched.
+ */
+export function runBalanceExtractorWith(
+  body: JsonValue,
+  aliases: readonly string[],
+): number | false {
+  const args: IDescendArgs = { aliases, depth: 0, maxDepth: MAX_BFS_DEPTH };
   return descendNode(body, args);
 }
 

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Extract.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Extract.ts
@@ -4,13 +4,16 @@
  * per-file LoC cap is honoured (phase-2e-residue split).
  */
 
-import { PIPELINE_DISPLAY_ID_FIELDS } from '../../Registry/WK/BalanceResolveWK.js';
+import {
+  PIPELINE_BALANCE_ALIASES,
+  PIPELINE_DISPLAY_ID_FIELDS,
+} from '../../Registry/WK/BalanceResolveWK.js';
 import type {
   BalanceExtractionOutcome,
   IAccountIdentity,
   IBalanceExtracted,
 } from '../../Types/PipelineContext.js';
-import { runBalanceExtractor } from './BalanceExtractor.js';
+import { runBalanceExtractorWith } from './BalanceExtractor.js';
 import { BULK_KEY } from './BalanceFetchPlanner.js';
 
 /** Sentinel returned by findCardRecord when no match is present. */
@@ -95,27 +98,63 @@ function findCardRecord(node: unknown, identity: IAccountIdentity): Record<strin
 }
 
 /**
- * Extract per-card balance from a bank-account-level response.
+ * Scan one bank-account body with a given alias list — the card's own
+ * nested record first, then the whole body.
  * @param body - Response body for the card's bank account.
  * @param identity - Card identity (cardUniqueId + cardDisplayId).
+ * @param aliases - Balance-alias list to scan with.
  * @returns Finite balance number, or `false` for MISS.
  */
-function extractPerCardBalance(body: unknown, identity: IAccountIdentity): number | false {
+function scanBodyWithAliases(
+  body: unknown,
+  identity: IAccountIdentity,
+  aliases: readonly string[],
+): number | false {
   const card = findCardRecord(body, identity);
-  const fromCard = isNoCardRecord(card) ? false : runBalanceExtractor(card);
+  const fromCard = isNoCardRecord(card) ? false : runBalanceExtractorWith(card, aliases);
   if (fromCard !== false) return fromCard;
-  return runBalanceExtractor(body);
+  return runBalanceExtractorWith(body, aliases);
+}
+
+/**
+ * Extract per-card balance, preferring the bank's declared family then
+ * falling back to the full alias list. The scoped pass restricts the
+ * scan to the declared family, so a card bank never bleeds onto an
+ * account alias while an in-family debit is present (R1 hardening). The
+ * fallback pass — byte-identical to the pre-kind unscoped extractor —
+ * fires ONLY when the scoped pass finds nothing, recovering banks whose
+ * balance legitimately lives under a cross-family alias (e.g. a FIBI
+ * account balance folded under the card-shared `totalAmount`).
+ * Behaviour-preserving: a scoped miss yields exactly the unscoped result.
+ * @param body - Response body for the card's bank account.
+ * @param identity - Card identity (cardUniqueId + cardDisplayId).
+ * @param aliases - Family-scoped balance-alias list.
+ * @returns Finite balance number, or `false` for MISS.
+ */
+function extractPerCardBalance(
+  body: unknown,
+  identity: IAccountIdentity,
+  aliases: readonly string[],
+): number | false {
+  const scoped = scanBodyWithAliases(body, identity, aliases);
+  if (scoped !== false) return scoped;
+  return scanBodyWithAliases(body, identity, PIPELINE_BALANCE_ALIASES);
 }
 
 /**
  * Extract a card's balance from one response body (undefined-safe).
  * @param body - Candidate response body (keyed or bulk), may be undefined.
  * @param identity - Card identity.
+ * @param aliases - Family-scoped balance-alias list.
  * @returns Finite balance, or `false` when absent / carries no balance.
  */
-function extractFromBody(body: unknown, identity: IAccountIdentity): number | false {
+function extractFromBody(
+  body: unknown,
+  identity: IAccountIdentity,
+  aliases: readonly string[],
+): number | false {
   if (body === undefined) return false;
-  return extractPerCardBalance(body, identity);
+  return extractPerCardBalance(body, identity, aliases);
 }
 
 /**
@@ -129,23 +168,28 @@ function pickKeyedOrBulk(keyed: number | false, bulk: number | false): BalanceEx
   return bulk === false ? 'MISS' : bulk;
 }
 
+/** Bundled args for {@link extractOneCard}. */
+interface IExtractOneArgs {
+  readonly identity: IAccountIdentity;
+  readonly responses: ReadonlyMap<string, unknown>;
+  /** Family-scoped balance-alias list (kind-required). */
+  readonly aliases: readonly string[];
+}
+
 /**
  * Extract one card's balance: prefer its own keyed response, then fall
  * back to the captured BULK_KEY body when the keyed response is absent
  * OR carries no balance — e.g. a wrong-endpoint live fetch that 200s
  * without a balance must not shadow the captured pool's real balance.
- * @param identity - Card identity.
- * @param responses - Responses keyed by bankAccountUniqueId.
+ * @param args - Card identity + responses + family-scoped aliases.
  * @returns Outcome.
  */
-function extractOneCard(
-  identity: IAccountIdentity,
-  responses: ReadonlyMap<string, unknown>,
-): BalanceExtractionOutcome {
+function extractOneCard(args: IExtractOneArgs): BalanceExtractionOutcome {
+  const { identity, responses, aliases } = args;
   const keyedBody = responses.get(identity.bankAccountUniqueId);
   const bulkBody = responses.get(BULK_KEY);
-  const fromKeyed = extractFromBody(keyedBody, identity);
-  const fromBulk = extractFromBody(bulkBody, identity);
+  const fromKeyed = extractFromBody(keyedBody, identity, aliases);
+  const fromBulk = extractFromBody(bulkBody, identity, aliases);
   return pickKeyedOrBulk(fromKeyed, fromBulk);
 }
 
@@ -153,18 +197,20 @@ function extractOneCard(
 interface IExtractAllArgs {
   readonly identities: ReadonlyMap<string, IAccountIdentity>;
   readonly responses: ReadonlyMap<string, unknown>;
+  /** Family-scoped balance aliases the per-card extractor scans (kind-required). */
+  readonly balanceAliases: readonly string[];
 }
 
 /**
  * Iterate every card identity, running the per-card extractor.
- * @param args - Bundled identities + responses.
+ * @param args - Bundled identities + responses + optional scoped aliases.
  * @returns Per-card outcomes (number or 'MISS').
  */
 function extractAllCards(args: IExtractAllArgs): IBalanceExtracted {
-  const { identities, responses } = args;
+  const { identities, responses, balanceAliases } = args;
   const out = new Map<string, BalanceExtractionOutcome>();
   for (const identity of identities.values()) {
-    const outcome = extractOneCard(identity, responses);
+    const outcome = extractOneCard({ identity, responses, aliases: balanceAliases });
     out.set(identity.cardDisplayId, outcome);
   }
   return out;

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Run.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Run.ts
@@ -6,6 +6,7 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { scopedResolveBalanceAliases } from '../../Registry/WK/BalanceResolveWK.js';
 import { some } from '../../Types/Option.js';
 import type {
   IActionContext,
@@ -144,7 +145,8 @@ async function executeDispatchChain(args: IDispatchChainArgs): Promise<Procedure
   const fetched = await fetchAllPlanEntries(args.fetchCtx, args.plan);
   const captured = readSeededCaptured(args.input);
   const responses = mergeCaptured(captured, fetched);
-  const extracted = extractAllCards({ identities, responses });
+  const balanceAliases = scopedResolveBalanceAliases(args.input.config.balanceKind);
+  const extracted = extractAllCards({ identities, responses, balanceAliases });
   return commitDispatchResult({ input: args.input, responses, extracted });
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.final.commit.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.final.commit.ts
@@ -16,7 +16,7 @@ import { EMPTY_TXN_HARVEST } from '../../Types/PipelineContext.js';
 import type { Procedure } from '../../Types/Procedure.js';
 import { fail } from '../../Types/Procedure.js';
 import type { INetworkDiscovery } from '../Network/NetworkDiscoveryTypes.js';
-import { resolveTxnEndpoint } from '../Scrape/ScrapeAutoMapper.js';
+import { resolveTxnEndpoint, scopedTxnBalanceAliases } from '../Scrape/ScrapeAutoMapper.js';
 import { EMPTY_TXN_ENDPOINT } from '../Scrape/ScrapePhaseActions.js';
 import detectDormantEvidence from './DormantEvidenceDetector.js';
 import { buildTxnHarvest } from './TxnParser.js';
@@ -258,7 +258,8 @@ async function commitTxnEndpoint(ctx: IPipelineContext): Promise<ITxnCommitOutco
   await Promise.resolve();
   if (!ctx.mediator.has) return buildBypassOutcome(ctx);
   const network = ctx.mediator.value.network;
-  const internal = resolveTxnEndpoint(network);
+  const balanceAliases = scopedTxnBalanceAliases(ctx.config.balanceKind);
+  const internal = resolveTxnEndpoint(network, balanceAliases);
   if (internal === false) return handleNoTxnEndpoint(ctx, network);
   return commitResolvedEndpoint(ctx, internal);
 }

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.post.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardPhaseActions.post.ts
@@ -69,6 +69,15 @@ function buildDashState(pageUrl: string): IDashboardState {
 }
 
 /**
+ * Build PII-safe logging context for the dashboard probe.
+ * @param input - Pipeline context.
+ * @returns Structured log context.
+ */
+function buildProbeLogContext(input: IPipelineContext): Parameters<typeof checkChangePassword>[1] {
+  return { logger: input.logger, companyId: input.companyId };
+}
+
+/**
  * Run the password-change probe + the primed-traffic gate.
  * @param mediator - Element mediator (already unwrapped).
  * @param input - Pipeline context (for logger access).
@@ -78,7 +87,8 @@ async function runPwdAndPrime(
   mediator: IElementMediator,
   input: IPipelineContext,
 ): Promise<Procedure<IPipelineContext> | boolean> {
-  const pwdCheck = await checkChangePassword(mediator);
+  const logContext = buildProbeLogContext(input);
+  const pwdCheck = await checkChangePassword(mediator, logContext);
   if (pwdCheck) return pwdCheck;
   return validateTrafficGate(mediator.network, input.logger);
 }

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardProbe.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/DashboardProbe.ts
@@ -3,6 +3,8 @@
  * Phases call these functions instead of importing WK directly.
  */
 
+import { randomUUID } from 'node:crypto';
+
 import type { SelectorCandidate } from '../../../Base/Config/LoginConfigTypes.js';
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import { WK_DASHBOARD } from '../../Registry/WK/DashboardWK.js';
@@ -14,13 +16,14 @@ import type { IElementMediator, IRaceResult } from '../Elements/ElementMediator.
 
 /** Timeout for change-password probe (ms). */
 const CHANGE_PWD_TIMEOUT = 3000;
+const DASHBOARD_PROBE_ERROR = 'DASHBOARD_PROBE_ERROR: change-password probe failed';
 
-/**
- * Check change-password prompt via passive probe (Rule #20: POST is read-only).
- * Uses resolveVisible — no click, no DOM mutation.
- * @param mediator - Element mediator.
- * @returns Failure if password change required, false otherwise.
- */
+/** Logging inputs for forced-password detection. */
+interface IDashboardProbeLogContext {
+  readonly logger: ScraperLogger;
+  readonly companyId: string;
+}
+
 /**
  * Extract auth token from mediator (iframe sessionStorage + headers).
  * Called by DASHBOARD.FINAL — stores result in diagnostics for SCRAPE.
@@ -55,28 +58,55 @@ export { extractAuthFromContext, extractDashboardAuth };
 
 /**
  * Race the change-password probe candidates with a short timeout.
- * Catches resolveVisible failures (closed page, mock errors) so the
- * caller treats them as "no prompt found".
  * @param mediator - Element mediator.
- * @returns Race result or false on probe error.
+ * @returns Race result or typed probe failure.
  */
-async function probeChangePwdRace(mediator: IElementMediator): Promise<IRaceResult | false> {
+async function probeChangePwdRace(mediator: IElementMediator): Promise<Procedure<IRaceResult>> {
   const candidates = WK_DASHBOARD.CHANGE_PWD as unknown as readonly SelectorCandidate[];
-  return mediator.resolveVisible(candidates, CHANGE_PWD_TIMEOUT).catch((): false => false);
+  try {
+    return succeed(await mediator.resolveVisible(candidates, CHANGE_PWD_TIMEOUT));
+  } catch {
+    return fail(ScraperErrorTypes.Generic, DASHBOARD_PROBE_ERROR);
+  }
+}
+
+/**
+ * Emits a PII-safe forced-password warning.
+ * @param context - Optional structured logging context.
+ * @returns Always true.
+ */
+function logForcedPassword(context?: IDashboardProbeLogContext): true {
+  context?.logger.warn({
+    event: 'dashboard.forced_password.detected',
+    companyId: context.companyId,
+    correlationId: randomUUID(),
+    marker: true,
+  });
+  return true;
+}
+
+/**
+ * Build the forced-password Procedure after logging the guardrail event.
+ * @param context - Optional structured logging context.
+ * @returns Change-password failure.
+ */
+function failForcedPassword(context?: IDashboardProbeLogContext): Procedure<IPipelineContext> {
+  logForcedPassword(context);
+  return fail(ScraperErrorTypes.ChangePassword, 'Password change required');
 }
 
 /**
  * Check change-password prompt via mediator using WK_DASHBOARD.
  * @param mediator - Element mediator.
+ * @param logContext - Optional PII-safe logging context.
  * @returns Failure if password change required, false otherwise.
  */
 export default async function checkChangePassword(
   mediator: IElementMediator,
+  logContext?: IDashboardProbeLogContext,
 ): Promise<Procedure<IPipelineContext> | false> {
   const changePwd = await probeChangePwdRace(mediator);
-  if (!changePwd) return false;
-  if (changePwd.found) {
-    return fail(ScraperErrorTypes.ChangePassword, 'Password change required');
-  }
+  if (!changePwd.success) return changePwd;
+  if (changePwd.value.found) return failForcedPassword(logContext);
   return false;
 }

--- a/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/ActionExecutors.ts
@@ -490,13 +490,33 @@ function hasAttr(v: string): boolean {
 }
 
 /**
+ * Build the aria-label tier selector, conjoining a distinct `href` when the
+ * resolved anchor carries one. Two controls can share an identical accessible
+ * name — e.g. an off-canvas "how to log in" decoy and the genuine on-screen
+ * login anchor both labelled `כניסה לחשבון`. A bare `[aria-label="…"]` then
+ * matches BOTH, and ACTION's `.first()` click lands on the DOM-first decoy.
+ * Conjoining the href (unique per destination) pins the selector to the EXACT
+ * element PRE's hit-test selected. Elements without an href (buttons) keep the
+ * bare aria-label selector, so the Beinleumi `<button title="…">` path is
+ * untouched.
+ * @param identity - DOM identity captured by `extractIdentity` at PRE time.
+ * @returns `[aria-label="…"]`, conjoined with `[href="…"]` when an href exists.
+ */
+function ariaLabelSelector(identity: IElementIdentity): string {
+  const aria = `[aria-label="${identity.ariaLabel}"]`;
+  if (hasAttr(identity.href)) return `${aria}[href="${identity.href}"]`;
+  return aria;
+}
+
+/**
  * Build a precise CSS attribute selector from the resolved element's actual
  * DOM identity, in priority order:
  *   1. id          → `[id="…"]`        (most specific, almost always unique)
  *   2. name        → `[name="…"]`      (form fields)
- *   3. aria-label  → `[aria-label="…"]` (semantic labels)
+ *   3. aria-label  → `[aria-label="…"]` (semantic labels; + `[href]` when the
+ *                    element is an anchor — disambiguates same-name twins)
  *   4. title       → `[title="…"]`     (Bootstrap-style buttons)
- *   5. href        → `[href="…"]`      (anchor links)
+ *   5. href        → `[href="…"]`      (anchor links with no accessible name)
  *
  * The selector matches the EXACT element PRE found, regardless of which WK
  * candidate kind triggered the match. This lets ariaLabel-kind candidates
@@ -511,7 +531,7 @@ function hasAttr(v: string): boolean {
 function buildIdentitySelector(identity: IElementIdentity): string | false {
   if (hasAttr(identity.id)) return `[id="${identity.id}"]`;
   if (hasAttr(identity.name)) return `[name="${identity.name}"]`;
-  if (hasAttr(identity.ariaLabel)) return `[aria-label="${identity.ariaLabel}"]`;
+  if (hasAttr(identity.ariaLabel)) return ariaLabelSelector(identity);
   if (hasAttr(identity.title)) return `[title="${identity.title}"]`;
   if (hasAttr(identity.href)) return `[href="${identity.href}"]`;
   return false;

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Entries.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Entries.ts
@@ -153,9 +153,12 @@ async function expandCandidateEntries(args: IExpandEntryArgs): Promise<readonly 
 
 /**
  * Build locator entries that surface MULTIPLE elements per locator (up to
- * `MAX_NTH_PER_LOCATOR`). Used only by `resolveAllVisible` so other
- * resolvers (login/preLogin/etc.) keep their `.first()`-only semantics —
- * zero behavioural change for banks that already pass on attempt 0.
+ * `MAX_NTH_PER_LOCATOR`). Backs `resolveVisibleNthAware`, which now serves
+ * BOTH the active resolve-and-click path and the passive `resolveVisible`
+ * discovery, plus the hit-test race fallback. Surfacing every nth-match lets
+ * the hit-test winner-picker prefer a truly-visible control over a same-text
+ * off-canvas decoy that merely happens to be DOM-first. The single-frame
+ * `resolveVisibleInContextImpl` still uses `.first()` via `buildLocatorEntries`.
  * @param page - Playwright page.
  * @param candidates - WK selector candidates.
  * @param formAnchor - Optional CSS form selector — when set, all candidate

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Locators.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Locators.ts
@@ -2,9 +2,10 @@
  * Per-kind locator builders + OCP-friendly dispatch table. Each builder
  * accepts a form-scoped context and returns BASE Playwright locators
  * (without `.first()`). Callers wrap as needed:
- *   - `buildCandidateLocators` applies `.first()` (resolveVisibleImpl).
- *   - `buildLocatorEntriesAll` enumerates `.nth(0..N-1)` (resolveAllVisible /
- *     resolveAndClick) so multi-match elements all enter the race.
+ *   - `buildCandidateLocators` applies `.first()` (resolveVisibleInContextImpl).
+ *   - `buildLocatorEntriesAll` enumerates `.nth(0..N-1)` (resolveVisible /
+ *     resolveAllVisible / resolveAndClick) so multi-match elements all enter
+ *     the race.
  *
  * Extracted from CreateElementMediator.ts (Phase 12a §3) so the god module
  * no longer owns SelectorCandidate→Locator dispatch.

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Race.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Race.ts
@@ -4,7 +4,7 @@
  * and packages winners into IRaceResult.
  *
  * Public surface (consumed by parent CreateElementMediator's resolver
- * impls — `resolveVisibleImpl`, `resolveVisibleNthAware`,
+ * impls — `resolveVisibleNthAware`,
  * `resolveAllVisibleImpl`):
  *
  *   - `raceEntriesToResult` — race entries through hit-test, return the
@@ -72,7 +72,7 @@ export function traceRaceDiagnostic(
 
 /**
  * Run the hit-test race against an entry list, log diagnostics.
- * Extracted so resolveVisibleImpl + resolveVisibleNthAware share one path.
+ * Extracted so resolveVisibleNthAware + resolveVisibleInContextImpl share one path.
  * @param entries - Locator entries (single-match `.first()` OR nth-enumerated).
  * @param timeout - Race timeout (already capped by caller).
  * @param label - Log prefix identifying the resolver (for diagnostic trace).
@@ -111,8 +111,8 @@ export async function enrichWinnerToResult(
 
 /**
  * Race entries through hit-test, return found-result or NOT_FOUND.
- * Shared body for resolveVisibleImpl (`.first()` per candidate) and
- * resolveVisibleNthAware (nth-enumerated). Caller picks the entry-builder.
+ * Shared body for resolveVisibleNthAware (nth-enumerated) and
+ * resolveVisibleInContextImpl (`.first()` per candidate). Caller picks the entry-builder.
  * @param entries - Locator entries to race.
  * @param timeout - Race timeout (already capped).
  * @param label - Diagnostic label for log output.

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Resolve.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Resolve.ts
@@ -58,23 +58,7 @@ interface IResolveAllArgs {
 }
 
 /**
- * Resolve the first visible element — parallel race across candidates with
- * `.first()` per locator. Uses the SAME resolveVisible + hit-test logic in
- * both LIVE and MOCK modes (Rule #20: passive discovery is identical). If
- * an element isn't visible in the rendered snapshot, the mock MUST fail —
- * that's the whole point. When `args.formAnchor` is set, ALL candidate kinds
- * are scoped to descendants of the form via Playwright Locator chaining.
- * @param args - Bundled page + candidates + timeout + formAnchor.
- * @returns Race result with locator + metadata, or NOT_FOUND.
- */
-async function resolveVisibleImpl(args: IClickResolveArgs): Promise<IRaceResult> {
-  const entries = buildLocatorEntries(args.page, args.candidates, args.formAnchor);
-  const effectiveTimeout = capTimeout(args.timeout);
-  return raceEntriesToResult(entries, effectiveTimeout, 'resolveVisible');
-}
-
-/**
- * Resolve the first visible element — like resolveVisibleImpl but enumerates
+ * Resolve the first visible element via a parallel race that enumerates
  * `.nth(0..MAX_NTH_PER_LOCATOR-1)` per base locator so multi-match elements
  * (e.g. several `<button type="submit">` across login + SMS forms) all enter
  * the race. Hit-test picks the truly visible+enabled winner.
@@ -190,7 +174,7 @@ async function runHitTestRaceLike(
 
 /**
  * Resolve the first visible element within a SINGLE frame context.
- * Same logic as resolveVisibleImpl but scoped to one context.
+ * Same logic as resolveVisibleNthAware but scoped to one context.
  * @param ctx - The specific Page or Frame to search.
  * @param candidates - WellKnown selector candidates.
  * @param timeout - Race timeout in ms.
@@ -322,7 +306,7 @@ function buildResolveVisible(page: Page): IElementMediator['resolveVisible'] {
     if (candidates.length === 0) return Promise.resolve(NOT_FOUND_RESULT);
     const timeout = timeoutMs ?? CLICK_RACE_TIMEOUT;
     const anchor = formAnchor ?? NO_FORM_ANCHOR;
-    return resolveVisibleImpl({ page, candidates, timeout, formAnchor: anchor });
+    return resolveVisibleNthAware({ page, candidates, timeout, formAnchor: anchor });
   };
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Indexing/ResponseParser.ts
@@ -15,6 +15,11 @@
  *     and this file (parseResponse).
  *
  * Structured-log helpers live in {@link ./ResponseParserLogs.js}.
+ *
+ * SOAP/WCF (Broker.svc-style) envelope unwrap is a bank-specific
+ * adapter concern, intentionally not on the shared response path; a
+ * future SOAP-backed bank migration adds a thin bank-specific adapter
+ * that unwraps before handing plain JSON to this generic parser.
  */
 
 import type { Response } from 'playwright-core';

--- a/src/Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointFieldMap.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointFieldMap.ts
@@ -10,6 +10,7 @@
  * the per-run {@link ITxnFieldMap}.
  */
 
+import { type BalanceKind, scopeAliasesByKind } from '../../../Registry/WK/BalanceKind.js';
 import { PIPELINE_WELL_KNOWN_TXN_FIELDS as WK } from '../../../Registry/WK/ScrapeWK.js';
 import type { ITxnFieldMap } from '../../../Types/PipelineContext.js';
 import type { ApiRecord } from '../AutoMapperFacade/AutoMapperTypes.js';
@@ -63,17 +64,39 @@ interface IFieldMapOptionals {
 }
 
 /**
+ * Resolve the balance alias preferring the bank's declared family,
+ * then falling back to the full {@link WK.balance} list. The fallback
+ * fires ONLY when the scoped pass finds nothing, so a browser bank
+ * whose balance lives under a cross-family alias still resolves —
+ * mirroring the BALANCE-RESOLVE primary seam's scoped-first-then-full
+ * behaviour. Behaviour-preserving: a scoped miss yields the unscoped
+ * alias.
+ * @param sample - First record from the txn array.
+ * @param balanceAliases - Family-scoped balance-alias list.
+ * @returns First matching balance key, or `false` when absent.
+ */
+function resolveBalanceAlias(sample: ApiRecord, balanceAliases: readonly string[]): string | false {
+  const scoped = resolveOptionalAlias(sample, balanceAliases);
+  if (scoped !== false) return scoped;
+  return resolveOptionalAlias(sample, WK.balance);
+}
+
+/**
  * Resolve the optional aliases bundle for {@link buildFieldMap}.
  * Pulled out so the orchestrator stays a thin guard + return.
  *
  * @param sample - First record from the txn array.
+ * @param balanceAliases - Family-scoped balance-alias list.
  * @returns Bundle holding the three optional alias results.
  */
-function resolveOptionalFields(sample: ApiRecord): IFieldMapOptionals {
+function resolveOptionalFields(
+  sample: ApiRecord,
+  balanceAliases: readonly string[],
+): IFieldMapOptionals {
   return {
     originalAmount: resolveOptionalAlias(sample, WK.originalAmount),
     processedDate: resolveOptionalAlias(sample, WK.processedDate),
-    balance: resolveOptionalAlias(sample, WK.balance),
+    balance: resolveBalanceAlias(sample, balanceAliases),
   };
 }
 
@@ -82,16 +105,18 @@ function resolveOptionalFields(sample: ApiRecord): IFieldMapOptionals {
  * Returns `false` when neither a date alias nor any amount alias
  * resolves — DASHBOARD.FINAL escalates to F-DASH-2.
  * @param sample - First record from the txn array.
+ * @param balanceAliases - Family-scoped balance-alias list.
  * @returns Resolved field map or `false`.
  */
-function buildFieldMap(sample: ApiRecord): ITxnFieldMap | false {
+function buildFieldMap(sample: ApiRecord, balanceAliases: readonly string[]): ITxnFieldMap | false {
   const date = resolveAlias(sample, WK.date);
   const amount = pickAmountAlias(sample);
   if (date === '' || amount === '') return false;
   const description = resolveAlias(sample, WK.description);
   const currency = resolveAlias(sample, WK.currency);
   const identifier = resolveAlias(sample, WK.identifier);
-  return { date, amount, description, currency, identifier, ...resolveOptionalFields(sample) };
+  const optionals = resolveOptionalFields(sample, balanceAliases);
+  return { date, amount, description, currency, identifier, ...optionals };
 }
 
 /** Empty fieldMap returned when the picked capture has zero
@@ -112,13 +137,29 @@ const EMPTY_FIELD_MAP: ITxnFieldMap = {
  * Resolve a fieldMap from the first transaction record, or fall
  * back to the empty fieldMap when the body has zero records.
  * @param records - Records harvested by `huntTransactions`.
+ * @param balanceAliases - Family-scoped balance aliases; defaults to
+ *   the full {@link WK.balance} list for kind-agnostic callers/tests.
  * @returns Resolved fieldMap (never `false`).
  */
-function resolveFieldMapOrEmpty(records: readonly ApiRecord[]): ITxnFieldMap {
+function resolveFieldMapOrEmpty(
+  records: readonly ApiRecord[],
+  balanceAliases: readonly string[] = WK.balance,
+): ITxnFieldMap {
   if (records.length === 0) return EMPTY_FIELD_MAP;
-  const sampleFieldMap = buildFieldMap(records[0]);
+  const sampleFieldMap = buildFieldMap(records[0], balanceAliases);
   if (sampleFieldMap === false) return EMPTY_FIELD_MAP;
   return sampleFieldMap;
+}
+
+/**
+ * Scope the legacy SCRAPE `fieldMap.balance` alias list
+ * ({@link WK.balance}) to a bank's declared kind — the SCRAPE
+ * (legacy) seam's family filter.
+ * @param kind - The bank's declared balance kind.
+ * @returns Family-scoped balance-alias list for the SCRAPE fieldMap.
+ */
+export function scopedTxnBalanceAliases(kind: BalanceKind): readonly string[] {
+  return scopeAliasesByKind(WK.balance, kind);
 }
 
 export default resolveFieldMapOrEmpty;

--- a/src/Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointResolver.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointResolver.ts
@@ -144,20 +144,29 @@ interface ICommitArtifacts {
   readonly responseBody: ApiRecord;
 }
 
+/** Compose result of {@link resolveRequestParts} — resolved request
+ *  parts (method + fieldMap) plus the parsed body sample. */
+interface IRequestPartsResult {
+  readonly parts: IResolvedRequestParts;
+  readonly responseBody: ApiRecord;
+}
+
 /**
  * Resolve method + fieldMap from a shape-passing capture body.
  * Pulled out so {@link buildCommitArtifacts} stays under the LoC budget.
  * @param ep - Capture returned by `discoverTransactionsEndpoint`.
+ * @param balanceAliases - Family-scoped balance aliases (optional;
+ *   the leaf resolver defaults to the full WK list when omitted).
  * @returns Resolved request parts (method + fieldMap) + parsed body.
  */
-function resolveRequestParts(ep: IDiscoveredEndpoint): {
-  parts: IResolvedRequestParts;
-  responseBody: ApiRecord;
-} {
+function resolveRequestParts(
+  ep: IDiscoveredEndpoint,
+  balanceAliases?: readonly string[],
+): IRequestPartsResult {
   const method = ep.method as 'GET' | 'POST';
   const responseBody = (ep.responseBody ?? {}) as ApiRecord;
   const huntedRecords = huntTransactions(responseBody);
-  const fieldMap = resolveFieldMapOrEmpty(huntedRecords);
+  const fieldMap = resolveFieldMapOrEmpty(huntedRecords, balanceAliases);
   return { parts: { method, fieldMap }, responseBody };
 }
 
@@ -168,13 +177,15 @@ function resolveRequestParts(ep: IDiscoveredEndpoint): {
  *
  * @param network - Network surface exposing the captured pool.
  * @param ep - Capture returned by `discoverTransactionsEndpoint`.
+ * @param balanceAliases - Family-scoped balance aliases (optional).
  * @returns Slim endpoint + parsed responseBody bundle.
  */
 function buildCommitArtifacts(
   network: INetworkDiscovery,
   ep: IDiscoveredEndpoint,
+  balanceAliases?: readonly string[],
 ): ICommitArtifacts {
-  const { parts, responseBody } = resolveRequestParts(ep);
+  const { parts, responseBody } = resolveRequestParts(ep, balanceAliases);
   const endpoint = buildTxnEndpoint(network, ep, parts);
   return { endpoint, responseBody };
 }
@@ -193,13 +204,18 @@ function buildCommitArtifacts(
  * auto-discovery for that one execution.
  *
  * @param network - Network surface exposing the pool of captures.
+ * @param balanceAliases - Family-scoped balance aliases (optional;
+ *   DASHBOARD.FINAL passes the bank's kind-scoped list).
  * @returns Resolved internal payload or `false`.
  */
-function resolveTxnEndpoint(network: INetworkDiscovery): ITxnEndpointInternal | false {
+function resolveTxnEndpoint(
+  network: INetworkDiscovery,
+  balanceAliases?: readonly string[],
+): ITxnEndpointInternal | false {
   const ep = network.discoverTransactionsEndpoint();
   if (ep === false) return false;
   if (!isCommittableCapture(ep)) return false;
-  const { endpoint, responseBody } = buildCommitArtifacts(network, ep);
+  const { endpoint, responseBody } = buildCommitArtifacts(network, ep, balanceAliases);
   return buildInternalResult(ep, endpoint, responseBody);
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts
+++ b/src/Scrapers/Pipeline/Mediator/Scrape/ScrapeAutoMapper.ts
@@ -25,6 +25,7 @@ export {
   extractTransactions,
   extractTransactionsForCard,
 } from './ContainerPicker/ContainerPicker.js';
+export { scopedTxnBalanceAliases } from './EndpointResolver/EndpointFieldMap.js';
 export { default as resolveTxnEndpoint } from './EndpointResolver/EndpointResolver.js';
 export { default as findFirstArray } from './FieldHunt/LifoCrawl.js';
 export type { IMonthChunk } from './ScrapeReplayAction.js';

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts
@@ -6,8 +6,9 @@
  */
 
 import { CompanyTypes } from '../../../../Definitions.js';
+import { ACCOUNT_KIND, CARD_CYCLE_KIND } from '../WK/BalanceKind.js';
 import { seedWkFromPipelineConfig } from './PipelineBankConfigSeeder.js';
-import type { BalanceKind, IPipelineBankConfig } from './PipelineBankConfigTypes.js';
+import type { IPipelineBankConfig } from './PipelineBankConfigTypes.js';
 
 export type {
   AuthPathKey,
@@ -15,61 +16,55 @@ export type {
   IPipelineBankConfig,
 } from './PipelineBankConfigTypes.js';
 
-/** Billing-cycle banks (credit-card companies) expose no account balance. */
-const CARD_CYCLE: BalanceKind = 'card-cycle';
-
-/** Deposit/checking banks expose a real account balance resolved live. */
-const ACCOUNT: BalanceKind = 'account';
-
 /** Pipeline bank registry — migrated banks only. */
 const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> = {
   [CompanyTypes.Beinleumi]: {
     urls: { base: 'https://www.fibi.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.Discount]: {
     urls: { base: 'https://www.discountbank.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.Hapoalim]: {
     urls: { base: 'https://www.bankhapoalim.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.Massad]: {
     urls: { base: 'https://www.bankmassad.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.OtsarHahayal]: {
     urls: { base: 'https://www.bankotsar.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.Pagi]: {
     urls: { base: 'https://www.pagi.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.VisaCal]: {
     urls: { base: 'https://www.cal-online.co.il/' },
-    balanceKind: CARD_CYCLE,
+    balanceKind: CARD_CYCLE_KIND,
   },
   [CompanyTypes.Amex]: {
     urls: { base: 'https://americanexpress.co.il' },
-    balanceKind: CARD_CYCLE,
+    balanceKind: CARD_CYCLE_KIND,
   },
   [CompanyTypes.Max]: {
     urls: { base: 'https://www.max.co.il' },
-    balanceKind: CARD_CYCLE,
+    balanceKind: CARD_CYCLE_KIND,
   },
   [CompanyTypes.Mercantile]: {
     urls: { base: 'https://www.mercantile.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
   },
   [CompanyTypes.Isracard]: {
     urls: { base: 'https://www.isracard.co.il' },
-    balanceKind: CARD_CYCLE,
+    balanceKind: CARD_CYCLE_KIND,
   },
   [CompanyTypes.OneZero]: {
     urls: { base: 'https://www.onezerobank.com' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
     headless: {
       identityBase: 'https://identity.tfd-bank.com/v1/',
       graphql: 'https://mobile.tfd-bank.com/mobile-graph/graphql',
@@ -86,7 +81,7 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
   },
   [CompanyTypes.PayBox]: {
     urls: { base: 'https://www.payboxapp.com/' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
     headless: {
       identityBase: 'https://apipin.payboxapp.com/api/2.0/',
       // PayBox has no GraphQL — set graphql to identityBase to satisfy the
@@ -115,7 +110,7 @@ const PIPELINE_BANK_CONFIG: Partial<Record<CompanyTypes, IPipelineBankConfig>> =
   },
   [CompanyTypes.Pepper]: {
     urls: { base: 'https://www.pepper.co.il' },
-    balanceKind: ACCOUNT,
+    balanceKind: ACCOUNT_KIND,
     headless: {
       identityBase: 'https://sa.pepper.co.il/',
       graphql: 'https://fe-sec.pepper.co.il/graphql',

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
@@ -4,6 +4,15 @@
  * Rule #15 named-alias discipline.
  */
 
+import type { BalanceKind } from '../WK/BalanceKind.js';
+
+/**
+ * Re-exported for back-compat — the canonical home is
+ * {@link ACCOUNT_BALANCE_FAMILY | WK/BalanceKind}. Consumers that
+ * imported `BalanceKind` from this module keep working.
+ */
+export type { BalanceKind };
+
 /** Generic auth-path keys — per-bank subsets plug into `paths` below. */
 export type AuthPathKey =
   | 'identity.deviceToken'
@@ -33,16 +42,6 @@ export type PhoneNumberFormatTag =
   | 'international-dash'
   | 'international-flat'
   | 'local-only';
-
-/**
- * Balance semantics for a bank — an explicit, REQUIRED per-bank declaration.
- * `'account'` banks expose a real account balance (deposit/checking banks)
- * and trigger a live BALANCE-RESOLVE; `'card-cycle'` banks expose only
- * per-cycle credit-card billing aggregates (VisaCal, Max, Amex, Isracard) and
- * have no account balance to resolve (deterministic no-op). Never inferred
- * from absence — an unstated kind is a config error, not a dormant no-op.
- */
-export type BalanceKind = 'account' | 'card-cycle';
 
 /** Headless-strategy URL block — populates ctx.apiMediator at build time. */
 export interface IHeadlessUrlsConfig {
@@ -94,15 +93,15 @@ export interface IPipelineBankConfig {
   readonly urls: {
     readonly base: string;
   };
+  /**
+   * Balance semantics this bank exposes. Scopes BALANCE-RESOLVE (and
+   * the legacy SCRAPE fieldMap) to the matching alias family so a
+   * card bank never resolves an account alias (and vice-versa).
+   * Mandatory — every registered bank declares its kind explicitly.
+   */
+  readonly balanceKind: BalanceKind;
   /** Fallback transaction API path — used when network discovery finds nothing. */
   readonly transactionsPath?: string;
   /** Headless-strategy URLs — populated for API-native banks (no browser). */
   readonly headless?: IHeadlessUrlsConfig;
-  /**
-   * Balance semantics — see {@link BalanceKind}. REQUIRED: every bank states
-   * its kind explicitly — `'account'` (live balance resolved) or `'card-cycle'`
-   * (deterministic no-op). Never inferred from absence — an unstated kind is a
-   * config error, not a silent dormant no-op.
-   */
-  readonly balanceKind: BalanceKind;
 }

--- a/src/Scrapers/Pipeline/Registry/WK/BalanceKind.ts
+++ b/src/Scrapers/Pipeline/Registry/WK/BalanceKind.ts
@@ -1,0 +1,93 @@
+/**
+ * BALANCE-RESOLVE — declared balance "kind" per bank plus the
+ * alias-family filter that scopes balance discovery to that kind.
+ *
+ * R1 hardening: the WK balance-alias lists order account aliases
+ * (`AccountBalance`, `balance`, …) BEFORE card-cycle debits
+ * (`nextTotalDebit`, `totalDebit`, …). A card bank whose response
+ * carries an incidental account-ish field would otherwise resolve
+ * that field first. Each bank declares a {@link BalanceKind}; the
+ * extractor PREFERS the matching family — a card bank never bleeds
+ * onto an account alias while an in-family debit is present — and
+ * falls back to the full alias list only when the family scan finds
+ * nothing, so a bank whose balance legitimately lives under a
+ * cross-family alias (e.g. an account balance folded under the
+ * card-shared `totalAmount`) still resolves.
+ *
+ * Dependency-free by design — imports no alias list — so both the
+ * BALANCE-RESOLVE and SCRAPE seams can consume it without a circular
+ * import.
+ */
+
+/**
+ * Balance semantics a bank exposes.
+ *  - `account` — a real running account balance (current-account banks).
+ *  - `card-cycle` — a credit-card billing-cycle debit total.
+ */
+export type BalanceKind = 'account' | 'card-cycle';
+
+/** Canonical {@link BalanceKind} for running deposit/checking accounts. */
+export const ACCOUNT_KIND: BalanceKind = 'account';
+
+/** Canonical {@link BalanceKind} for credit-card billing-cycle balances. */
+export const CARD_CYCLE_KIND: BalanceKind = 'card-cycle';
+
+/**
+ * Account-family balance aliases — running-balance style fields.
+ * Disjoint from {@link CARD_CYCLE_BALANCE_FAMILY}; together the two
+ * families partition the full WK balance-alias surface.
+ *
+ * `BalanceDisplay` is the PRIMARY-resolver account alias for browser
+ * banks that fold the balance into the transactions response (no
+ * separate balance endpoint). It lives in the account family so
+ * `scopedResolveBalanceAliases('account')` keeps it — dropping it
+ * would silently regress those account banks' resolved balance.
+ */
+export const ACCOUNT_BALANCE_FAMILY: ReadonlySet<string> = new Set([
+  'AccountBalance',
+  'balance',
+  'currentBalance',
+  'balanceAmount',
+  'withdrawableBalance',
+  'runningBalance',
+  'currentAccountBalance',
+  'closingBalance',
+  'BalanceDisplay',
+]);
+
+/**
+ * Card-cycle-family balance aliases — billing-cycle debit totals.
+ * Disjoint from {@link ACCOUNT_BALANCE_FAMILY}.
+ */
+export const CARD_CYCLE_BALANCE_FAMILY: ReadonlySet<string> = new Set([
+  'nextTotalDebit',
+  'totalDebit',
+  'currentDebit',
+  'currentBillingAmount',
+  'totalAmount',
+  'billingSumSekel',
+  'totalIlsBillingDate',
+]);
+
+/** Maps a declared {@link BalanceKind} to its alias family. */
+const FAMILY_BY_KIND: Readonly<Record<BalanceKind, ReadonlySet<string>>> = {
+  account: ACCOUNT_BALANCE_FAMILY,
+  'card-cycle': CARD_CYCLE_BALANCE_FAMILY,
+};
+
+/**
+ * Scope a balance-alias list to the bank's declared kind. Returns the
+ * subset of `aliases` whose members belong to the kind's family —
+ * order-preserving and never adding an alias the base list lacked, so
+ * the result is always a behaviour-preserving restriction.
+ * @param aliases - Base balance-alias list (a path's full WK list).
+ * @param kind - The bank's declared balance kind.
+ * @returns Family-scoped alias list (a subset of `aliases`).
+ */
+export function scopeAliasesByKind(
+  aliases: readonly string[],
+  kind: BalanceKind,
+): readonly string[] {
+  const family = FAMILY_BY_KIND[kind];
+  return aliases.filter((alias): boolean => family.has(alias));
+}

--- a/src/Scrapers/Pipeline/Registry/WK/BalanceResolveWK.ts
+++ b/src/Scrapers/Pipeline/Registry/WK/BalanceResolveWK.ts
@@ -10,6 +10,8 @@
  * through this dedicated seam.
  */
 
+import { type BalanceKind, scopeAliasesByKind } from './BalanceKind.js';
+
 /**
  * Standalone balance-alias export for the BALANCE-RESOLVE phase.
  * Superset of the legacy `PIPELINE_WELL_KNOWN_TXN_FIELDS.balance`
@@ -47,6 +49,16 @@ export const PIPELINE_BALANCE_ALIASES: readonly string[] = [
   'totalIlsBillingDate',
   'BalanceDisplay',
 ] as const;
+
+/**
+ * Scope {@link PIPELINE_BALANCE_ALIASES} to a bank's declared kind —
+ * the BALANCE-RESOLVE (primary) seam's family filter.
+ * @param kind - The bank's declared balance kind.
+ * @returns Family-scoped balance-alias list for BALANCE-RESOLVE.
+ */
+export function scopedResolveBalanceAliases(kind: BalanceKind): readonly string[] {
+  return scopeAliasesByKind(PIPELINE_BALANCE_ALIASES, kind);
+}
 
 /**
  * Field-name aliases that, when present alongside a balance field

--- a/src/Tests/E2eMocked/Home/HomeNavOverrideGuard.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/Home/HomeNavOverrideGuard.e2e-mocked.test.ts
@@ -1,0 +1,134 @@
+/**
+ * R3 guard: HOME nav override is target="_blank"-driven.
+ */
+
+import pino from 'pino';
+import { type Browser, type BrowserContext, type Page } from 'playwright-core';
+
+import ScraperError from '../../../Scrapers/Base/ScraperError.js';
+import { createElementMediator } from '../../../Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.js';
+import type { IHomeDiscovery } from '../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { resolveHomeStrategy } from '../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { isOk } from '../../../Scrapers/Pipeline/Types/Procedure.js';
+import { closeSharedBrowser, getSharedBrowser } from '../Helpers/BrowserFixture.js';
+import { loadFixture, setupRequestInterception } from '../Helpers/RequestInterceptor.js';
+
+const MARKETING_URL = 'https://www.example-bank.local/';
+const LOGIN_URL = 'https://digital.example-bank.local/personalarea/Login/';
+const BROWSER_BOOT_TIMEOUT_MS = 30000;
+const TEST_TIMEOUT_MS = 90000;
+
+let browser: Browser;
+
+interface IGuardCase {
+  readonly fixtureRoot: string;
+  readonly expectedOverride: string | undefined;
+}
+
+interface IPreparedPage {
+  readonly context: BrowserContext;
+  readonly page: Page;
+}
+
+type MockRoutes = Parameters<typeof setupRequestInterception>[1];
+type MockRoute = MockRoutes[number];
+
+beforeAll(async () => {
+  browser = await getSharedBrowser();
+}, BROWSER_BOOT_TIMEOUT_MS);
+
+afterAll(async () => {
+  await closeSharedBrowser();
+});
+
+/**
+ * Builds a silent logger for production HOME resolver code.
+ * @returns Silent pino logger.
+ */
+function silentLogger(): pino.Logger {
+  return pino({ enabled: false });
+}
+
+/**
+ * Creates one HTML fixture route.
+ * @param fixtureRoot - Fixture directory under E2eMocked fixtures.
+ * @param fileName - HTML file name inside the fixture directory.
+ * @param match - URL substring matched by the route.
+ * @returns Mock route descriptor.
+ */
+function buildHtmlRoute(fixtureRoot: string, fileName: string, match: string): MockRoute {
+  const fixturePath = `${fixtureRoot}/${fileName}`;
+  const body = loadFixture(fixturePath);
+  return { match, contentType: 'text/html', body };
+}
+
+/**
+ * Creates fixture routes for the requested HOME page shape.
+ * @param fixtureRoot - Fixture directory under E2eMocked fixtures.
+ * @returns Mock route descriptors.
+ */
+function buildRoutes(fixtureRoot: string): MockRoutes {
+  const loginRoute = buildHtmlRoute(fixtureRoot, 'login-page.html', '/personalarea/Login');
+  const marketingRoute = buildHtmlRoute(fixtureRoot, 'marketing-page.html', 'example-bank.local');
+  const abortRoute = { match: /.*/, abort: true };
+  return [loginRoute, marketingRoute, abortRoute];
+}
+
+/**
+ * Opens the marketing fixture with production-like request interception.
+ * @param fixtureRoot - Fixture directory under E2eMocked fixtures.
+ * @returns Fresh browser context and page.
+ */
+async function preparePage(fixtureRoot: string): Promise<IPreparedPage> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const routes = buildRoutes(fixtureRoot);
+  await setupRequestInterception(page, routes);
+  await page.goto(MARKETING_URL, { waitUntil: 'domcontentloaded' });
+  return { context, page };
+}
+
+/**
+ * Resolves the HOME discovery object with real mediator extraction.
+ * @param page - Live fixture page.
+ * @returns HOME discovery.
+ */
+async function resolveDiscovery(page: Page): Promise<IHomeDiscovery> {
+  const mediator = createElementMediator(page);
+  const logger = silentLogger();
+  const discovery = await resolveHomeStrategy(mediator, logger, page);
+  if (!isOk(discovery))
+    throw new ScraperError('HOME PRE expected to resolve in R3 nav-override guard');
+  return discovery.value;
+}
+
+/**
+ * Asserts navHrefOverride for one captured fixture.
+ * @param guardCase - Fixture and expected override contract.
+ * @returns True after assertions complete.
+ */
+async function expectOverride(guardCase: IGuardCase): Promise<boolean> {
+  const { context, page } = await preparePage(guardCase.fixtureRoot);
+  try {
+    const discovery = await resolveDiscovery(page);
+    expect(discovery.navHrefOverride).toBe(guardCase.expectedOverride);
+  } finally {
+    await context.close();
+  }
+  return true;
+}
+
+describe('HOME phase — R3 nav-override target guard', () => {
+  it(
+    'does not attach navHrefOverride for an absolute href without target="_blank"',
+    async () =>
+      expectOverride({ fixtureRoot: 'home-absolute-href-no-blank', expectedOverride: undefined }),
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'attaches navHrefOverride for an absolute href with target="_blank"',
+    async () => expectOverride({ fixtureRoot: 'home-target-blank', expectedOverride: LOGIN_URL }),
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/Tests/E2eMocked/HomeHiddenTwinTrigger.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/HomeHiddenTwinTrigger.e2e-mocked.test.ts
@@ -1,0 +1,158 @@
+/**
+ * HOME trigger resolution — visible/hidden same-text twin. LATENT bug in the
+ * SHARED home resolver, exposed by Bank Leumi's home shape. Mock-E2E test.
+ *
+ * Faithful reproduction of the real Bank Leumi home shape the user reported.
+ * TWO controls share the identical visible text AND aria-label "כניסה לחשבון":
+ *   1. Node A (DOM-FIRST) — an OFF-CANVAS link inside a collapsed search/help
+ *      panel, shifted off-screen (position:absolute; left:-10000px). It keeps
+ *      a real bounding box, so Playwright reports it "visible", but a human
+ *      never sees or reaches it and it FAILS the elementFromPoint hit-test.
+ *      Real Leumi gives it href="#" (a JS search term that surfaces a "how to
+ *      log in" help article); modelled here as a real /help URL so the
+ *      wrong-pick is OBSERVABLE via the final URL. It has NO login form.
+ *   2. Node B (DOM-SECOND) — the GENUINE on-screen login anchor
+ *      (class="enter_account"), targeting /personalarea/Login/.
+ *
+ * WK_HOME.ENTRY has NO candidate selective to the genuine login — every
+ * candidate matches BOTH twins identically (same text, same aria-label). So:
+ *   - origin/main (resolveVisible): every candidate's .first() lands on the
+ *     DOM-first twin (Node A). Node A fails the hit-test, but resolveWinner
+ *     FALLS BACK to fulfilled[0] (Hittest.ts) → returns the off-canvas twin.
+ *   - PR #381 (resolveAllVisible + pickByAccessibleName): the visible set
+ *     keeps the off-canvas twin (hit-test computed but NOT applied —
+ *     Create/Resolve.ts runAllVisibleRace → diag.fulfilledIndices);
+ *     pickByAccessibleName returns the DOM-FIRST 'ariaLabel' match, Node A.
+ * BOTH branches therefore pick the off-canvas decoy and navigate to /help —
+ * empirically confirmed on origin/main. PR #381 did NOT introduce this and
+ * did NOT fix it; it merely surfaced it by migrating the only twin-shaped
+ * bank into the pipeline.
+ *
+ * NOTE: the PR author's offline fixtures modelled the hidden node as
+ * display:none, which Playwright EXCLUDES from the visible set, so those
+ * fixtures could never surface this. Real Leumi uses an off-canvas
+ * (Playwright-visible) node — reproduced faithfully here.
+ *
+ * P0 contract: this is the test-pyramid FOUNDATION. The desired behaviour
+ * (reach the genuine login) currently FAILS on the origin/main baseline, so
+ * it is marked it.failing to document the latent bug while keeping CI green.
+ * P2 applies the GLOBAL resolver fix (prefer a hit-test-passing, real-href
+ * interactive control over an off-canvas/hidden same-text decoy) and flips
+ * this to a passing it(). No production code changes in P0.
+ */
+
+import pino from 'pino';
+import { type Browser, type BrowserContext, type Page } from 'playwright-core';
+
+import ScraperError from '../../Scrapers/Base/ScraperError.js';
+import {
+  createElementMediator,
+  extractActionMediator,
+} from '../../Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.js';
+import { executeHomeNavigation } from '../../Scrapers/Pipeline/Mediator/Home/HomeActions.Navigate.js';
+import { resolveHomeStrategy } from '../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { isOk } from '../../Scrapers/Pipeline/Types/Procedure.js';
+import { closeSharedBrowser, getSharedBrowser } from './Helpers/BrowserFixture.js';
+import { loadFixture, setupRequestInterception } from './Helpers/RequestInterceptor.js';
+
+const HOME_URL = 'https://www.example-bank.local/';
+const REAL_LOGIN_URL = 'https://digital.example-bank.local/personalarea/Login/';
+const LOGIN_PATH = '/personalarea/Login/';
+const BROWSER_BOOT_TIMEOUT_MS = 30000;
+const TEST_TIMEOUT_MS = 90000;
+
+let browser: Browser;
+
+beforeAll(async () => {
+  browser = await getSharedBrowser();
+}, BROWSER_BOOT_TIMEOUT_MS);
+
+afterAll(async () => {
+  await closeSharedBrowser();
+});
+
+/**
+ * Build a silent pino logger suitable for production code that does not
+ * need log inspection.
+ * @returns Silent pino logger.
+ */
+function silentLogger(): pino.Logger {
+  return pino({ enabled: false });
+}
+
+/**
+ * Provision a fresh context+page wired to the home + login + help fixtures.
+ * The home page contains the off-canvas help twin (DOM-first) and the
+ * genuine on-screen login anchor (DOM-second), both with text "כניסה לחשבון".
+ * @returns Fresh context + page (caller must close the context).
+ */
+async function preparePage(): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await setupRequestInterception(page, [
+    {
+      match: '/personalarea/Login',
+      contentType: 'text/html',
+      body: loadFixture('home-hidden-twin/login-page.html'),
+    },
+    {
+      match: '/help/how-to-login',
+      contentType: 'text/html',
+      body: loadFixture('home-hidden-twin/manual-page.html'),
+    },
+    {
+      match: 'www.example-bank.local/',
+      contentType: 'text/html',
+      body: loadFixture('home-hidden-twin/home-page.html'),
+    },
+    {
+      match: /.*/,
+      abort: true,
+    },
+  ]);
+  await page.goto(HOME_URL, { waitUntil: 'domcontentloaded' });
+  return { context, page };
+}
+
+/**
+ * Drive the real HOME PRE→ACTION code path against the provided page.
+ * Same-tab DIRECT anchor — no navHrefOverride is expected; the executor
+ * clicks the resolved trigger and the page navigates in place.
+ * @param page - Live Playwright page (post-home goto).
+ * @returns didNavigate flag from the real production code.
+ */
+async function runHomePreAndAction(page: Page): Promise<{ didNavigate: boolean }> {
+  const logger = silentLogger();
+  const mediator = createElementMediator(page);
+  const discoveryResult = await resolveHomeStrategy(mediator, logger, page);
+  if (!isOk(discoveryResult)) {
+    throw new ScraperError('HOME PRE failed in visible/hidden twin test');
+  }
+  const executor = extractActionMediator(mediator, page);
+  const didNavigate = await executeHomeNavigation(executor, discoveryResult.value, logger);
+  return { didNavigate };
+}
+
+describe('HOME phase — visible/hidden same-text twin (latent shared-resolver bug)', () => {
+  // it.failing: the desired assertion (reach the genuine login) currently
+  // throws on the origin/main baseline because the resolver picks the
+  // off-canvas decoy. P2's global fix flips this to a passing it().
+  it.failing(
+    'resolves the genuine on-screen login, not the off-canvas decoy (fixed globally in P2)',
+    async () => {
+      const { context, page } = await preparePage();
+      try {
+        await runHomePreAndAction(page);
+        const finalUrl = page.url();
+        expect(finalUrl).toContain(LOGIN_PATH);
+        expect(finalUrl).toBe(REAL_LOGIN_URL);
+        const passwordLocator = page.locator('input[type="password"]');
+        const passwordCount = await passwordLocator.count();
+        expect(passwordCount).toBeGreaterThan(0);
+      } finally {
+        await context.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/Tests/E2eMocked/HomeHiddenTwinTrigger.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/HomeHiddenTwinTrigger.e2e-mocked.test.ts
@@ -134,10 +134,13 @@ async function runHomePreAndAction(page: Page): Promise<{ didNavigate: boolean }
 }
 
 describe('HOME phase — visible/hidden same-text twin (latent shared-resolver bug)', () => {
-  // it.failing: the desired assertion (reach the genuine login) currently
-  // throws on the origin/main baseline because the resolver picks the
-  // off-canvas decoy. P2's global fix flips this to a passing it().
-  it.failing(
+  // P2 global fix landed (two layers): PRE — passive resolveVisible is
+  // nth-aware + hit-test winner-picking, so it resolves the genuine
+  // on-screen login over the off-canvas decoy; ACTION — buildIdentitySelector
+  // conjoins the distinct href onto the shared aria-label, so the click
+  // targets that exact element instead of re-resolving to the DOM-first
+  // decoy. (Was it.failing on the buggy baseline.)
+  it(
     'resolves the genuine on-screen login, not the off-canvas decoy (fixed globally in P2)',
     async () => {
       const { context, page } = await preparePage();

--- a/src/Tests/E2eMocked/Oracle/HomeOracle.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/Oracle/HomeOracle.e2e-mocked.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+
+import pino from 'pino';
+import { type Browser, type BrowserContext, type Page } from 'playwright-core';
+
+import ScraperError from '../../../Scrapers/Base/ScraperError.js';
+import {
+  createElementMediator,
+  extractActionMediator,
+} from '../../../Scrapers/Pipeline/Mediator/Elements/CreateElementMediator.js';
+import { executeHomeNavigation } from '../../../Scrapers/Pipeline/Mediator/Home/HomeActions.Navigate.js';
+import { resolveHomeStrategy } from '../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { isOk } from '../../../Scrapers/Pipeline/Types/Procedure.js';
+import { closeSharedBrowser, getSharedBrowser } from '../Helpers/BrowserFixture.js';
+import { setupRequestInterception } from '../Helpers/RequestInterceptor.js';
+
+const HOME_URL = 'https://www.example-bank.local/';
+const REAL_LOGIN_URL = 'https://digital.example-bank.local/personalarea/Login/';
+const LOGIN_PATH = '/personalarea/Login/';
+const BROWSER_BOOT_TIMEOUT_MS = 30000;
+const TEST_TIMEOUT_MS = 90000;
+
+let browser: Browser;
+
+interface IPreparedPage {
+  readonly context: BrowserContext;
+  readonly page: Page;
+}
+
+type MockRoutes = Parameters<typeof setupRequestInterception>[1];
+
+/**
+ * Loads a PII-free oracle HTML fixture.
+ * @param relativePath - Fixture path below this test directory.
+ * @returns Fixture body.
+ */
+function loadOracleFixture(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+const HOME_ROUTES: MockRoutes = [
+  {
+    match: '/personalarea/Login',
+    contentType: 'text/html',
+    body: loadOracleFixture('fixtures/home/login.html'),
+  },
+  {
+    match: '/help/how-to-login',
+    contentType: 'text/html',
+    body: loadOracleFixture('fixtures/home/manual.html'),
+  },
+  {
+    match: 'www.example-bank.local/',
+    contentType: 'text/html',
+    body: loadOracleFixture('fixtures/home/home.html'),
+  },
+  { match: /.*/, abort: true },
+];
+
+beforeAll(async () => {
+  browser = await getSharedBrowser();
+}, BROWSER_BOOT_TIMEOUT_MS);
+
+afterAll(async () => {
+  await closeSharedBrowser();
+});
+
+/**
+ * Builds a silent logger for production HOME code.
+ * @returns Silent pino logger.
+ */
+function silentLogger(): pino.Logger {
+  return pino({ enabled: false });
+}
+
+/**
+ * Opens the representative home fixture.
+ * @returns Fresh browser context and page.
+ */
+async function preparePage(): Promise<IPreparedPage> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await setupRequestInterception(page, HOME_ROUTES);
+  await page.goto(HOME_URL, { waitUntil: 'domcontentloaded' });
+  return { context, page };
+}
+
+/**
+ * Runs HOME PRE and ACTION through production mediators.
+ * @param page - Live fixture page.
+ * @returns Navigation outcome.
+ */
+async function runHomePreAndAction(page: Page): Promise<{ readonly didNavigate: boolean }> {
+  const logger = silentLogger();
+  const mediator = createElementMediator(page);
+  const result = await resolveHomeStrategy(mediator, logger, page);
+  if (!isOk(result)) throw new ScraperError('HOME PRE failed in oracle');
+  const executor = extractActionMediator(mediator, page);
+  return { didNavigate: await executeHomeNavigation(executor, result.value, logger) };
+}
+
+describe('Leumi oracle — home trigger readiness', () => {
+  it(
+    'resolves the hit-test-passing login control over an off-canvas same-name twin',
+    async () => {
+      const { context, page } = await preparePage();
+      try {
+        await runHomePreAndAction(page);
+        const finalUrl = page.url();
+        const passwordCount = await page.getByPlaceholder('סיסמה').count();
+        expect(finalUrl).toBe(REAL_LOGIN_URL);
+        expect(passwordCount).toBe(1);
+        expect(finalUrl).toContain(LOGIN_PATH);
+      } finally {
+        await context.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/Tests/E2eMocked/Oracle/fixtures/home/home.html
+++ b/src/Tests/E2eMocked/Oracle/fixtures/home/home.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>דף בית אורקל</title>
+    <style>
+      .collapsed-search {
+        position: absolute;
+        left: -10000px;
+        top: 0;
+        width: 280px;
+      }
+      .collapsed-search a {
+        display: inline-block;
+        height: 44px;
+        line-height: 44px;
+        width: 260px;
+      }
+      .primary-login {
+        display: inline-block;
+        padding: 12px 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>בנק מדומה</h1>
+      <nav class="collapsed-search" aria-label="חיפוש">
+        <a aria-label="כניסה לחשבון" href="https://www.example-bank.local/help/how-to-login"
+          >כניסה לחשבון</a
+        >
+      </nav>
+    </header>
+    <main>
+      <a
+        class="primary-login enter_account"
+        aria-label="כניסה לחשבון"
+        href="https://digital.example-bank.local/personalarea/Login/"
+        >כניסה לחשבון</a
+      >
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/Oracle/fixtures/home/login.html
+++ b/src/Tests/E2eMocked/Oracle/fixtures/home/login.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>דף התחברות אורקל</title>
+  </head>
+  <body>
+    <main>
+      <h1>התחברות לחשבון</h1>
+      <form>
+        <label for="user">תעודת זהות</label>
+        <input id="user" type="text" name="id" placeholder="תעודת זהות" />
+        <label for="pwd">סיסמה</label>
+        <input id="pwd" type="password" name="password" placeholder="סיסמה" />
+        <button type="submit">כניסה</button>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/Oracle/fixtures/home/manual.html
+++ b/src/Tests/E2eMocked/Oracle/fixtures/home/manual.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>עזרה בהתחברות</title>
+  </head>
+  <body>
+    <main>
+      <h1>עזרה בהתחברות</h1>
+      <p>עמוד עזרה בלבד ללא טופס התחברות.</p>
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/fixtures/dashboard-marker-and-dashboard-present/scenario.json
+++ b/src/Tests/E2eMocked/fixtures/dashboard-marker-and-dashboard-present/scenario.json
@@ -1,0 +1,3 @@
+{
+  "sequence": ["found", "found"]
+}

--- a/src/Tests/E2eMocked/fixtures/dashboard-probe-error/scenario.json
+++ b/src/Tests/E2eMocked/fixtures/dashboard-probe-error/scenario.json
@@ -1,0 +1,3 @@
+{
+  "sequence": ["throw"]
+}

--- a/src/Tests/E2eMocked/fixtures/home-absolute-href-no-blank/login-page.html
+++ b/src/Tests/E2eMocked/fixtures/home-absolute-href-no-blank/login-page.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>דף ההתחברות</title>
+  </head>
+  <body>
+    <main>
+      <h1>התחברות לחשבון</h1>
+      <form>
+        <label for="user">תעודת זהות</label>
+        <input id="user" type="text" name="id" placeholder="תעודת זהות" />
+        <label for="pwd">סיסמה</label>
+        <input id="pwd" type="password" name="password" placeholder="סיסמה" />
+        <button type="submit">כניסה</button>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/fixtures/home-absolute-href-no-blank/marketing-page.html
+++ b/src/Tests/E2eMocked/fixtures/home-absolute-href-no-blank/marketing-page.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>אתר השיווק — קישור רגיל</title>
+  </head>
+  <body>
+    <header>
+      <h1>אתר השיווק של הבנק</h1>
+      <nav>
+        <a
+          aria-label="כניסה לחשבון שלי"
+          href="https://digital.example-bank.local/personalarea/Login/"
+        >
+          החשבון שלי
+        </a>
+      </nav>
+    </header>
+    <main>
+      <p>קישור התחברות רגיל עם כתובת מלאה, ללא פתיחה בלשונית חדשה.</p>
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/fixtures/home-hidden-twin/home-page.html
+++ b/src/Tests/E2eMocked/fixtures/home-hidden-twin/home-page.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>בנק לדוגמה — דף הבית</title>
+    <style>
+      /* Off-canvas nav: present in the DOM with a REAL bounding box, so
+         Playwright's waitFor({state:'visible'}) reports it visible — but it
+         is shifted far off-screen, so a human never sees or reaches it and
+         document.elementFromPoint at its centre returns nothing (fails the
+         hit-test). This mirrors a real bank's off-canvas burger menu. It is
+         deliberately NOT display:none — Playwright would EXCLUDE a
+         display:none node from the visible set, and then neither the old
+         nor the new resolver could ever pick it. */
+      .offcanvas-nav {
+        position: absolute;
+        left: -10000px;
+        top: 0;
+        width: 280px;
+      }
+      .offcanvas-nav a {
+        display: inline-block;
+        width: 260px;
+        height: 44px;
+        line-height: 44px;
+      }
+      .primary-login {
+        display: inline-block;
+        padding: 12px 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>בנק לדוגמה</h1>
+      <!-- DOM-FIRST twin: same visible text + accessible name "כניסה לחשבון",
+           but this is the off-canvas "how to log in / open an account" HELP
+           link. Shifted off-screen — a human never sees it; Playwright still
+           reports it visible (non-empty bbox, not display:none). It targets
+           the help page, which has NO login form. -->
+      <nav class="offcanvas-nav" aria-label="תפריט נייד">
+        <a
+          class="offcanvas-help-login"
+          aria-label="כניסה לחשבון"
+          href="https://www.example-bank.local/help/how-to-login"
+          >כניסה לחשבון</a
+        >
+      </nav>
+    </header>
+    <main>
+      <p>ברוכים הבאים. להתחברות לחשבון הפרטי לחצו על הכפתור.</p>
+      <!-- DOM-SECOND twin: the GENUINE, on-screen login control the user
+           actually clicks. Identical visible text + accessible name as the
+           off-canvas help link above; this one passes the hit-test and
+           targets the real login page. -->
+      <a
+        class="primary-login enter_account"
+        aria-label="כניסה לחשבון"
+        href="https://digital.example-bank.local/personalarea/Login/"
+        >כניסה לחשבון</a
+      >
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/fixtures/home-hidden-twin/login-page.html
+++ b/src/Tests/E2eMocked/fixtures/home-hidden-twin/login-page.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>דף ההתחברות</title>
+  </head>
+  <body>
+    <main>
+      <h1>התחברות לחשבון</h1>
+      <form>
+        <label for="user">תעודת זהות</label>
+        <input id="user" type="text" name="id" placeholder="תעודת זהות" />
+        <label for="pwd">סיסמה</label>
+        <input id="pwd" type="password" name="password" placeholder="סיסמה" />
+        <button type="submit">כניסה</button>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/Tests/E2eMocked/fixtures/home-hidden-twin/manual-page.html
+++ b/src/Tests/E2eMocked/fixtures/home-hidden-twin/manual-page.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>איך נכנסים לחשבון — מדריך</title>
+  </head>
+  <body>
+    <main>
+      <h1>איך נכנסים לחשבון או פותחים חשבון חדש</h1>
+      <p>מדריך שלב-אחר-שלב. אין כאן טופס התחברות.</p>
+    </main>
+  </body>
+</html>

--- a/src/Tests/Oracle/Leumi/BalanceOracle.test.ts
+++ b/src/Tests/Oracle/Leumi/BalanceOracle.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+import { runBalanceExtractorWith } from '../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceExtractor.js';
+import { ACCOUNT_KIND } from '../../../Scrapers/Pipeline/Registry/WK/BalanceKind.js';
+import { scopedResolveBalanceAliases } from '../../../Scrapers/Pipeline/Registry/WK/BalanceResolveWK.js';
+import type { JsonValue } from '../../../Scrapers/Pipeline/Types/JsonValue.js';
+import unwrapWcfForFixture from './unwrapWcfForFixture.js';
+
+/** Expected account balance carried by the representative fixture. */
+const EXPECTED_ACCOUNT_BALANCE = 4321.5;
+
+/**
+ * Loads a JSON oracle fixture.
+ * @param relativePath - Fixture path below this directory.
+ * @returns Parsed JSON fixture.
+ */
+function loadJsonFixture(relativePath: string): JsonValue {
+  const raw = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+  return JSON.parse(raw) as JsonValue;
+}
+
+describe('Leumi oracle — balance account-family readiness', () => {
+  it('unwraps the fixture envelope outside production and resolves the account balance', () => {
+    const envelope = loadJsonFixture('fixtures/balance/account-wcf.json');
+    const plainBody = unwrapWcfForFixture(envelope);
+    const aliases = scopedResolveBalanceAliases(ACCOUNT_KIND);
+    const resolved = runBalanceExtractorWith(plainBody, aliases);
+    expect(resolved).toBe(EXPECTED_ACCOUNT_BALANCE);
+  });
+});

--- a/src/Tests/Oracle/Leumi/DashboardOracle.test.ts
+++ b/src/Tests/Oracle/Leumi/DashboardOracle.test.ts
@@ -1,0 +1,76 @@
+import { ScraperErrorTypes } from '../../../Scrapers/Base/ErrorTypes.js';
+import checkChangePassword from '../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardProbe.js';
+import type {
+  IElementMediator,
+  IRaceResult,
+} from '../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import { NOT_FOUND_RESULT } from '../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+
+/** Per-call behaviour for the representative dashboard marker probe. */
+type ProbeBehaviour = 'found' | 'missing' | 'throw';
+
+/** A race result whose marker is present. */
+const FOUND_RESULT: IRaceResult = { ...NOT_FOUND_RESULT, found: true as const };
+
+/**
+ * Resolves one scripted probe behaviour.
+ * @param behaviour - Probe behaviour.
+ * @returns Probe result promise.
+ */
+function resolveProbeBehaviour(behaviour: ProbeBehaviour): Promise<IRaceResult> {
+  if (behaviour === 'throw') return Promise.reject(new Error('oracle-probe-error'));
+  return Promise.resolve(behaviour === 'found' ? FOUND_RESULT : NOT_FOUND_RESULT);
+}
+
+/**
+ * Builds a scripted visibility probe.
+ * @param sequence - Per-call probe behaviours.
+ * @returns Visibility probe callback.
+ */
+function makeResolveVisible(sequence: readonly ProbeBehaviour[]): () => Promise<IRaceResult> {
+  let call = -1;
+  return (): Promise<IRaceResult> => {
+    call += 1;
+    return resolveProbeBehaviour(sequence[call] ?? 'missing');
+  };
+}
+
+/**
+ * Builds a mediator whose visibility probe follows a fixed sequence.
+ * @param sequence - Per-call probe behaviours.
+ * @returns Mock element mediator.
+ */
+function makeSequencedMediator(sequence: readonly ProbeBehaviour[]): IElementMediator {
+  return { resolveVisible: makeResolveVisible(sequence) } as unknown as IElementMediator;
+}
+
+/**
+ * Asserts a typed Procedure failure.
+ * @param result - Dashboard probe result.
+ * @param errorType - Expected error type.
+ * @returns True after assertions.
+ */
+function assertProbeFailure(
+  result: Awaited<ReturnType<typeof checkChangePassword>>,
+  errorType: ScraperErrorTypes,
+): true {
+  expect(result).not.toBe(false);
+  if (result && typeof result === 'object') expect(result.success).toBe(false);
+  if (result && typeof result === 'object' && !result.success)
+    expect(result.errorType).toBe(errorType);
+  return true;
+}
+
+describe('Leumi oracle — dashboard fail-closed readiness', () => {
+  it('returns a forced-password failure for a change-password marker capture', async () => {
+    const mediator = makeSequencedMediator(['found']);
+    const result = await checkChangePassword(mediator);
+    assertProbeFailure(result, ScraperErrorTypes.ChangePassword);
+  });
+
+  it('returns a typed failure when the dashboard probe errors', async () => {
+    const mediator = makeSequencedMediator(['throw']);
+    const result = await checkChangePassword(mediator);
+    assertProbeFailure(result, ScraperErrorTypes.Generic);
+  });
+});

--- a/src/Tests/Oracle/Leumi/HomeNavOracle.test.ts
+++ b/src/Tests/Oracle/Leumi/HomeNavOracle.test.ts
@@ -1,0 +1,150 @@
+import pino from 'pino';
+import type { Page } from 'playwright-core';
+
+import ScraperError from '../../../Scrapers/Base/ScraperError.js';
+import type {
+  IElementMediator,
+  IRaceResult,
+} from '../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import { NOT_FOUND_RESULT } from '../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { IHomeDiscovery } from '../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { resolveHomeStrategy } from '../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import { isOk, succeed } from '../../../Scrapers/Pipeline/Types/Procedure.js';
+
+const LOGIN_HREF = 'https://digital.example-bank.local/personalarea/Login/';
+const LOGIN_LABEL = 'כניסה לחשבון';
+
+/** Per-attribute scripted values for a representative home control. */
+interface IAttrResponses {
+  readonly target: string;
+  readonly href: string;
+}
+
+/**
+ * Builds a representative visible control result.
+ * @returns Visible control result.
+ */
+function makeVisibleResult(): IRaceResult {
+  return { ...NOT_FOUND_RESULT, found: true as const, value: LOGIN_LABEL };
+}
+
+/**
+ * Reads scripted target and href values.
+ * @param responses - Scripted attribute values.
+ * @param attr - Attribute name.
+ * @returns Scripted attribute value.
+ */
+function readAttributeValue(responses: IAttrResponses, attr: string): string {
+  return attr === 'target' ? responses.target : responses.href;
+}
+
+/**
+ * Scripted mediator for representative home-control attributes.
+ */
+class ScriptedHomeMediator {
+  private readonly _presence = succeed(true);
+  private readonly _visible = makeVisibleResult();
+
+  /**
+   * Stores scripted attribute responses.
+   * @param _responses - Scripted attribute values.
+   */
+  constructor(private readonly _responses: IAttrResponses) {}
+
+  /**
+   * Resolves the representative visible control.
+   * @returns Visible control.
+   */
+  public resolveVisible(): Promise<IRaceResult> {
+    return Promise.resolve(this._visible);
+  }
+
+  /**
+   * Resolves the representative visible control list.
+   * @returns Visible control list.
+   */
+  public resolveAllVisible(): Promise<readonly IRaceResult[]> {
+    return Promise.resolve([this._visible]);
+  }
+
+  /**
+   * Reports that the representative control carries probed attributes.
+   * @returns Attribute-presence result.
+   */
+  public checkAttribute(): ReturnType<IElementMediator['checkAttribute']> {
+    return Promise.resolve(this._presence);
+  }
+
+  /**
+   * Reads scripted target and href values.
+   * @param _race - Ignored resolved control.
+   * @param attr - Attribute name.
+   * @returns Scripted attribute value.
+   */
+  public getAttributeValue(_race: IRaceResult, attr: string): Promise<string> {
+    const value = readAttributeValue(this._responses, attr);
+    return Promise.resolve(value);
+  }
+}
+
+/**
+ * Builds a mediator that resolves one representative visible anchor.
+ * @param responses - Scripted attribute values.
+ * @returns Mock element mediator.
+ */
+function makeHomeMediator(responses: IAttrResponses): IElementMediator {
+  return new ScriptedHomeMediator(responses) as unknown as IElementMediator;
+}
+
+/**
+ * Minimal page stub for HOME PRE.
+ * @returns Page stub.
+ */
+function makePageStub(): Page {
+  return {
+    /**
+     * Page URL.
+     * @returns Static home URL.
+     */
+    url: (): string => 'https://www.example-bank.local/',
+    /**
+     * Page frames.
+     * @returns Empty frame list.
+     */
+    frames: (): Page[] => [],
+  } as unknown as Page;
+}
+
+/**
+ * Builds a silent logger for HOME PRE.
+ * @returns Silent pino logger.
+ */
+function silentLogger(): pino.Logger {
+  return pino({ enabled: false });
+}
+
+/**
+ * Resolves HOME PRE for one representative control.
+ * @param responses - Scripted attribute values.
+ * @returns Discovery result.
+ */
+async function runResolve(responses: IAttrResponses): Promise<IHomeDiscovery> {
+  const mediator = makeHomeMediator(responses);
+  const page = makePageStub();
+  const logger = silentLogger();
+  const result = await resolveHomeStrategy(mediator, logger, page);
+  if (!isOk(result)) throw new ScraperError('HOME PRE expected to succeed in oracle');
+  return result.value;
+}
+
+describe('Leumi oracle — home nav override readiness', () => {
+  it('does not attach a nav override when the representative control lacks target blank', async () => {
+    const discovery = await runResolve({ target: '', href: LOGIN_HREF });
+    expect(discovery.navHrefOverride).toBeUndefined();
+  });
+
+  it('attaches a nav override only when the representative control opens a new tab', async () => {
+    const discovery = await runResolve({ target: '_blank', href: LOGIN_HREF });
+    expect(discovery.navHrefOverride).toBe(LOGIN_HREF);
+  });
+});

--- a/src/Tests/Oracle/Leumi/fixtures/balance/account-wcf.json
+++ b/src/Tests/Oracle/Leumi/fixtures/balance/account-wcf.json
@@ -1,0 +1,9 @@
+{
+  "Envelope": {
+    "Body": {
+      "GetAccountDataResponse": {
+        "GetAccountDataResult": "{\"accounts\":[{\"nextTotalDebit\":9999,\"currentBalance\":\"4321.5\",\"currency\":376}]}"
+      }
+    }
+  }
+}

--- a/src/Tests/Oracle/Leumi/unwrapWcfForFixture.ts
+++ b/src/Tests/Oracle/Leumi/unwrapWcfForFixture.ts
@@ -1,0 +1,60 @@
+import ScraperError from '../../../Scrapers/Base/ScraperError.js';
+import type { JsonValue } from '../../../Scrapers/Pipeline/Types/JsonValue.js';
+
+type JsonObject = Record<string, JsonValue>;
+
+/** Message used when a representative SOAP/WCF fixture is malformed. */
+const INVALID_WCF_FIXTURE = 'invalid SOAP/WCF oracle fixture';
+
+/**
+ * Checks whether a JSON value is an object record.
+ * @param value - Candidate JSON value.
+ * @returns True when the value is a non-array object.
+ */
+function isRecord(value: JsonValue): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parses a JSON string payload carried inside a SOAP/WCF result field.
+ * @param payload - Result payload from the fixture envelope.
+ * @returns Parsed JSON or false when the payload is invalid.
+ */
+function parsePayload(payload: JsonValue): JsonValue | false {
+  if (typeof payload !== 'string') return false;
+  try {
+    return JSON.parse(payload) as JsonValue;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reads the synthetic Broker-style result slot from the fixture envelope.
+ * @param envelope - Fixture-level SOAP/WCF wrapper.
+ * @returns String payload when present, otherwise false.
+ */
+function readResultSlot(envelope: JsonValue): JsonValue | false {
+  if (!isRecord(envelope) || !isRecord(envelope.Envelope)) return false;
+  const body = envelope.Envelope.Body;
+  if (!isRecord(body) || !isRecord(body.GetAccountDataResponse)) return false;
+  return body.GetAccountDataResponse.GetAccountDataResult ?? false;
+}
+
+/**
+ * Unwraps a representative SOAP/WCF fixture before generic parsing.
+ *
+ * This mirrors the documented future-adapter boundary: envelope unwrap
+ * belongs outside the shared response path, and tests hand plain JSON to
+ * the generic parser/extractor seam.
+ *
+ * @param envelope - Synthetic SOAP/WCF fixture payload.
+ * @returns Plain JSON body for generic pipeline seams.
+ * @throws Error when the fixture does not match the representative shape.
+ */
+export default function unwrapWcfForFixture(envelope: JsonValue): JsonValue {
+  const resultSlot = readResultSlot(envelope);
+  const parsed = parsePayload(resultSlot);
+  if (parsed === false) throw new ScraperError(INVALID_WCF_FIXTURE);
+  return parsed;
+}

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeDeepLoginPhaseContext.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/Fixtures/_makeDeepLoginPhaseContext.ts
@@ -94,11 +94,11 @@ function composeDeepLoginContext(args: IDeepLoginContextArgs): IPipelineContext 
 }
 
 /**
- * Build the deep LOGIN pipeline config. Extracted so the composer stays
- * under the 10-line cap now that `balanceKind` is a required field.
+ * Build the LOGIN-phase pipeline config. Split out so
+ * {@link composeDeepLoginContext} stays under the 10-line cap.
  *
- * @param loginUrl - Base URL for the pipeline config.
- * @returns Pipeline config with a required account `balanceKind`.
+ * @param loginUrl - Base URL the bank's login page is served from.
+ * @returns Pipeline config carrying the account balanceKind.
  */
 function buildDeepLoginConfig(loginUrl: string): IPipelineContext['config'] {
   return { urls: { base: loginUrl }, balanceKind: 'account' };

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceKindScoping.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceKindScoping.test.ts
@@ -1,0 +1,150 @@
+/**
+ * R1 hardening — `BalanceKind` family-scoping fire-tests.
+ *
+ * Proves the two balance paths resolve the bank's DECLARED family and
+ * never bleed across families:
+ *  - PRIMARY (BALANCE-RESOLVE): `runBalanceExtractorWith` scoped by
+ *    {@link scopedResolveBalanceAliases}.
+ *  - LEGACY (SCRAPE fieldMap): `resolveFieldMapOrEmpty` scoped by
+ *    {@link scopedTxnBalanceAliases}.
+ *
+ * Each discrimination test FIRES (fails) against the pre-fix unscoped
+ * code (which always resolved the account-first `balance` alias) and
+ * passes only once scoping restricts the scan to the declared family.
+ *
+ * Also guards the invariants the design relies on: the two families
+ * partition the alias surface, and every migrated bank declares a kind.
+ */
+
+import { CompanyTypes } from '../../../../../Definitions.js';
+import {
+  runBalanceExtractor,
+  runBalanceExtractorWith,
+} from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceExtractor.js';
+import resolveFieldMapOrEmpty, {
+  scopedTxnBalanceAliases,
+} from '../../../../../Scrapers/Pipeline/Mediator/Scrape/EndpointResolver/EndpointFieldMap.js';
+import {
+  ACCOUNT_BALANCE_FAMILY,
+  ACCOUNT_KIND,
+  type BalanceKind,
+  CARD_CYCLE_BALANCE_FAMILY,
+  CARD_CYCLE_KIND,
+} from '../../../../../Scrapers/Pipeline/Registry/WK/BalanceKind.js';
+import {
+  PIPELINE_BALANCE_ALIASES,
+  scopedResolveBalanceAliases,
+} from '../../../../../Scrapers/Pipeline/Registry/WK/BalanceResolveWK.js';
+import { PIPELINE_WELL_KNOWN_TXN_FIELDS as WK } from '../../../../../Scrapers/Pipeline/Registry/WK/ScrapeWK.js';
+import type { JsonValue } from '../../../../../Scrapers/Pipeline/Types/JsonValue.js';
+
+/** Account value carried by the discriminating fixtures. */
+const ACCOUNT_VALUE = 999;
+
+/** Card-cycle debit value carried by the discriminating fixtures. */
+const CARD_CYCLE_VALUE = 1800;
+
+/**
+ * Record carrying BOTH an account-ish (`balance`) and a card-cycle
+ * (`nextTotalDebit`) field. Without scoping the account-first lists
+ * always win `balance`; scoping flips a card bank onto its debit.
+ */
+const MIXED_BODY: JsonValue = { balance: ACCOUNT_VALUE, nextTotalDebit: CARD_CYCLE_VALUE };
+
+/** Banks whose balance is a credit-card billing-cycle debit total. */
+const EXPECTED_CARD_CYCLE_BANKS: readonly CompanyTypes[] = [
+  CompanyTypes.VisaCal,
+  CompanyTypes.Amex,
+  CompanyTypes.Max,
+  CompanyTypes.Isracard,
+];
+
+describe('BalanceKind — family classification invariants', () => {
+  const unionAliases = [...new Set([...PIPELINE_BALANCE_ALIASES, ...WK.balance])];
+
+  it('declares exactly 9 account + 7 card-cycle aliases', () => {
+    expect(ACCOUNT_BALANCE_FAMILY.size).toBe(9);
+    expect(CARD_CYCLE_BALANCE_FAMILY.size).toBe(7);
+  });
+
+  it.each(unionAliases)('classifies %s into exactly one family', alias => {
+    const isInAccount = ACCOUNT_BALANCE_FAMILY.has(alias);
+    const isInCardCycle = CARD_CYCLE_BALANCE_FAMILY.has(alias);
+    expect(Number(isInAccount) + Number(isInCardCycle)).toBe(1);
+  });
+});
+
+describe('PRIMARY balance extractor — BalanceKind scoping', () => {
+  it('resolves the card-cycle debit when scoped to card-cycle', () => {
+    const aliases = scopedResolveBalanceAliases(CARD_CYCLE_KIND);
+    const resolved = runBalanceExtractorWith(MIXED_BODY, aliases);
+    expect(resolved).toBe(CARD_CYCLE_VALUE);
+  });
+
+  it('resolves the running balance when scoped to account', () => {
+    const aliases = scopedResolveBalanceAliases(ACCOUNT_KIND);
+    const resolved = runBalanceExtractorWith(MIXED_BODY, aliases);
+    expect(resolved).toBe(ACCOUNT_VALUE);
+  });
+
+  it('documents the latent bleed of the unscoped entry point', () => {
+    const resolved = runBalanceExtractor(MIXED_BODY);
+    expect(resolved).toBe(ACCOUNT_VALUE);
+  });
+});
+
+describe('LEGACY fieldMap balance — BalanceKind scoping', () => {
+  const sample = { OperationDate: '2026-01-01', OperationAmount: 10, ...MIXED_BODY };
+
+  it('selects the card-cycle alias when scoped to card-cycle', () => {
+    const aliases = scopedTxnBalanceAliases(CARD_CYCLE_KIND);
+    expect(resolveFieldMapOrEmpty([sample], aliases).balance).toBe('nextTotalDebit');
+  });
+
+  it('selects the account alias when scoped to account', () => {
+    const aliases = scopedTxnBalanceAliases(ACCOUNT_KIND);
+    expect(resolveFieldMapOrEmpty([sample], aliases).balance).toBe('balance');
+  });
+
+  it('falls back to the account-first alias when unscoped', () => {
+    expect(resolveFieldMapOrEmpty([sample]).balance).toBe('balance');
+  });
+});
+
+describe('Per-bank balanceKind declaration', () => {
+  /**
+   * Dynamically loads the bank-config registry entries.
+   *
+   * Pipeline tests may not statically import `Registry/Config`; the
+   * dynamic form is the sanctioned escape for registry invariants.
+   *
+   * @returns every company-id → config entry (all non-nullish).
+   */
+  async function loadEntries(): Promise<[string, { readonly balanceKind: BalanceKind }][]> {
+    const mod =
+      await import('../../../../../Scrapers/Pipeline/Registry/Config/PipelineBankConfig.js');
+    return Object.entries(mod.PIPELINE_BANK_CONFIG);
+  }
+
+  it('registers all 14 migrated banks', async () => {
+    const entries = await loadEntries();
+    expect(entries).toHaveLength(14);
+  });
+
+  it('declares a valid balanceKind for every bank', async () => {
+    const entries = await loadEntries();
+    const validKinds: BalanceKind[] = [ACCOUNT_KIND, CARD_CYCLE_KIND];
+    const isEveryKindValid = entries.every(entry => validKinds.includes(entry[1].balanceKind));
+    expect(isEveryKindValid).toBe(true);
+  });
+
+  it('marks exactly the four card-cycle banks', async () => {
+    const entries = await loadEntries();
+    const cardCycleBanks = entries
+      .filter(entry => entry[1].balanceKind === CARD_CYCLE_KIND)
+      .map(entry => entry[0]);
+    const got = [...cardCycleBanks].sort();
+    const want = [...EXPECTED_CARD_CYCLE_BANKS].sort();
+    expect(got).toEqual(want);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceSuppressionGuard.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/BalanceResolve/BalanceSuppressionGuard.test.ts
@@ -1,0 +1,114 @@
+/**
+ * REGRESSION GUARD — R1 account balance MUST NOT be pool-suppressed.
+ *
+ * Locks the origin/main contract: when SCRAPE emits account identities +
+ * a non-empty (dedicated) balance-fetch template, BALANCE-RESOLVE.pre
+ * MUST commit a non-empty fetch plan so the live balance fetch proceeds,
+ * regardless of what the already-captured network pool happens to hold.
+ *
+ * <p>PR #381 added a `poolDisprovesBalance` heuristic: when a non-empty
+ * captured pool carries no balance, it swaps the template for EMPTY and
+ * suppresses the fetch. That mislabels account banks whose balance lives
+ * behind a dedicated endpoint (its own JSDoc names "Beinleumi") — their
+ * transactions-only pool "disproves" a balance that the live fetch would
+ * have retrieved, yielding a false 0 balance.
+ *
+ * <p>Fire proof: GREEN on origin/main (mediator/pool ignored — the plan
+ * is built straight from the template). RED against PR #381 (the pool
+ * suppresses the template ⇒ EMPTY_PLAN ⇒ length 0). The positive control
+ * (no pool) stays GREEN on both, isolating the pool as the sole cause.
+ */
+
+import { executeBalanceResolvePre } from '../../../../../Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.js';
+import type { IElementMediator } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { IDiscoveredEndpoint } from '../../../../../Scrapers/Pipeline/Mediator/Network/Types/Endpoint.js';
+import { none, some } from '../../../../../Scrapers/Pipeline/Types/Option.js';
+import type {
+  IAccountIdentity,
+  IBalanceFetchTemplate,
+  IPipelineContext,
+} from '../../../../../Scrapers/Pipeline/Types/PipelineContext.js';
+import { isOk } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+import { makeMockContext } from '../../Infrastructure/MockFactories.js';
+
+/** Account-bank id under test (account-kind, not card-cycle). */
+const ACCOUNT_BA = 'BA-ACCOUNT-7781';
+
+/** Dedicated per-account balance endpoint SCRAPE emits (non-empty url). */
+const DEDICATED_TEMPLATE: IBalanceFetchTemplate = {
+  url: 'https://account-bank.example/api/GetBalance',
+  method: 'GET',
+  urlQueryKey: 'acct',
+};
+
+/** Captured body carrying transactions only — NO balance field anywhere. */
+const TXNS_ONLY_BODY = { marker: 'transactions-only-no-balance' };
+
+/**
+ * Build a single account-identity map (account-kind bank).
+ * @returns One-entry identity map keyed by the bank-account id.
+ */
+function oneAccountIdentity(): ReadonlyMap<string, IAccountIdentity> {
+  const identity: IAccountIdentity = {
+    cardDisplayId: ACCOUNT_BA,
+    cardUniqueId: `UID-${ACCOUNT_BA}`,
+    bankAccountUniqueId: ACCOUNT_BA,
+  };
+  return new Map([[ACCOUNT_BA, identity]]);
+}
+
+/**
+ * Build the SCRAPE option: account identities + a non-empty template.
+ * @returns Option<IScrapeState> threaded into the mock context.
+ */
+function accountScrape(): IPipelineContext['scrape'] {
+  return some({
+    accounts: [],
+    accountIdentities: oneAccountIdentity(),
+    balanceFetchTemplate: DEDICATED_TEMPLATE,
+  });
+}
+
+/**
+ * Captured-pool reader returning the single balance-free endpoint.
+ * @returns One-entry endpoint list whose body carries no balance.
+ */
+function getNoBalancePool(): readonly IDiscoveredEndpoint[] {
+  const endpoint = { responseBody: TXNS_ONLY_BODY } as unknown as IDiscoveredEndpoint;
+  return [endpoint];
+}
+
+/**
+ * Build a mediator whose captured pool carries a non-empty,
+ * balance-free transactions body (PR #381's suppression trigger).
+ * @returns Option<IElementMediator> wired with one no-balance endpoint.
+ */
+function poolMediator(): IPipelineContext['mediator'] {
+  const network = { getAllEndpoints: getNoBalancePool };
+  return some({ network } as unknown as IElementMediator);
+}
+
+/**
+ * Run PRE and return the committed balance-fetch-plan length (−1 when
+ * PRE failed or committed no plan).
+ * @param ctx - Pipeline context for BALANCE-RESOLVE.pre.
+ * @returns Committed plan length, or −1.
+ */
+async function committedPlanLength(ctx: IPipelineContext): Promise<number> {
+  const result = await executeBalanceResolvePre(ctx);
+  if (!isOk(result)) return -1;
+  const plan = result.value.balanceFetchPlan;
+  return plan.has ? plan.value.length : -1;
+}
+
+describe('REGRESSION GUARD — R1 account balance not pool-suppressed', () => {
+  it('builds a non-empty plan for an account bank despite a balance-free captured pool', async () => {
+    const ctx = makeMockContext({ scrape: accountScrape(), mediator: poolMediator() });
+    expect(await committedPlanLength(ctx)).toBeGreaterThanOrEqual(1);
+  });
+
+  it('positive control — same account context with no captured pool builds a non-empty plan', async () => {
+    const ctx = makeMockContext({ scrape: accountScrape(), mediator: none() });
+    expect(await committedPlanLength(ctx)).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardForcedPasswordGuard.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardForcedPasswordGuard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * REGRESSION GUARD — R4 forced-password detection MUST stay strict.
+ *
+ * Locks the origin/main contract: a visible change-password marker is a
+ * forced-change interstitial and MUST escalate, regardless of any
+ * secondary dashboard-success probe AND regardless of a secondary probe
+ * error. PR #381 weakened this (marker treated as benign when a
+ * dashboard marker coexists; a probe error coerced to "ready"), silently
+ * downgrading a security wall.
+ *
+ * <p>Fire proof: GREEN on origin/main (strict — one probe, marker ⇒
+ * fail). RED against the PR-381 DashboardProbe (the second probe makes
+ * checkChangePassword return false, so these expectations fail).
+ * Security-relevant: fail-closed.
+ */
+
+import { ScraperErrorTypes } from '../../../../../Scrapers/Base/ErrorTypes.js';
+import checkChangePassword from '../../../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardProbe.js';
+import type {
+  IElementMediator,
+  IRaceResult,
+} from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import { NOT_FOUND_RESULT } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+
+/** Per-call behaviour for the scripted resolveVisible probe. */
+type ProbeBehaviour = 'found' | 'missing' | 'throw';
+
+/** A race result whose marker is present (found). */
+const FOUND_RESULT: IRaceResult = { ...NOT_FOUND_RESULT, found: true as const };
+
+/**
+ * Build a mediator whose resolveVisible answers a scripted behaviour per
+ * call index: call 1 is the change-pwd probe; call 2 is the
+ * dashboard-ready probe PR #381 added. Strict detection ignores call 2.
+ * @param sequence - Per-call behaviours (index 0 = first call).
+ * @returns Mock element mediator.
+ */
+function makeSequencedMediator(sequence: readonly ProbeBehaviour[]): IElementMediator {
+  let call = -1;
+  return {
+    /**
+     * Scripted visibility probe.
+     * @returns The scripted result, or a rejection for `throw`.
+     */
+    resolveVisible: (): Promise<IRaceResult> => {
+      call += 1;
+      const beh = sequence[call] ?? 'missing';
+      if (beh === 'throw') return Promise.reject(new Error('probe-error'));
+      return Promise.resolve(beh === 'found' ? FOUND_RESULT : NOT_FOUND_RESULT);
+    },
+  } as unknown as IElementMediator;
+}
+
+/**
+ * Assert the probe result is a forced-password-change failure (not a
+ * benign `false`). The `not.toBe(false)` is the fire trigger: PR #381
+ * returns false here. Named `assert*` so jest/expect-expect recognises
+ * it as the test's assertion (eslint.config.mjs §12d).
+ * @param result - checkChangePassword return value.
+ * @returns The asserted result, for optional chaining by callers.
+ */
+function assertForcedChange(
+  result: Awaited<ReturnType<typeof checkChangePassword>>,
+): Awaited<ReturnType<typeof checkChangePassword>> {
+  expect(result).not.toBe(false);
+  if (result && typeof result === 'object') {
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.errorType).toBe(ScraperErrorTypes.ChangePassword);
+  }
+  return result;
+}
+
+describe('REGRESSION GUARD — R4 forced-password stays strict', () => {
+  it('escalates when a change-pwd marker COEXISTS with a dashboard-success marker', async () => {
+    const mediator = makeSequencedMediator(['found', 'found']);
+    const result = await checkChangePassword(mediator);
+    assertForcedChange(result);
+  });
+
+  it('escalates when a change-pwd marker is found and the secondary probe errors', async () => {
+    const mediator = makeSequencedMediator(['found', 'throw']);
+    const result = await checkChangePassword(mediator);
+    assertForcedChange(result);
+  });
+});

--- a/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardForcedPasswordGuard.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardForcedPasswordGuard.test.ts
@@ -14,6 +14,9 @@
  * Security-relevant: fail-closed.
  */
 
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { ScraperErrorTypes } from '../../../../../Scrapers/Base/ErrorTypes.js';
 import checkChangePassword from '../../../../../Scrapers/Pipeline/Mediator/Dashboard/DashboardProbe.js';
 import type {
@@ -25,8 +28,36 @@ import { NOT_FOUND_RESULT } from '../../../../../Scrapers/Pipeline/Mediator/Elem
 /** Per-call behaviour for the scripted resolveVisible probe. */
 type ProbeBehaviour = 'found' | 'missing' | 'throw';
 
+/** Fixture JSON shape for probe sequences. */
+interface IProbeFixture {
+  readonly sequence?: readonly unknown[];
+}
+
 /** A race result whose marker is present (found). */
 const FOUND_RESULT: IRaceResult = { ...NOT_FOUND_RESULT, found: true as const };
+
+/**
+ * Validate a fixture sequence entry.
+ * @param value - Candidate fixture entry.
+ * @returns True when the entry is a supported probe behaviour.
+ */
+function isProbeBehaviour(value: unknown): value is ProbeBehaviour {
+  return value === 'found' || value === 'missing' || value === 'throw';
+}
+
+/**
+ * Load a PII-scrubbed dashboard probe fixture sequence.
+ * @param name - Fixture folder name.
+ * @returns Probe behaviour sequence.
+ */
+function loadProbeSequence(name: string): readonly ProbeBehaviour[] {
+  const url = new URL(`../../../../E2eMocked/fixtures/${name}/scenario.json`, import.meta.url);
+  const path = fileURLToPath(url);
+  const raw = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(raw) as IProbeFixture;
+  if (!Array.isArray(parsed.sequence) || !parsed.sequence.every(isProbeBehaviour)) return [];
+  return parsed.sequence;
+}
 
 /**
  * Build a mediator whose resolveVisible answers a scripted behaviour per
@@ -70,9 +101,25 @@ function assertForcedChange(
   return result;
 }
 
+/**
+ * Assert the probe error is surfaced as a typed Procedure failure.
+ * @param result - checkChangePassword return value.
+ * @returns True after assertions.
+ */
+function assertProbeFailure(result: Awaited<ReturnType<typeof checkChangePassword>>): true {
+  expect(result).not.toBe(false);
+  if (result && typeof result === 'object') {
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.errorType).toBe(ScraperErrorTypes.Generic);
+    if (!result.success) expect(result.errorMessage).toContain('DASHBOARD_PROBE_ERROR');
+  }
+  return true;
+}
+
 describe('REGRESSION GUARD — R4 forced-password stays strict', () => {
   it('escalates when a change-pwd marker COEXISTS with a dashboard-success marker', async () => {
-    const mediator = makeSequencedMediator(['found', 'found']);
+    const sequence = loadProbeSequence('dashboard-marker-and-dashboard-present');
+    const mediator = makeSequencedMediator(sequence);
     const result = await checkChangePassword(mediator);
     assertForcedChange(result);
   });
@@ -81,5 +128,12 @@ describe('REGRESSION GUARD — R4 forced-password stays strict', () => {
     const mediator = makeSequencedMediator(['found', 'throw']);
     const result = await checkChangePassword(mediator);
     assertForcedChange(result);
+  });
+
+  it('surfaces probe errors as failures instead of treating the dashboard as ready', async () => {
+    const sequence = loadProbeSequence('dashboard-probe-error');
+    const mediator = makeSequencedMediator(sequence);
+    const result = await checkChangePassword(mediator);
+    assertProbeFailure(result);
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardProbe.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Dashboard/DashboardProbe.test.ts
@@ -49,6 +49,34 @@ function makeMediator(script: IMediatorScript = {}): IElementMediator {
   } as unknown as IElementMediator;
 }
 
+/**
+ * Build a logger that captures WARN entries.
+ * @param capture - WARN entry sink.
+ * @returns Scraper logger.
+ */
+function makeWarnLogger(capture: (entry: unknown) => boolean): ScraperLogger {
+  return { warn: capture } as unknown as ScraperLogger;
+}
+
+/**
+ * Assert the forced-password warning contains only approved fields.
+ * @param entry - Captured WARN entry.
+ * @returns True after assertions.
+ */
+function assertForcedWarning(entry: unknown): true {
+  const event = entry as {
+    readonly companyId?: unknown;
+    readonly correlationId?: unknown;
+    readonly marker?: unknown;
+  };
+  expect(event.companyId).toBe('amex');
+  expect(typeof event.correlationId).toBe('string');
+  expect(event.marker).toBe(true);
+  const serialized = JSON.stringify(entry);
+  expect(serialized).not.toContain('fixt-p');
+  return true;
+}
+
 describe('checkChangePassword', () => {
   it('returns false when nothing found', async () => {
     const mediator = makeMediator();
@@ -67,16 +95,34 @@ describe('checkChangePassword', () => {
     }
   });
 
-  it('returns false when resolveVisible throws (defensive catch)', async () => {
+  it('fails with a typed probe error when resolveVisible throws', async () => {
     const mediator = makeMediator({ visibleThrows: true });
     const result = await checkChangePassword(mediator);
-    expect(result).toBe(false);
+    expect(result).not.toBe(false);
+    if (result && typeof result === 'object') {
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.errorType).toBe(ScraperErrorTypes.Generic);
+      if (!result.success) expect(result.errorMessage).toContain('DASHBOARD_PROBE_ERROR');
+    }
   });
 
   it('returns false when found=false is returned', async () => {
     const mediator = makeMediator({ visibleResult: NOT_FOUND_RESULT });
     const result = await checkChangePassword(mediator);
     expect(result).toBe(false);
+  });
+
+  it('logs a PII-safe warning when the forced-pwd marker is present', async () => {
+    const entries: unknown[] = [];
+    const found: IRaceResult = { ...NOT_FOUND_RESULT, found: true as const };
+    const logger = makeWarnLogger(entry => {
+      entries.push(entry);
+      return true;
+    });
+    const mediator = makeMediator({ visibleResult: found });
+    await checkChangePassword(mediator, { logger, companyId: 'amex' });
+    expect(entries).toHaveLength(1);
+    assertForcedWarning(entries[0]);
   });
 });
 

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/ActionExecutorsIdentity.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/ActionExecutorsIdentity.test.ts
@@ -95,6 +95,18 @@ describe('raceResultToTarget — identity-based selector tiers', () => {
     if (target) expect(target.selector).toBe('[aria-label="Send"]');
   });
 
+  it('conjoins [href="…"] onto aria-label to disambiguate same-name twins', () => {
+    // Two controls can share an accessible name (off-canvas decoy + genuine
+    // login anchor both labelled "כניסה לחשבון"); the distinct href pins the
+    // selector to the exact element PRE resolved, so ACTION cannot fall back
+    // to the DOM-first decoy via `.first()`.
+    const identity = makeIdentity({ ariaLabel: 'כניסה לחשבון', href: '/personalarea/Login/' });
+    const result = makeFoundResultWithIdentity(identity);
+    const target = raceResultToTarget(result, page);
+    if (target)
+      expect(target.selector).toBe('[aria-label="כניסה לחשבון"][href="/personalarea/Login/"]');
+  });
+
   it('falls through to [title="…"] when id+name+aria-label absent', () => {
     const identity = makeIdentity({ title: 'שלח' });
     const result = makeFoundResultWithIdentity(identity);

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorCallbacks.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorCallbacks.test.ts
@@ -187,6 +187,16 @@ describe('CreateElementMediator — walkUpToAnchorHref callback (invoked locally
        */
       first: (): Locator => locator,
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       * @returns 1.
+       */
+      count: (): Promise<number> => Promise.resolve(1),
+      /**
+       * Test helper - nth collapses to self (single match).
+       * @returns Self locator.
+       */
+      nth: (): Locator => locator,
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -276,6 +286,16 @@ describe('CreateElementMediator — traceElementInfo callback (invoked locally)'
        * @returns Result.
        */
       first: (): Locator => locator,
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       * @returns 1.
+       */
+      count: (): Promise<number> => Promise.resolve(1),
+      /**
+       * Test helper - nth collapses to self (single match).
+       * @returns Self locator.
+       */
+      nth: (): Locator => locator,
       /**
        * Test helper.
        *
@@ -379,6 +399,16 @@ describe('CreateElementMediator — resolveVisibleInContextImpl winner<0 branch'
        */
       first: (): Locator => locator,
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       * @returns 1.
+       */
+      count: (): Promise<number> => Promise.resolve(1),
+      /**
+       * Test helper - nth collapses to self (single match).
+       * @returns Self locator.
+       */
+      nth: (): Locator => locator,
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -452,6 +482,16 @@ describe('CreateElementMediator — buildCandidateLocators default fallback kind
        */
       first: (): Locator => locator,
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       * @returns 1.
+       */
+      count: (): Promise<number> => Promise.resolve(1),
+      /**
+       * Test helper - nth collapses to self (single match).
+       * @returns Self locator.
+       */
+      nth: (): Locator => locator,
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -513,6 +553,16 @@ describe('CreateElementMediator — extractIdentity callback (invoked locally)',
        * @returns Result.
        */
       first: (): Locator => locator,
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       * @returns 1.
+       */
+      count: (): Promise<number> => Promise.resolve(1),
+      /**
+       * Test helper - nth collapses to self (single match).
+       * @returns Self locator.
+       */
+      nth: (): Locator => locator,
       /**
        * Test helper.
        *

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.check.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.check.test.ts
@@ -30,6 +30,22 @@ describe('CreateElementMediator — getAttributeValue with null return', () => {
         return this as unknown as Locator;
       },
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -101,6 +117,22 @@ describe('CreateElementMediator — checkAttribute with empty attr', () => {
        * @returns Result.
        */
       first(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
         return this as unknown as Locator;
       },
       /**

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.snapshot.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.snapshot.test.ts
@@ -36,6 +36,22 @@ describe('CreateElementMediator — snapshotValue href target + fallback', () =>
         return this as unknown as Locator;
       },
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
        * waitFor — visible only.
        * @returns Resolves.
        */
@@ -225,6 +241,22 @@ describe('CreateElementMediator — isTrulyVisible evaluate-callback branches', 
        * @returns Result.
        */
       first(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
         return this as unknown as Locator;
       },
       /**

--- a/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.text.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Elements/CreateElementMediatorExtra.text.test.ts
@@ -29,6 +29,22 @@ describe('CreateElementMediator — snapshotValue text-path branches', () => {
         return this as unknown as Locator;
       },
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -86,6 +102,22 @@ describe('CreateElementMediator — snapshotValue text-path branches', () => {
        * @returns Result.
        */
       first(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
         return this as unknown as Locator;
       },
       /**
@@ -152,6 +184,22 @@ describe('CreateElementMediator — snapshotValue text-path branches', () => {
         return this as unknown as Locator;
       },
       /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
        * Test helper.
        *
        * @returns Result.
@@ -215,6 +263,22 @@ describe('CreateElementMediator — traceElementIdentity catch branch', () => {
        * @returns Result.
        */
       first(): Locator {
+        return this as unknown as Locator;
+      },
+      /**
+       * Test helper - count for nth-aware resolveVisible (single match).
+       *
+       * @returns 1.
+       */
+      count(): Promise<number> {
+        return Promise.resolve(1);
+      },
+      /**
+       * Test helper - nth collapses to self (single match).
+       *
+       * @returns Self.
+       */
+      nth(): Locator {
         return this as unknown as Locator;
       },
       /**

--- a/src/Tests/Unit/Pipeline/Mediator/Home/HomeNavOverrideGuard.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Home/HomeNavOverrideGuard.test.ts
@@ -1,0 +1,165 @@
+/**
+ * REGRESSION GUARD — R3 HOME nav-override MUST stay target="_blank"-only.
+ *
+ * Locks the origin/main contract: a DIRECT home trigger receives a
+ * `navHrefOverride` (replacing the click with a same-tab navigation)
+ * ONLY when the anchor declares `target="_blank"`. An absolute href
+ * WITHOUT `target="_blank"` is an ordinary link and MUST keep its click
+ * path. PR #381 widened the rule to "any absolute href", hijacking
+ * ordinary clicks across every bank's HOME phase.
+ *
+ * <p>Fire proof: GREEN on origin/main (target-only). RED against the
+ * PR-381 HomeResolver (its `resolveNavOverrideHref` attaches the
+ * override for any absolute href, so the no-blank expectation fails).
+ *
+ * <p>The mock implements BOTH `resolveVisible` (origin/main single-
+ * winner path) and `resolveAllVisible` (the PR-381 enumerate path) so
+ * the guard executes cleanly against either implementation and the only
+ * difference observed is the override semantics under test.
+ */
+
+import type { Page } from 'playwright-core';
+
+import ScraperError from '../../../../../Scrapers/Base/ScraperError.js';
+import type {
+  IElementMediator,
+  IRaceResult,
+} from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import { NOT_FOUND_RESULT } from '../../../../../Scrapers/Pipeline/Mediator/Elements/ElementMediator.js';
+import type { IHomeDiscovery } from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import {
+  NAV_STRATEGY,
+  resolveHomeStrategy,
+} from '../../../../../Scrapers/Pipeline/Mediator/Home/HomeResolver.js';
+import type { ScraperLogger } from '../../../../../Scrapers/Pipeline/Types/Debug.js';
+import { isOk, succeed } from '../../../../../Scrapers/Pipeline/Types/Procedure.js';
+
+const SILENT_LOG = {
+  /**
+   * No-op debug.
+   * @returns True.
+   */
+  debug: (): boolean => true,
+  /**
+   * No-op trace.
+   * @returns True.
+   */
+  trace: (): boolean => true,
+  /**
+   * No-op info.
+   * @returns True.
+   */
+  info: (): boolean => true,
+  /**
+   * No-op warn.
+   * @returns True.
+   */
+  warn: (): boolean => true,
+  /**
+   * No-op error.
+   * @returns True.
+   */
+  error: (): boolean => true,
+} as unknown as ScraperLogger;
+
+/** An absolute href that is NOT a new-tab (`target="_blank"`) anchor. */
+const ABSOLUTE_HREF = 'https://digital.example-bank.local/personalarea/Login/';
+
+/** Per-attribute scripted values for the resolved trigger element. */
+interface IAttrResponses {
+  readonly target: string;
+  readonly href: string;
+}
+
+/**
+ * Build a mediator that always resolves one visible DIRECT trigger
+ * ('Login') and answers scripted `target`/`href` attribute reads.
+ * Implements both visibility methods so the guard runs on origin/main
+ * (`resolveVisible`) and PR-381 (`resolveAllVisible`) alike.
+ * @param responses - Per-attribute scripted values.
+ * @returns Mock element mediator.
+ */
+function makePopupMediator(responses: IAttrResponses): IElementMediator {
+  const visible: IRaceResult = { ...NOT_FOUND_RESULT, found: true as const, value: 'Login' };
+  return {
+    /**
+     * Single-winner visibility probe (origin/main path).
+     * @returns The visible DIRECT trigger.
+     */
+    resolveVisible: (): Promise<IRaceResult> => Promise.resolve(visible),
+    /**
+     * Enumerate-N visibility probe (PR-381 path).
+     * @returns A one-entry list holding the visible DIRECT trigger.
+     */
+    resolveAllVisible: (): Promise<readonly IRaceResult[]> => Promise.resolve([visible]),
+    /**
+     * checkAttribute returns true only for `href` (force DIRECT path).
+     * @param _r - Race result.
+     * @param attr - Attribute name.
+     * @returns Succeeded with whether the attribute is present.
+     */
+    checkAttribute: (_r: IRaceResult, attr: string) => {
+      const presence = succeed(attr === 'href');
+      return Promise.resolve(presence);
+    },
+    /**
+     * Per-attribute scripted value.
+     * @param _r - Race result.
+     * @param attr - Attribute name.
+     * @returns Scripted value, or empty string for other attributes.
+     */
+    getAttributeValue: (_r: IRaceResult, attr: string): Promise<string> => {
+      if (attr === 'target') return Promise.resolve(responses.target);
+      if (attr === 'href') return Promise.resolve(responses.href);
+      return Promise.resolve('');
+    },
+  } as unknown as IElementMediator;
+}
+
+/**
+ * Minimal Page stub for `resolveHomeStrategy`.
+ * @returns Page stub.
+ */
+function makePageStub(): Page {
+  return {
+    /**
+     * URL.
+     * @returns Static URL.
+     */
+    url: (): string => 'https://www.example-bank.local/',
+    /**
+     * frames.
+     * @returns Empty frame list.
+     */
+    frames: (): Page[] => [],
+  } as unknown as Page;
+}
+
+/**
+ * Drive `resolveHomeStrategy` and assert PRE succeeded, returning the
+ * discovery for override assertions.
+ * @param responses - Per-attribute responses.
+ * @returns Discovery value after PRE.
+ */
+async function runResolve(responses: IAttrResponses): Promise<IHomeDiscovery> {
+  const mediator = makePopupMediator(responses);
+  const pageStub = makePageStub();
+  const result = await resolveHomeStrategy(mediator, SILENT_LOG, pageStub);
+  const isResolved = isOk(result);
+  expect(isResolved).toBe(true);
+  if (!result.success) throw new ScraperError('HOME PRE expected to succeed in R3 guard');
+  return result.value;
+}
+
+describe('REGRESSION GUARD — R3 nav-override stays target="_blank"-only', () => {
+  it('does NOT attach navHrefOverride for an absolute href WITHOUT target="_blank"', async () => {
+    const discovery = await runResolve({ target: '', href: ABSOLUTE_HREF });
+    expect(discovery.strategy).toBe(NAV_STRATEGY.DIRECT);
+    expect(discovery.navHrefOverride).toBeUndefined();
+  });
+
+  it('DOES attach navHrefOverride for a genuine target="_blank" anchor (positive control)', async () => {
+    const discovery = await runResolve({ target: '_blank', href: ABSOLUTE_HREF });
+    expect(discovery.navHrefOverride).toBe(ABSOLUTE_HREF);
+  });
+});


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | TypeScript strict — no `any`, no unused | ✅ `tsc --noEmit` exit 0 on full stack |
| 2 | ESLint `--max-warnings 0` | ✅ exit 0 on all changed files |
| 3 | Prettier (120, single-quote, trailing comma) | ✅ `prettier --check` clean |
| 4 | Conventional Commits + 50/72 rule | ✅ all 9 subjects ≤50, bodies wrapped ≤72 |
| 5 | Co-authored-by trailer on every commit | ✅ present on all 9 |
| 6 | File size ≤150 lines | ✅ largest new file 133 lines |
| 7 | Functions ≤10 lines / OCP via maps | ✅ helpers ≤10 lines, family maps over branching |
| 8 | ZERO CSS selectors in interaction code | ✅ home resolver uses visible-text + hit-test only |
| 9 | Zero Leumi production code (Beinleumi-aware gate) | ✅ `git diff origin/main..HEAD -- src/Scrapers` has no `leumi` |
| 10 | Test pyramid fires on each regression | ✅ each guard RED on weakened code, GREEN on fix |
| 11 | All 14 banks green (no coupling regression) | ✅ integration mode-a+b 9 suites / 140; floor 5494 |
| 12 | Coverage gates (br 95 / fn 97 / ln 98 / st 97) | ✅ floor `test:pipeline` met (97.24 / 95 / 97.48 / 98.38) |
| 13 | Mocks: external-only, PII-free fixtures | ✅ synthetic `example-bank.local`, no real captures |
| 14 | Single-responsibility commits (atomic) | ✅ one logical change per commit |
| 15 | Extends (not replaces) merged #382 | ✅ rebased onto #382 merge; #382 tests restored byte-for-byte |

## Relationship to PR #382 (merged)

`#382` (`feat(pipeline): config-driven balance-resolve + required
balanceKind`) was squash-merged into `main` first. This PR is **rebased on
top of that merge and extends it — it does not replace it.**

- #382 owns the **config-driven balance-resolve** PRE/ACTION template and
  the required `balanceKind` field, including its intentional card-cycle
  live-fetch suppression (`poolDisprovesBalance`).
- Our R1 work **adds alias-family scoping** in both balance seams (the
  primary `BalanceResolve` extractor and the legacy `EndpointFieldMap`).
  The scan tries the declared family first and, on a family **miss**, falls
  back to #382's full alias list — **byte-identical to #382's behavior**. An
  in-family field always wins, so R1 discrimination is preserved while
  #382's path is never weakened.
- #382's three live-fetch integration tests (`BalanceResolveActionsV6`,
  `BalanceResolveCrossBank`, `BalanceResolveActionsCoverage`) are **restored
  byte-for-byte** to the merged version. Our card-cycle scoping is proven
  independently by the new `BalanceKindScoping.test.ts`.

## Why

PR #381 (Bank Leumi migration onto the declarative Pipeline) introduced
**shared, non-Leumi regressions** in the pipeline that affect every bank:
popup/nav-override widening, a home same-name twin mis-resolution, an
account-vs-card balance mix-up, and a fail-open dashboard probe.

This PR fixes those **shared** regressions on top of the green `origin/main`
baseline (now including #382), with a test pyramid that actually fires on
each one. **The Leumi migration itself is intentionally OUT of scope** —
Leumi appears only as a fixture-level validation oracle (zero Leumi
production code).

## What changed (R1–R5)

- **R1 — balance family scoping** (`feat(pipeline): scope balance by
  balanceKind`): on top of #382's required `balanceKind`, both balance seams
  (primary extractor and legacy field-map) scope their alias scan to the
  declared family, then fall back to #382's full list on a family miss.
  Behavior-preserving (in-family field always wins; fallback = #382's
  unscoped scan) — never adds an alias a path did not already have.
- **R2 — home twin disambiguation** (`fix(pipeline): disambiguate
  same-name home twin`): GLOBAL resolver fix. When two controls share the
  same visible text/aria-label, prefer the one that passes the center
  hit-test over an off-canvas decoy. This is the single genuine production
  behavior fix.
- **R3 — nav-override guardrail** (`test: Guard home nav target override`):
  lock nav-href override to `target="_blank"` only, with an e2e-mocked guard
  proving it.
- **R4 — dashboard probe fail-closed** (`fix: fail closed dashboard probe` +
  `test: guard dashboard probe failures`): a probe error now fails closed
  with a typed `Procedure` failure and a PII-safe WARN, instead of silently
  passing.
- **R5 — response-unwrap boundary doc + migration oracle** (`docs: note
  shared response unwrap boundary` + `test: add Leumi migration oracle`):
  document that SOAP/WCF envelope unwrapping stays a bank-specific adapter
  concern off the shared path, and add a fixture-level oracle that drives
  the real P1/P2/P3/P4 seams a future migration depends on.

## Validation

- **Balance targeted**: 15 suites / 130 tests green — our scoping +
  #382's restored live-fetch tests coexist.
- **Floor (`test:pipeline`)**: 485 suites / 5494 tests green, coverage
  thresholds met (Stmts 97.24 / Br 95 / Fns 97.48 / Lines 98.38).
- **E2E-mocked (`test:e2e:mock`)**: 11 passed / 35 tests, incl. home-twin,
  nav-override and dashboard guards + the migration oracle.
- **Integration (`test:integration` mode-a+b)**: 9 suites / 140 passed —
  bank login-discovery + mirror byte-stability, no coupling regression.
- **Zero-Leumi gate**: empty across the whole `origin/main..HEAD` diff in
  `src/Scrapers` (Beinleumi-aware).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>