### PR TITLE
fix(pipeline): nudge Amex cards view via txn href

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
+++ b/src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts
@@ -120,19 +120,75 @@ async function awaitAndLog(args: IAwaitArgs): Promise<true> {
 }
 
 /**
- * Drive a same-URL SPA to its cards/transactions view by clicking the
- * well-known transactions link, so an accounts API that only fires on
- * navigation (e.g. Isracard `GetCardList`) finally fires, then re-runs
- * the id-capture wait. The nudge click does NOT mark a dashboard click,
- * so its capture lands in `getPreNavCaptures()` for POST to read.
+ * True when a DOM href points at a well-known transactions page (e.g. Amex
+ * `/transactions`). Mirrors the Dashboard phase's href matcher locally so
+ * account-resolve stays self-contained (no cross-stage import).
+ * @param href - Candidate DOM anchor href.
+ * @returns Whether it matches any WK transactions-page pattern.
+ */
+function matchesTxnPattern(href: string): boolean {
+  return WK_DASHBOARD.TXN_PAGE_PATTERNS.some((pattern): boolean => pattern.test(href));
+}
+
+/**
+ * First DOM href pointing at a transactions page, or '' when none match.
+ * @param hrefs - All anchor hrefs collected from the page.
+ * @returns The matching href, or '' if absent.
+ */
+function pickTxnHref(hrefs: readonly string[]): string {
+  return hrefs.find(matchesTxnPattern) ?? '';
+}
+
+/**
+ * Href-navigate fallback for SPAs whose transactions link is reachable by
+ * href rather than by the visible-text click (e.g. Amex `/transactions`).
+ * Navigates straight to the txn page so its id-bearing accounts API fires,
+ * then re-runs the wait. Navigation does NOT mark a dashboard click, so the
+ * capture lands in `getPreNavCaptures()` for POST. No-op when no href matches.
  * @param args - Bundled mediator + logger.
- * @returns Always true once the click + re-wait completed.
+ * @returns Always true once the navigate (+ re-wait) completed.
+ */
+async function navigateTxnHrefAndReWait(args: IAwaitArgs): Promise<true> {
+  const hrefs = await args.mediator.collectAllHrefs();
+  const href = pickTxnHref(hrefs);
+  if (href !== '') {
+    args.log.debug({ message: 'account-resolve.pre nudge → navigate transactions href' });
+    await args.mediator.navigateTo(href);
+    await awaitAndLog(args);
+  }
+  return true;
+}
+
+/**
+ * After the visible-text click, fall back to href-navigation only when the
+ * pool still has no id-bearing capture (the Amex href-only case). No-op when
+ * the click already revealed an id, preserving zero blast radius.
+ * @param args - Bundled mediator + logger.
+ * @returns Always true (sentinel for the chained call site).
+ */
+async function navigateIfStillNoId(args: IAwaitArgs): Promise<true> {
+  const pool = args.mediator.network.getPreNavCaptures();
+  if (findFirstIdInPool(pool) !== false) return true;
+  return navigateTxnHrefAndReWait(args);
+}
+
+/**
+ * Drive a same-URL SPA to its cards/transactions view so an accounts API
+ * that only fires on navigation (e.g. Isracard `GetCardList`) finally fires,
+ * then re-runs the id-capture wait. Two generic stages, click-first:
+ * (1) click the well-known transactions link (visible-text — zero CSS), for
+ * SPAs whose link toggles the view in place (Isracard); (2) if still no id,
+ * navigate to the href-discoverable transactions page (Amex). Neither stage
+ * marks a dashboard click, so captures land in `getPreNavCaptures()` for POST.
+ * @param args - Bundled mediator + logger.
+ * @returns Always true once the click + re-wait + optional navigate completed.
  */
 async function nudgeCardsViewAndReWait(args: IAwaitArgs): Promise<true> {
   const candidates = WK_DASHBOARD.TRANSACTIONS;
   args.log.debug({ message: 'account-resolve.pre nudge → click transactions link' });
   await args.mediator.resolveAndClick(candidates, NUDGE_CLICK_TIMEOUT_MS);
   await awaitAndLog(args);
+  await navigateIfStillNoId(args);
   return true;
 }
 

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts
@@ -29,6 +29,7 @@ import { makeMockContext } from '../../Infrastructure/MockFactories.js';
  *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
  *  driving an id into the pool. */
 const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
+const NAVIGATE_OK: Procedure<void> = succeed(undefined);
 
 /** Args bundle for the synthetic-pool mediator factory. */
 interface IPoolMediatorArgs {
@@ -42,6 +43,15 @@ interface IPoolMediatorArgs {
    * transactions link is clicked.
    */
   readonly onClickCaptures?: readonly IDiscoveredEndpoint[];
+  /** DOM anchor hrefs returned by `collectAllHrefs` (defaults to none). */
+  readonly hrefs?: readonly string[];
+  /**
+   * Captures revealed by the PRE href-navigate fallback — simulates a
+   * nav-gated accounts API (e.g. Amex `GetCardList`) firing only after
+   * navigating directly to the href-discoverable transactions page, when
+   * the visible-text click alone did not surface it.
+   */
+  readonly onNavigateCaptures?: readonly IDiscoveredEndpoint[];
 }
 
 /**
@@ -97,6 +107,22 @@ function makePoolMediator(args: IPoolMediatorArgs): IElementMediator {
     resolveAndClick: (): Promise<Procedure<IRaceResult>> => {
       if (args.onClickCaptures) pool = args.onClickCaptures;
       return Promise.resolve(NUDGE_NOOP_RESULT);
+    },
+    /**
+     * DOM anchor hrefs for the href-navigate fallback (empty by default,
+     * so the fallback no-ops unless a test supplies a txn href).
+     * @returns Configured hrefs.
+     */
+    collectAllHrefs: (): Promise<readonly string[]> => Promise.resolve(args.hrefs ?? []),
+    /**
+     * Href-navigate fallback. When `onNavigateCaptures` is supplied the
+     * pool is swapped to it, modelling an SPA whose accounts API only
+     * fires once the transactions page is navigated to directly.
+     * @returns Resolved void success.
+     */
+    navigateTo: (): Promise<Procedure<void>> => {
+      if (args.onNavigateCaptures) pool = args.onNavigateCaptures;
+      return Promise.resolve(NAVIGATE_OK);
     },
   } as unknown as IElementMediator;
 }
@@ -524,6 +550,18 @@ describe('executeAccountResolvePre — wait outcome telemetry', () => {
        * @returns Resolved click sentinel.
        */
       resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
+      /**
+       * Empty href set — the href-navigate fallback finds no txn page and
+       * no-ops, so the test still falls through to the false outcome.
+       * @returns Empty hrefs.
+       */
+      collectAllHrefs: (): Promise<readonly string[]> => Promise.resolve([]),
+      /**
+       * Unused navigate stub (no href matches) — present so the fallback's
+       * mediator contract is satisfied.
+       * @returns Resolved void success.
+       */
+      navigateTo: (): Promise<Procedure<void>> => Promise.resolve(NAVIGATE_OK),
     } as unknown as IElementMediator;
     const baseCtx = makeMockContext();
     const ctx = {
@@ -606,5 +644,63 @@ describe('executeAccountResolvePre — same-URL SPA cards-view nudge', () => {
         expect(post.value.accountDiscovery.value.ids.length).toBeGreaterThan(0);
       }
     }
+  });
+
+  // Amex's id-bearing GetCardList only fires once the SPA reaches its cards
+  // view. Unlike Isracard (a visible-text click toggles the view), Amex's
+  // transactions link is discoverable by HREF (`/transactions`), NOT by the
+  // Hebrew visible-text candidates — so the text-click nudge alone leaves the
+  // pool id-less and POST fails. The generic href-navigate fallback drives the
+  // SPA straight to the txn page so GetCardList fires. Faithful to the captured
+  // Amex dashboard trace (L3 DOM scan: match=.../transactions).
+  const amexTxnHref = 'https://web.americanexpress.example/transactions';
+
+  it('navigates the txn href when the text-click reveals no id (Amex href-only link), then resolves', async () => {
+    // captures:[] (stalled SPA) + NO onClickCaptures (the text-click is a
+    // no-op for Amex) + a discoverable txn href + onNavigateCaptures revealing
+    // GetCardList. The text-only nudge leaves the pool empty → POST would fail
+    // loud; only the href-navigate fallback makes POST resolve, so a passing
+    // POST proves the fallback fired.
+    const mediator = makePoolMediator({
+      captures: [],
+      hrefs: [amexTxnHref],
+      onNavigateCaptures: [idCapture],
+    });
+    const ctx = ctxWith(mediator);
+    const pre = await executeAccountResolvePre(ctx);
+    expect(pre.success).toBe(true);
+    const post = await executeAccountResolvePost(ctx);
+    expect(post.success).toBe(true);
+    if (isOk(post) && post.value.accountDiscovery.has) {
+      expect(post.value.accountDiscovery.value.ids.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does NOT navigate when the text-click already revealed an id (zero blast radius for click SPAs)', async () => {
+    // onClickCaptures reveals the id (Isracard click path). onNavigateCaptures
+    // is a POISON no-id pool — were the href-navigate to fire it would erase
+    // the id and POST would fail loud. A passing POST proves it was skipped.
+    const mediator = makePoolMediator({
+      captures: [],
+      onClickCaptures: [idCapture],
+      hrefs: [amexTxnHref],
+      onNavigateCaptures: [noiseCapture],
+    });
+    const ctx = ctxWith(mediator);
+    await executeAccountResolvePre(ctx);
+    const post = await executeAccountResolvePost(ctx);
+    expect(post.success).toBe(true);
+    if (isOk(post)) expect(post.value.accountDiscovery.has).toBe(true);
+  });
+
+  it('stays a no-op when neither the click nor a txn href yields an id (loud POST failure preserved)', async () => {
+    // No id anywhere and no txn href → the fallback finds nothing → POST still
+    // fails loud, preserving the genuine ACCOUNT_RESOLUTION_FAILED contract so
+    // the fallback never masks a real account-resolve miss.
+    const mediator = makePoolMediator({ captures: [noiseCapture], hrefs: [] });
+    const ctx = ctxWith(mediator);
+    await executeAccountResolvePre(ctx);
+    const post = await executeAccountResolvePost(ctx);
+    expect(post.success).toBe(false);
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts
@@ -33,6 +33,7 @@ import { toActionCtx } from '../../Infrastructure/TestHelpers.js';
  *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
  *  driving an id into the pool. */
 const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
+const NAVIGATE_OK: Procedure<void> = succeed(undefined);
 
 /**
  * Build a stub element mediator whose pool/wait surface is fully
@@ -96,6 +97,16 @@ function makeMediatorStub(
      * @returns Resolved click sentinel.
      */
     resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
+    /**
+     * Empty href set — the href-navigate fallback no-ops.
+     * @returns Empty hrefs.
+     */
+    collectAllHrefs: (): Promise<readonly string[]> => Promise.resolve([]),
+    /**
+     * Unused navigate stub — present for the fallback contract.
+     * @returns Resolved void success.
+     */
+    navigateTo: (): Promise<Procedure<void>> => Promise.resolve(NAVIGATE_OK),
   } as unknown as IElementMediator;
 }
 

--- a/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
+++ b/src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts
@@ -24,6 +24,7 @@ import { makeMockContext } from '../../Infrastructure/MockFactories.js';
  *  `resolveAndClick` contract (`Promise<Procedure<IRaceResult>>`) without
  *  driving an id into the pool. */
 const NUDGE_NOOP_RESULT = succeed(NOT_FOUND_RESULT);
+const NAVIGATE_OK: Procedure<void> = succeed(undefined);
 
 /**
  * Build a stub mediator whose pre-nav pool yields the given account
@@ -69,6 +70,16 @@ function makeStubMediator(idCapture: IDiscoveredEndpoint | false): IElementMedia
      * @returns Resolved click sentinel.
      */
     resolveAndClick: (): Promise<Procedure<IRaceResult>> => Promise.resolve(NUDGE_NOOP_RESULT),
+    /**
+     * Empty href set — the href-navigate fallback no-ops.
+     * @returns Empty hrefs.
+     */
+    collectAllHrefs: (): Promise<readonly string[]> => Promise.resolve([]),
+    /**
+     * Unused navigate stub — present for the fallback contract.
+     * @returns Resolved void success.
+     */
+    navigateTo: (): Promise<Procedure<void>> => Promise.resolve(NAVIGATE_OK),
   } as unknown as IElementMediator;
 }
 


### PR DESCRIPTION
## Guideline compliance

| # | Guideline (source) | Status | Verification |
|---|---|---|---|
| 1 | 100% bank separation (CLAUDE.md — architecture) | ✅ | Generic Mediator/WK orchestration; no per-bank branch, no Amex↔Isracard coupling, no new cross-stage import (WK matcher duplicated inline to keep account-resolve self-contained) |
| 2 | ZERO CSS selectors in interaction (CLAUDE.md) | ✅ | Nudge resolves by visible text (`WK_DASHBOARD.TRANSACTIONS`) and navigates by URL href; `matchesTxnPattern` tests href strings vs `TXN_PAGE_PATTERNS` URL regexes — no CSS selectors added |
| 3 | ≤10 lines per function (CLEAN_CODE.md §1) | ✅ | All 4 new helpers ≤10 lines; `nudgeCardsViewAndReWait` / `executeAccountResolvePre` stay ≤10 |
| 4 | TypeScript strict, no `any` (CLAUDE.md) | ✅ | `npm run type-check` exit 0; post-commit `: any count` unchanged at 8 (0 new) |
| 5 | Acyclic dependencies (`lint:cycles`) | ✅ | `npm run lint:cycles` → 0 cycles, within the frozen baseline |
| 6 | Tests are proof (test-guidlines.md) | ✅ | Faithful failing test written FIRST (FAILs pre-fix, PASSes post-fix); full pipeline **478 suites / 5457 tests** pass |
| 7 | ESLint clean (before-commit-guidlines.md) | ✅ | `eslint --max-warnings 0` clean on all 4 changed files |
| 8 | husky gates, no bypass (before-commit-guidlines.md) | ✅ | Committed `ccaea0b0` through all 21 gates; no `--no-verify`; selective `git add` (no `git add .`) |
| 9 | Conventional Commits + trailer (commit-guidlines.md) | ✅ | `fix(pipeline): …` (50/72); `Co-authored-by: Copilot` trailer present |

## Why

Amex's id-bearing `GetCardList` accounts endpoint only fires once the SPA reaches
its cards view. When the SPA stalls on `personalarea/login` after login,
account-resolve's passive wait times out and the existing visible-text click
nudge cannot fire it — Amex's transactions link is **href-discoverable**, not
text-clickable — so ACCOUNT-RESOLVE fails live with `ACCOUNT_RESOLUTION_FAILED`.
The pipeline test pyramid previously did not fire on this class of bug.

## What

A generic, second-stage **href-navigate fallback** in the account-resolve nudge.
It runs **only when BOTH** the passive wait **AND** the visible-text click leave
the pool with no id-bearing capture (zero blast radius — a passively-resolving
bank's id-bearing pool short-circuits the nudge). No per-bank branching, no
Amex/Isracard coupling, no new cross-stage import.

- `src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts` —
  add `matchesTxnPattern`, `pickTxnHref`, `navigateTxnHrefAndReWait`,
  `navigateIfStillNoId`; wire the fallback into `nudgeCardsViewAndReWait` after
  the existing text-click + re-wait. When still no id: `collectAllHrefs()` →
  first href matching `WK_DASHBOARD.TXN_PAGE_PATTERNS` → `navigateTo` → re-wait.
- `src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActions.test.ts` —
  extend `makePoolMediator` (`hrefs` / `onNavigateCaptures` + `collectAllHrefs` /
  `navigateTo` stubs); add 1 pyramid-firing Amex test (proven to FAIL pre-fix) +
  2 guard tests.
- `src/Tests/Unit/Pipeline/Mediator/AccountResolve/AccountResolveActionsCoverage.test.ts` —
  bespoke stub gains `collectAllHrefs` / `navigateTo`.
- `src/Tests/Unit/Pipeline/Phases/AccountResolve/AccountResolvePhase.test.ts` —
  `makeStubMediator` gains `collectAllHrefs` / `navigateTo`.

## Test plan

- [x] unit tests added (1 faithful failing test + 2 guards)
- [x] `npm run type-check` exit 0
- [x] `eslint --max-warnings 0` clean (4 files)
- [x] `npm run lint:cycles` → 0 cycles
- [x] `npm run test:pipeline` → 478 suites / 5457 tests pass
- [ ] Amex **E2E Real** — maintainer-run / USER-ONLY (real **user/pass** creds; Amex uses the user/pass login scenario — **no OTP**); see Notes

## Docs

- [x] N/A — internal pipeline orchestration fix; no user-visible option, error, or
  public-API surface change (`lib/index.cjs` semantics unchanged).

## CI / security

- [x] no secrets committed
- [x] no PII or customer identifiers in code, tests, or commit messages

## Notes for reviewer

**Honest live caveat:** this cannot be proven LIVE offline — all existing Amex
traces predate the nudge, integration fixtures are synthetic, and the *stalled*
`personalarea/login` DOM was never captured, so it is unconfirmed whether
`collectAllHrefs` finds `/transactions` when the nav micro-frontends have not
rendered. The faithful test models the link-rendered worst case (the defensible
offline scope). **Final proof is the user-gated Amex E2E Real.** Because the
fallback activates only after both the passive wait and the text-click leave no
id, a passively-resolving bank (e.g. Hapoalim, or an Isracard click-toggle SPA)
is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the account resolution process with an enhanced fallback navigation mechanism that activates when initial detection methods don't successfully capture account information.

* **Tests**
  * Expanded test coverage for account resolution fallback scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
