### PR TITLE
fix: use URL.canParse in login forensic trace

### DIFF
--- a/src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/LoginForensicTrace.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/AuthFailureWatcher/LoginForensicTrace.ts
@@ -36,12 +36,9 @@ function scrub(text: string): string {
  * @returns Host component or the sentinel '(opaque)'.
  */
 function safeHostOf(url: string): string {
-  try {
-    const { host } = new URL(url);
-    return host || '(opaque)';
-  } catch {
-    return '(opaque)';
-  }
+  if (!URL.canParse(url)) return '(opaque)';
+  const { host } = new URL(url);
+  return host || '(opaque)';
 }
 
 /**
@@ -51,12 +48,9 @@ function safeHostOf(url: string): string {
  * @returns host+pathname, or '(opaque)' on failure.
  */
 function hostPathOf(url: string): string {
-  try {
-    const { host, pathname } = new URL(url);
-    return host ? host + pathname : '(opaque)';
-  } catch {
-    return '(opaque)';
-  }
+  if (!URL.canParse(url)) return '(opaque)';
+  const { host, pathname } = new URL(url);
+  return host ? host + pathname : '(opaque)';
 }
 
 /** Return type alias: ConsoleMessage → boolean handler. */


### PR DESCRIPTION
## Why

A CodeRabbit review finding on PR #389 flagged that the login forensic trace
helpers parsed URLs with `try { new URL(url) } catch`, where a total guard is
clearer and avoids exception control flow. The fix was deferred while #389 and
#381 were in flight — to keep the Amex CI a pure production-fingerprint signal —
and now lands as an isolated, single-responsibility cleanup.

## What

- **`LoginForensicTrace.ts`** — `safeHostOf` and `hostPathOf` now guard with
  `URL.canParse(url)` instead of `try { new URL(url) } catch`. Behavior is
  byte-identical: unparseable, host-less, and `about:blank` URLs still return
  the `(opaque)` sentinel; valid URLs still return host (or host + pathname).

The `dedupeFrameHosts` catch is **left intact** — it guards `page.frames()` (a
Playwright call that can genuinely throw), not a URL parse, so a guard does not
apply there.

No public-API change — both helpers are module-local. The forensic trace is a
gated, default-off path (`PIPELINE_AUTH_REQ_TRACE`).

## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | `commit-guidlines.md` — Conventional Commit, atomic | ✅ single `fix:` commit, subject 45 ≤ 50, body wrapped ≤ 72, `Co-authored-by: Copilot` trailer |
| 2 | `commit-guidlines.md` §8 — selective staging (no `git add .`) | ✅ staged only `LoginForensicTrace.ts` |
| 3 | CLEAN_CODE.md — functions ≤ 10 lines | ✅ both helpers are 3 lines |
| 4 | CLAUDE.md — TypeScript strict, no `any` | ✅ `tsc --noEmit` EXIT 0 |
| 5 | `code-simplification-guidlines.md` — clarity, behavior preserved exactly | ✅ total guard replaces exception control flow; all 21 tests unchanged GREEN |
| 6 | `test-guidlines.md` — tests prove behavior | ✅ `LoginForensicTrace` suite 21/21 (opaque, host-less, and normal-URL cases all preserved) |
| 7 | `before-commit-guidlines.md` — validate before commit | ✅ 16 husky gates GREEN (tsc / eslint / biome / prettier / architecture / cycles / canaries / dead-code / docs-coverage …) |
| 8 | `pr-guidlines.md` §1/§2 — small, single-responsibility PR | ✅ 1 file, +6/−12, one logical change |
| 9 | `pr-guidlines.md` §10 — guideline-compliance section present | ✅ this table |
| 10 | `logging-pii-guidlines.md` §1 — no PII in the forensic path | ✅ host / path only; digit-scrub unchanged; default-off gated path |
| 11 | `before-commit-guidlines.md` — no secrets / PII in diff | ✅ single helper file, no secrets |
