### PR TITLE
chore(deps): override ws to ^8.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10271,9 +10271,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
     "ua-parser-js": "1.0.41",
     "@babel/core": "^7.29.6",
     "esbuild": "^0.28.1",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "ws": "^8.21.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [


### PR DESCRIPTION
## Why

The `ws` package — a transitive **dev-only** dependency (jsdom → jest) — is
vulnerable to a DoS (GHSA-96hv-2xvq-fx4p, HIGH severity) at versions `< 8.21.0`
when a request carries many HTTP headers. This was the last unresolved item in
GitHub security alert #63 after #392 cleared the other three GHSAs.

Although the dependency is exercised only in the test runner (never shipped to
consumers), pinning it to a patched release takes the full `npm audit` —
**both `--omit=dev` and the complete dev+prod tree** — to **0 vulnerabilities**
and clears the alert.

## What

- **`package.json`** — add `"ws": "^8.21.0"` to the existing `overrides` block
  (after `js-yaml`). This forces every transitive `ws` to a patched 8.x release
  while staying within major `8`, which jsdom requires.
- **`package-lock.json`** — regenerated with `npm install --package-lock-only`
  (no `node_modules` mutation); `ws` now resolves to `8.21.0`.

No source code changes — the husky pre-commit hook correctly skipped the
quality gates for this deps-only commit.

## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | `commit-guidlines.md` — Conventional Commit, atomic | ✅ single `chore(deps):` commit, subject ≤ 50, body wrapped ≤ 72, `Co-authored-by: Copilot` trailer |
| 2 | `commit-guidlines.md` §8 — selective staging (no `git add .`) | ✅ staged only `package.json` + `package-lock.json` |
| 3 | `dependency-updates-guidlines.md` — prioritize security fixes; SemVer-safe | ✅ patch/minor within major 8; jsdom's expected major preserved |
| 4 | `coding-principle-guidlines.md` §11 — dependency security, patch vulnerable deps | ✅ resolves the HIGH `ws` DoS (GHSA-96hv-2xvq-fx4p) |
| 5 | `before-commit-guidlines.md` — validate before commit | ✅ `npm audit` (dev+prod) = 0 vulnerabilities; lockfile `ws` = 8.21.0 |
| 6 | `pr-guidlines.md` §1 — small, single-responsibility PR | ✅ 2 files, +5/−4, one logical change (ws override) |
| 7 | `pr-guidlines.md` §10 — guideline-compliance section present | ✅ this table |
| 8 | CLAUDE.md — no new dependency added; uses existing `overrides` pattern | ✅ override only, no new package |
| 9 | `before-commit-guidlines.md` — no secrets / PII in diff | ✅ lockfile + manifest only |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides to pin an additional package version for improved consistency and compatibility.
  * Kept the existing override unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->