### PR TITLE
test: stabilize mirror otp nonce length

### DIFF
--- a/src/Tests/Integration/Mirror/MirrorOtpChallenge.ts
+++ b/src/Tests/Integration/Mirror/MirrorOtpChallenge.ts
@@ -45,7 +45,7 @@ interface IOtpChallengeState {
  * @returns Fresh nonce string.
  */
 function generateNonce(): string {
-  const seed = Math.random().toString(36).slice(2, 11);
+  const seed = Math.random().toString(36).slice(2).padEnd(9, '0').slice(0, 9);
   return `otp-${seed}`;
 }
 


### PR DESCRIPTION
## Why

The Mirror integration test helper `generateNonce()` produced OTP nonces with
`Math.random().toString(36).slice(2, 11)`. When the base-36 fractional expansion
is short, `slice(2, 11)` yields **fewer than 9 characters** (~0.02% of calls).
Two test suites assert the nonce matches a strict 9-character pattern:

- `MirrorOtpChallenge.test.ts` — `expect(nonce).toMatch(/^otp-[a-z0-9]{9}$/)`
- `MirrorSimulator.test.ts` — `/^integ_otp_challenge=otp-[a-z0-9]{9}; Path=\/$/`

So both suites are **intermittently flaky**: green on most runs, red whenever the
generator emits a short nonce. Flaky tests erode trust in the suite and can block
CI on an unrelated push (CodeRabbit finding).

## What

One-line, **test-only** change in `src/Tests/Integration/Mirror/MirrorOtpChallenge.ts`:

```diff
- const seed = Math.random().toString(36).slice(2, 11);
+ const seed = Math.random().toString(36).slice(2).padEnd(9, '0').slice(0, 9);
```

- `padEnd(9, '0')` guarantees the seed is **at least** 9 chars (pads short
  expansions with `'0'`, which is in `[a-z0-9]`).
- `.slice(0, 9)` caps it at **exactly** 9 chars.
- Loop-free and deterministic — no theoretical infinite loop, no entropy stalls.
- The `otp-<random9>` contract (and the JSDoc) is unchanged; uniqueness across
  calls is preserved.

**Empirical RED→GREEN proof** (5,000,000 iterations): the old logic emitted
**1099** non-9-char nonces; the new logic emitted **0**. Targeted suites
(`MirrorOtpChallenge` + `MirrorSimulator`) pass: 2 suites / 13 tests.

No production code is touched — verified by the husky `T1-INVERSE` zero-prod-diff
gate on the `chore/test-*` branch (`git diff -- src/Scrapers` is empty).

## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | Test-only PR — zero production-code diff (`pr-guidlines.md §11`) | ✅ husky `T1-INVERSE` gate GREEN; `git diff -- src/Scrapers` empty |
| 2 | Single-responsibility, small PR (`pr-guidlines.md §1/§2`) | ✅ 1 file, +1/−1 |
| 3 | Deterministic, non-flaky tests (`test-guidlines.md`) | ✅ 0/5M short nonces (was 1099/5M); targeted suites green |
| 4 | `CLEAN_CODE.md` — function ≤10 lines, no `any` | ✅ `generateNonce` unchanged size; pure string ops |
| 5 | Conventional Commits + `Co-authored-by` trailer (`commit-guidlines.md`) | ✅ `test:` subject 39 chars, body wrapped ≤72 |
| 6 | All husky gates GREEN (`before-commit-guidlines.md`) | ✅ tsc/eslint/biome/build/canaries/cycles/… all passed |
| 7 | No secrets / PII (`logging-pii-guidlines.md`) | ✅ test simulator nonce; no credentials |
| 8 | PR body sections present (`pr-guidlines.md §10`) | ✅ Why / What / Guideline compliance |
