### PR TITLE
chore: reformat tree to prettier 3.9.1 + guard deps-bump PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -190,7 +190,7 @@ jobs:
   lint-and-types:
     name: Lint & Types
     needs: changes
-    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.md == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci_scripts == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.md == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci_scripts == 'true' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -203,7 +203,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-node-deps
-        if: needs.changes.outputs.src == 'true'
+        if: needs.changes.outputs.src == 'true' || needs.changes.outputs.deps == 'true'
       - if: needs.changes.outputs.src == 'true'
         run: npx ncp src/Tests/.tests-config.tpl.cjs src/Tests/.tests-config.cjs
 
@@ -211,7 +211,7 @@ jobs:
         if: needs.changes.outputs.src == 'true'
         run: npx eslint src --max-warnings 0 --ignore-pattern '**/*.cjs'
       - name: Prettier check
-        if: needs.changes.outputs.src == 'true'
+        if: needs.changes.outputs.src == 'true' || needs.changes.outputs.deps == 'true'
         run: npx prettier --check "src/**/*.{ts,tsx,js,jsx,json,md}"
       - name: Lint Markdown
         if: needs.changes.outputs.md == 'true' || needs.changes.outputs.src == 'true'

--- a/src/Scrapers/Base/BaseScraperWithBrowser.ts
+++ b/src/Scrapers/Base/BaseScraperWithBrowser.ts
@@ -67,8 +67,7 @@ export type LegacyLoginSetup = LegacyBankConfig['loginSetup'];
 
 /** Discriminated result of resolveLegacyBank: either loginSetup or a failure. */
 export type LegacyBankLookup =
-  | { readonly loginSetup: LegacyLoginSetup }
-  | { readonly failure: IScraperScrapingResult };
+  { readonly loginSetup: LegacyLoginSetup } | { readonly failure: IScraperScrapingResult };
 
 /**
  * Look up the legacy bank config for a given companyId. Pipeline-only

--- a/src/Scrapers/Base/Interface.ts
+++ b/src/Scrapers/Base/Interface.ts
@@ -85,9 +85,7 @@ interface IExternalBrowserContextOptions {
 }
 
 type ScraperBrowserOptions =
-  | IExternalBrowserOptions
-  | IExternalBrowserContextOptions
-  | IDefaultBrowserOptions;
+  IExternalBrowserOptions | IExternalBrowserContextOptions | IDefaultBrowserOptions;
 
 export type ScraperOptions = ScraperBrowserOptions & {
   /**

--- a/src/Scrapers/Pipeline/Core/PipelineContextSlotKeys.ts
+++ b/src/Scrapers/Pipeline/Core/PipelineContextSlotKeys.ts
@@ -35,7 +35,4 @@ export type BalanceSlotKey =
 
 /** Union of every result-slot key — single source of truth for IResultSlots. */
 export type ResultSlotKey =
-  | PhaseStateSlotKey
-  | DiscoverySlotKey
-  | PhaseEmitSlotKey
-  | BalanceSlotKey;
+  PhaseStateSlotKey | DiscoverySlotKey | PhaseEmitSlotKey | BalanceSlotKey;

--- a/src/Scrapers/Pipeline/Core/PipelineResult.ts
+++ b/src/Scrapers/Pipeline/Core/PipelineResult.ts
@@ -59,8 +59,8 @@ function combineWithBalance(
 function extractAccounts(ctx: IPipelineContext): IScraperScrapingResult['accounts'] {
   if (!ctx.scrape.has) return [];
   const balanceMap = readBalanceResolution(ctx);
-  return ctx.scrape.value.accounts.map(
-    (acc): ITransactionsAccount => combineWithBalance(acc, balanceMap),
+  return ctx.scrape.value.accounts.map((acc): ITransactionsAccount =>
+    combineWithBalance(acc, balanceMap),
   );
 }
 

--- a/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Dispatch.ts
+++ b/src/Scrapers/Pipeline/Mediator/BalanceResolve/BalanceResolveActions.Dispatch.ts
@@ -168,8 +168,8 @@ async function fetchAllPlanEntries(
   ctx: IFetchExecCtx,
   plan: readonly IBalanceFetchPlanEntry[],
 ): Promise<ReadonlyMap<string, unknown>> {
-  const dispatchPromises = plan.map(
-    (entry): Promise<IDispatchResult> => dispatchEntry({ ctx, entry }),
+  const dispatchPromises = plan.map((entry): Promise<IDispatchResult> =>
+    dispatchEntry({ ctx, entry }),
   );
   const results = await Promise.all(dispatchPromises);
   return collectSuccesses(plan, results);

--- a/src/Scrapers/Pipeline/Mediator/Credentials/PhoneFormatter.ts
+++ b/src/Scrapers/Pipeline/Mediator/Credentials/PhoneFormatter.ts
@@ -26,10 +26,7 @@ import { fail, isOk, succeed } from '../../Types/Procedure.js';
  * - `local-only` → `XXXXXXXXX` (no current consumer; reserved)
  */
 export type PhoneNumberFormat =
-  | 'international-plus'
-  | 'international-dash'
-  | 'international-flat'
-  | 'local-only';
+  'international-plus' | 'international-dash' | 'international-flat' | 'local-only';
 
 /** Israeli country-code prefix — every bank we onboard is IL-issued. */
 const IL_COUNTRY_CODE = '972';

--- a/src/Scrapers/Pipeline/Mediator/Dashboard/TxnParser.accountId.ts
+++ b/src/Scrapers/Pipeline/Mediator/Dashboard/TxnParser.accountId.ts
@@ -18,8 +18,7 @@ import { PIPELINE_WELL_KNOWN_ACCOUNT_FIELDS as WK_ACCT } from '../../Registry/WK
  * means the pair is unrelated and the loop should keep walking.
  */
 type IPairOutcome =
-  | { readonly kind: 'match'; readonly value: string | false }
-  | { readonly kind: 'skip' };
+  { readonly kind: 'match'; readonly value: string | false } | { readonly kind: 'skip' };
 
 const PAIR_OUTCOME_SKIP: IPairOutcome = { kind: 'skip' };
 

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Entries.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Entries.ts
@@ -60,9 +60,11 @@ function entriesForCandidate(
   candidate: SelectorCandidate,
   formAnchor: string,
 ): ILocatorEntry[] {
-  return buildCandidateLocators(ctx, candidate, formAnchor).map(
-    (locator): ILocatorEntry => ({ locator, candidate, context: ctx }),
-  );
+  return buildCandidateLocators(ctx, candidate, formAnchor).map((locator): ILocatorEntry => ({
+    locator,
+    candidate,
+    context: ctx,
+  }));
 }
 
 /**
@@ -144,8 +146,8 @@ function entriesFromExpansion(
  */
 async function expandCandidateEntries(args: IExpandEntryArgs): Promise<readonly ILocatorEntry[]> {
   const bases = buildCandidateLocatorsBase(args.ctx, args.candidate, args.formAnchor);
-  const expansionPromises = bases.map(
-    (b): Promise<readonly Locator[]> => expandLocatorToNth(b, args.maxPerLocator),
+  const expansionPromises = bases.map((b): Promise<readonly Locator[]> =>
+    expandLocatorToNth(b, args.maxPerLocator),
   );
   const expanded = await Promise.all(expansionPromises);
   return entriesFromExpansion(expanded, args.candidate, args.ctx);
@@ -205,8 +207,8 @@ function mapCandidatesToExpansions(
   candidates: readonly SelectorCandidate[],
   formAnchor = NO_FORM_ANCHOR,
 ): Promise<readonly ILocatorEntry[]>[] {
-  return candidates.map(
-    (c): Promise<readonly ILocatorEntry[]> => expandOneCandidate(ctx, c, formAnchor),
+  return candidates.map((c): Promise<readonly ILocatorEntry[]> =>
+    expandOneCandidate(ctx, c, formAnchor),
   );
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Elements/Create/Resolve.ts
+++ b/src/Scrapers/Pipeline/Mediator/Elements/Create/Resolve.ts
@@ -145,9 +145,11 @@ function buildContextEntries(
   candidates: readonly SelectorCandidate[],
 ): readonly ILocatorEntry[] {
   return candidates.flatMap((c): ILocatorEntry[] =>
-    buildCandidateLocators(ctx, c).map(
-      (locator): ILocatorEntry => ({ locator, candidate: c, context: ctx }),
-    ),
+    buildCandidateLocators(ctx, c).map((locator): ILocatorEntry => ({
+      locator,
+      candidate: c,
+      context: ctx,
+    })),
   );
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Form/Actions/ActionsDiscovery.ts
+++ b/src/Scrapers/Pipeline/Mediator/Form/Actions/ActionsDiscovery.ts
@@ -155,8 +155,8 @@ async function processDiscoveryEntry(p: IProcessEntryArgs): Promise<Procedure<bo
  */
 function reduceDiscoveryFill(r: IReduceArgs): Promise<Procedure<boolean>> {
   const { args, acc, entry } = r;
-  return acc.then(
-    (prev): Promise<Procedure<boolean>> => processDiscoveryEntry({ args, prev, entry }),
+  return acc.then((prev): Promise<Procedure<boolean>> =>
+    processDiscoveryEntry({ args, prev, entry }),
   );
 }
 

--- a/src/Scrapers/Pipeline/Mediator/Home/HomeCrashRecovery.ts
+++ b/src/Scrapers/Pipeline/Mediator/Home/HomeCrashRecovery.ts
@@ -55,8 +55,8 @@ interface IHomeRecoveryArgs {
  * @returns True when any crash marker text is present.
  */
 async function detectClientCrash(mediator: IElementMediator): Promise<boolean> {
-  const probes = CLIENT_CRASH_MARKERS.map(
-    (marker: string): Promise<number> => mediator.countByText(marker),
+  const probes = CLIENT_CRASH_MARKERS.map((marker: string): Promise<number> =>
+    mediator.countByText(marker),
   );
   const counts = await Promise.all(probes);
   return counts.some((count: number): boolean => count > 0);

--- a/src/Scrapers/Pipeline/Mediator/Home/HomeStrategyClassify.ts
+++ b/src/Scrapers/Pipeline/Mediator/Home/HomeStrategyClassify.ts
@@ -70,8 +70,8 @@ async function detectModalAttribute(
   mediator: IElementMediator,
   result: IRaceResult,
 ): Promise<boolean> {
-  const checks = MODAL_ATTRIBUTES.map(
-    (attr: string): Promise<boolean> => hasAttribute(mediator, result, attr),
+  const checks = MODAL_ATTRIBUTES.map((attr: string): Promise<boolean> =>
+    hasAttribute(mediator, result, attr),
   );
   const results = await Promise.all(checks);
   return results.some(Boolean);

--- a/src/Scrapers/Pipeline/Mediator/Network/Fetch/Headers.ts
+++ b/src/Scrapers/Pipeline/Mediator/Network/Fetch/Headers.ts
@@ -8,12 +8,7 @@ import { JSON_CONTENT_TYPE } from '../FetchConfig.js';
 
 /** JSON-serializable value for API request/response bodies. */
 export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
+  string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
 /**
  * Build standard JSON request headers for API calls.

--- a/src/Scrapers/Pipeline/Phases/ApiDirectScrape/IApiDirectScrapeShape.ts
+++ b/src/Scrapers/Pipeline/Phases/ApiDirectScrape/IApiDirectScrapeShape.ts
@@ -53,8 +53,7 @@ export type ApiBody = Record<string, unknown>;
 export type CustomerUrlTag = WKUrlGroup | ((ctx: IActionContext) => WKUrlGroup);
 export type BalanceUrlTag<TAcct> = WKUrlGroup | ((acct: TAcct) => WKUrlGroup);
 export type TxnsUrlTag<TAcct, TCursor> =
-  | WKUrlGroup
-  | ((acct: TAcct, cursor: TCursor | false, ctx: IActionContext) => WKUrlGroup);
+  WKUrlGroup | ((acct: TAcct, cursor: TCursor | false, ctx: IActionContext) => WKUrlGroup);
 
 /**
  * Bundle passed to {@link IApiDirectScrapeCustomerStep.extractAccounts}.

--- a/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
+++ b/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfigTypes.ts
@@ -29,10 +29,7 @@ export type AuthPathKey =
  * login flow consumes the value.
  */
 export type PhoneNumberFormatTag =
-  | 'international-plus'
-  | 'international-dash'
-  | 'international-flat'
-  | 'local-only';
+  'international-plus' | 'international-dash' | 'international-flat' | 'local-only';
 
 /**
  * Balance semantics for a bank — an explicit, REQUIRED per-bank declaration.

--- a/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeData/ScrapeDataTemplating.ts
+++ b/src/Scrapers/Pipeline/Strategy/Scrape/ScrapeData/ScrapeDataTemplating.ts
@@ -141,8 +141,8 @@ function filterOnePluralKey(body: MutBody, key: string, accountId: string): DidF
  */
 function filterPluralCardArrays(body: Record<string, unknown>, accountId: string): DidFilter {
   if (accountId.length === 0) return false as DidFilter;
-  const outcomes = PLURAL_CARDS_KEYS.map(
-    (key): DidFilter => filterOnePluralKey(body, key, accountId),
+  const outcomes = PLURAL_CARDS_KEYS.map((key): DidFilter =>
+    filterOnePluralKey(body, key, accountId),
   );
   return outcomes.includes(true as DidFilter) as DidFilter;
 }

--- a/src/Scrapers/Pipeline/Types/FixtureCapture.ts
+++ b/src/Scrapers/Pipeline/Types/FixtureCapture.ts
@@ -162,13 +162,11 @@ export async function collectIframeSnapshots(page: Page): Promise<readonly IIfra
   const children = page.frames().filter((f): IsMainFrame => (f !== mainFrame) as IsMainFrame);
   const readPromises = children.map(readFrameContent);
   const htmls = await Promise.all(readPromises);
-  const snaps = children.map(
-    (f, i): IIframeSnapshot => ({
-      html: htmls[i],
-      url: readFrameUrl(f),
-      name: readFrameName(f),
-    }),
-  );
+  const snaps = children.map((f, i): IIframeSnapshot => ({
+    html: htmls[i],
+    url: readFrameUrl(f),
+    name: readFrameName(f),
+  }));
   return snaps.filter((s): IsNonEmptySnapshot => (s.html.length > 0) as IsNonEmptySnapshot);
 }
 
@@ -216,14 +214,12 @@ async function writeFrameMetadata(
   const meta: IFrameMetaFile = {
     label: args.label,
     main: { url: mainUrl, htmlPath: `${args.label}.html` },
-    iframes: indexed.map(
-      (s): IIframeMetaRow => ({
-        idx: s.idx,
-        url: s.url,
-        name: s.name,
-        htmlPath: `${args.label}-iframe-${String(s.idx)}.html`,
-      }),
-    ),
+    iframes: indexed.map((s): IIframeMetaRow => ({
+      idx: s.idx,
+      url: s.url,
+      name: s.name,
+      htmlPath: `${args.label}-iframe-${String(s.idx)}.html`,
+    })),
   };
   const metaPath = `${args.bankDir}/${args.label}.frames.json`;
   const json = JSON.stringify(meta);
@@ -241,16 +237,14 @@ async function writeFrameMetadata(
 async function maybeWalkFrames(fs: FsPromisesModule, args: IWriteFrameArgs): Promise<number> {
   if (!args.walkFrames) return 0;
   const snapshots = await collectIframeSnapshots(args.page);
-  const indexed = snapshots.map(
-    (s, idx): IIndexedSnapshot => ({
-      html: s.html,
-      url: s.url,
-      name: s.name,
-      idx,
-    }),
-  );
-  const writePromises = indexed.map(
-    (s): Promise<void> => writeIframeSnapshot({ fs, outer: args, snap: s }),
+  const indexed = snapshots.map((s, idx): IIndexedSnapshot => ({
+    html: s.html,
+    url: s.url,
+    name: s.name,
+    idx,
+  }));
+  const writePromises = indexed.map((s): Promise<void> =>
+    writeIframeSnapshot({ fs, outer: args, snap: s }),
   );
   await Promise.all(writePromises);
   await writeFrameMetadata(fs, args, indexed);

--- a/src/Scrapers/Pipeline/Types/ScrapeConfig.ts
+++ b/src/Scrapers/Pipeline/Types/ScrapeConfig.ts
@@ -49,8 +49,7 @@ interface ITransactionsFetchConfig<TRaw> {
 
 /** Pagination strategy for transaction fetching. */
 type PaginationKind =
-  | { readonly kind: 'none' }
-  | { readonly kind: 'monthly'; readonly defaultMonthsBack: number };
+  { readonly kind: 'none' } | { readonly kind: 'monthly'; readonly defaultMonthsBack: number };
 
 /**
  * Generic scrape config — banks provide this to define their scrape flow.

--- a/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
+++ b/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
@@ -522,8 +522,8 @@ function collectChildFrames(page: Page): readonly Frame[] {
  * @returns Number of iframe files written.
  */
 async function writeChildFrames(childFrames: readonly Frame[], opts: ICliOptions): Promise<number> {
-  const tasks = childFrames.map(
-    (frame, index): Promise<boolean> => writeOneFrame({ index, frame, opts }),
+  const tasks = childFrames.map((frame, index): Promise<boolean> =>
+    writeOneFrame({ index, frame, opts }),
   );
   const results = await Promise.all(tasks);
   return results.filter(Boolean).length;

--- a/src/Tests/Integration/Banks/Amex/AmexPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/Amex/AmexPhaseConfig.ts
@@ -73,12 +73,10 @@ const PHASE_11_STEP_NAMES = [
  * under `fixtures/banks/amex/`. Built via `.map()` over the config
  * array — no duplication.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [AMEX_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [AMEX_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Banks/Beinleumi/BeinleumiPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/Beinleumi/BeinleumiPhaseConfig.ts
@@ -110,12 +110,10 @@ const PHASE_11_STEP_NAMES = [
  * under `fixtures/banks/beinleumi/`. Built via `.map()` over the
  * config array — no duplication.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [BEINLEUMI_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [BEINLEUMI_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Banks/Isracard/IsracardPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/Isracard/IsracardPhaseConfig.ts
@@ -62,12 +62,10 @@ const PHASE_11_STEP_NAMES = [
  * Maps the production PHASE_CHAIN to the harvested phase HTML files
  * under `fixtures/banks/isracard/`.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [ISRACARD_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [ISRACARD_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Banks/Leumi/LeumiPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/Leumi/LeumiPhaseConfig.ts
@@ -60,12 +60,10 @@ const PHASE_11_STEP_NAMES = [
  * Ordered list of Leumi phase expectations driven by Mode A. Built via
  * `.map()` over the config array — no duplication.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [LEUMI_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [LEUMI_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Banks/Max/MaxPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/Max/MaxPhaseConfig.ts
@@ -84,12 +84,10 @@ const PHASE_11_STEP_NAMES = [
  * under `fixtures/banks/max/`. Built via `.map()` over the config
  * array — no duplication.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [MAX_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [MAX_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Banks/VisaCal/VisaCalPhaseConfig.ts
+++ b/src/Tests/Integration/Banks/VisaCal/VisaCalPhaseConfig.ts
@@ -92,12 +92,10 @@ const PHASE_11_STEP_NAMES = [
  * under `fixtures/banks/visaCal/`. Built via `.map()` over the
  * config array — no duplication.
  */
-const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map(
-  (stepName): IPhaseExpectation => ({
-    stepName,
-    mustContain: [VISACAL_BANK_MARKER],
-  }),
-);
+const PHASE_EXPECTATIONS = PHASE_11_STEP_NAMES.map((stepName): IPhaseExpectation => ({
+  stepName,
+  mustContain: [VISACAL_BANK_MARKER],
+}));
 
 export { PHASE_EXPECTATIONS };
 export type { IPhaseExpectation };

--- a/src/Tests/Integration/Mirror/MirrorManifestLoader.ts
+++ b/src/Tests/Integration/Mirror/MirrorManifestLoader.ts
@@ -362,8 +362,8 @@ function optionalPostData(value: unknown, ptr: string): Option<IPostDataPredicat
  */
 function optionalHeaders(value: unknown, ptr: string): Option<readonly IHeaderPredicate[]> {
   if (value === undefined) return none();
-  const list = expectArray(value, ptr).map(
-    (entry, i): IHeaderPredicate => parseHeaderPredicate(entry, `${ptr}[${String(i)}]`),
+  const list = expectArray(value, ptr).map((entry, i): IHeaderPredicate =>
+    parseHeaderPredicate(entry, `${ptr}[${String(i)}]`),
   );
   return some(list);
 }
@@ -393,8 +393,8 @@ function parseHeaderPredicate(entry: unknown, entryPtr: string): IHeaderPredicat
  */
 function optionalCookies(value: unknown, ptr: string): Option<readonly ICookiePredicate[]> {
   if (value === undefined) return none();
-  const list = expectArray(value, ptr).map(
-    (entry, i): ICookiePredicate => parseCookiePredicate(entry, `${ptr}[${String(i)}]`),
+  const list = expectArray(value, ptr).map((entry, i): ICookiePredicate =>
+    parseCookiePredicate(entry, `${ptr}[${String(i)}]`),
   );
   return some(list);
 }

--- a/src/Tests/Integration/Mirror/MirrorSimulator.ts
+++ b/src/Tests/Integration/Mirror/MirrorSimulator.ts
@@ -167,9 +167,8 @@ async function installSimulator(args: IInstallSimulatorArgs): Promise<ISimulator
   const manifest = loadMirrorManifest({ bankId: args.bankId, fixturesRoot: args.fixturesRoot });
   const state: ISimulatorState = buildInitialState(manifest);
   const ctx: IRouteCtx = buildRouteCtx({ manifest, state, args });
-  await args.page.route(
-    '**/*',
-    (route, req): Promise<SimulatorStepStatus> => handleRoute(route, req, ctx),
+  await args.page.route('**/*', (route, req): Promise<SimulatorStepStatus> =>
+    handleRoute(route, req, ctx),
   );
   return buildHandle(args.page, state);
 }

--- a/src/Tests/Integration/Tools/RecipeStepTypes.ts
+++ b/src/Tests/Integration/Tools/RecipeStepTypes.ts
@@ -86,12 +86,7 @@ interface IRecordResponseStep {
 
 /** Sum type of all harvester step kinds. */
 type IHarvestStep =
-  | IGotoStep
-  | IRevealStep
-  | ILoginStep
-  | IWaitForStep
-  | ISnapshotStep
-  | IRecordResponseStep;
+  IGotoStep | IRevealStep | ILoginStep | IWaitForStep | ISnapshotStep | IRecordResponseStep;
 
 /** Bank recipe in the extended union format. */
 interface IExtendedRecipe {

--- a/src/Tests/Tools/lint-guideline-coverage.ts
+++ b/src/Tests/Tools/lint-guideline-coverage.ts
@@ -301,8 +301,8 @@ function printReport(failures: readonly ICoverageFailure[]): number {
 }
 
 const ESLINT_RUNNER = new ESLint();
-const AUDIT_PROMISES = PIPELINE_CLUSTERS.map(
-  (cluster): Promise<readonly ICoverageFailure[]> => auditCluster(ESLINT_RUNNER, cluster),
+const AUDIT_PROMISES = PIPELINE_CLUSTERS.map((cluster): Promise<readonly ICoverageFailure[]> =>
+  auditCluster(ESLINT_RUNNER, cluster),
 );
 const CLUSTER_FAILURES = await Promise.all(AUDIT_PROMISES);
 const ALL_FAILURES: readonly ICoverageFailure[] = CLUSTER_FAILURES.flat();

--- a/src/Tests/Unit/Pipeline/CrossValidation/Phases/ScrapePhaseFactory.test.ts
+++ b/src/Tests/Unit/Pipeline/CrossValidation/Phases/ScrapePhaseFactory.test.ts
@@ -70,9 +70,8 @@ function buildRedactedTxn(ordinal: number): ITransaction {
  * @returns Redacted account record.
  */
 function buildRedactedAccount(txnCount: number): ITransactionsAccount {
-  const txns = Array.from(
-    { length: txnCount },
-    (_unused, index): ITransaction => buildRedactedTxn(index),
+  const txns = Array.from({ length: txnCount }, (_unused, index): ITransaction =>
+    buildRedactedTxn(index),
   );
   return { accountNumber: 'FAKE-000000', balance: 0, txns };
 }

--- a/src/Tests/Unit/Pipeline/Infrastructure/BeinleumiCrossEndpointScan.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/BeinleumiCrossEndpointScan.test.ts
@@ -93,18 +93,16 @@ function loadAllDumps(): readonly ILoadedResponse[] {
  * @returns Endpoint list with only the fields the scanners read.
  */
 function adaptEndpoints(dumps: readonly ILoadedResponse[]): readonly IDiscoveredEndpoint[] {
-  return dumps.map(
-    (d): IDiscoveredEndpoint => ({
-      url: d.url,
-      method: 'GET',
-      postData: '',
-      contentType: 'application/json',
-      requestHeaders: {},
-      responseHeaders: {},
-      responseBody: d.body,
-      timestamp: 0,
-    }),
-  );
+  return dumps.map((d): IDiscoveredEndpoint => ({
+    url: d.url,
+    method: 'GET',
+    postData: '',
+    contentType: 'application/json',
+    requestHeaders: {},
+    responseHeaders: {},
+    responseBody: d.body,
+    timestamp: 0,
+  }));
 }
 
 /**

--- a/src/Tests/Unit/Pipeline/Infrastructure/MirrorDetection.test.ts
+++ b/src/Tests/Unit/Pipeline/Infrastructure/MirrorDetection.test.ts
@@ -178,13 +178,11 @@ describe('detectMirroredAccounts', () => {
      */
     const makeCard = (cardId: string, count: number): IFingerAccount => ({
       accountNumber: cardId,
-      txns: dates.slice(0, count).map(
-        (d, i): IFingerTxn => ({
-          date: d,
-          chargedAmount: -((i + 1) * 11) - (cardId.codePointAt(0) ?? 0),
-          description: `${cardId}-FAKE-${String(i)}`,
-        }),
-      ),
+      txns: dates.slice(0, count).map((d, i): IFingerTxn => ({
+        date: d,
+        chargedAmount: -((i + 1) * 11) - (cardId.codePointAt(0) ?? 0),
+        description: `${cardId}-FAKE-${String(i)}`,
+      })),
     });
     const accounts: IFingerAccount[] = [
       makeCard('CARD-A', 22),

--- a/src/Tests/Unit/Pipeline/Mediator/Credentials/PhoneNormalisation.integration.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Credentials/PhoneNormalisation.integration.test.ts
@@ -36,10 +36,7 @@ const RAW_PHONE = '972000000000';
  * config) — that is the integration pin.
  */
 type PhoneNumberFormatTag =
-  | 'international-plus'
-  | 'international-dash'
-  | 'international-flat'
-  | 'local-only';
+  'international-plus' | 'international-dash' | 'international-flat' | 'local-only';
 
 /** Local mirror of the registry's `IPipelineBankConfig` shape — see above. */
 interface IPipelineBankConfig {

--- a/src/Tests/Unit/Pipeline/Strategy/Scrape/ScrapeDataActions.test.ts
+++ b/src/Tests/Unit/Pipeline/Strategy/Scrape/ScrapeDataActions.test.ts
@@ -148,8 +148,8 @@ describe('deduplicateTxns — Phase F: identifier-first dedup + date-desc sort',
       chargedAmount: 12.5,
     };
     const distinctIds: readonly string[] = ['voucher-1001', 'voucher-1002'];
-    const coffees = distinctIds.map(
-      (id): ITransaction => makeTxn({ ...sharedAttrs, identifier: id }),
+    const coffees = distinctIds.map((id): ITransaction =>
+      makeTxn({ ...sharedAttrs, identifier: id }),
     );
 
     const result = callDedupLegacy(coffees, 0);
@@ -202,8 +202,8 @@ describe('deduplicateTxns — Phase F: identifier-first dedup + date-desc sort',
       orderedByDateDesc[0], // newest second
       orderedByDateDesc[1], // middle last
     ];
-    const txns = insertionOrder.map(
-      (row): ITransaction => makeTxn({ identifier: row.id, date: row.date }),
+    const txns = insertionOrder.map((row): ITransaction =>
+      makeTxn({ identifier: row.id, date: row.date }),
     );
 
     const result = callDedupLegacy(txns, 0);

--- a/src/Tests/Unit/Pipeline/Types/Debug.test.ts
+++ b/src/Tests/Unit/Pipeline/Types/Debug.test.ts
@@ -46,9 +46,8 @@ describe('Feature — WithBankContext', () => {
   });
 
   it('supports async return values', async () => {
-    const result = await runWithBankContext(
-      'bankY',
-      (): Promise<string> => Promise.resolve('done'),
+    const result = await runWithBankContext('bankY', (): Promise<string> =>
+      Promise.resolve('done'),
     );
     expect(result).toBe('done');
   });

--- a/src/Tests/Unit/TelegramOtpFetcher.test.ts
+++ b/src/Tests/Unit/TelegramOtpFetcher.test.ts
@@ -346,8 +346,8 @@ function flushDetachedSideEffects(
   const isReached = spy.mock.calls.length >= targetCalls;
   if (isReached) return Promise.resolve(true);
   if (maxTicks <= 0) return Promise.resolve(false);
-  return Promise.resolve().then(
-    (): Promise<boolean> => flushDetachedSideEffects(spy, targetCalls, maxTicks - 1),
+  return Promise.resolve().then((): Promise<boolean> =>
+    flushDetachedSideEffects(spy, targetCalls, maxTicks - 1),
   );
 }
 
@@ -373,8 +373,8 @@ function flushUntilUrlPresent(spy: jest.Mock, urlRegex: RegExp, maxTicks = 200):
   });
   if (isPresent) return Promise.resolve(true);
   if (maxTicks <= 0) return Promise.resolve(false);
-  return Promise.resolve().then(
-    (): Promise<boolean> => flushUntilUrlPresent(spy, urlRegex, maxTicks - 1),
+  return Promise.resolve().then((): Promise<boolean> =>
+    flushUntilUrlPresent(spy, urlRegex, maxTicks - 1),
   );
 }
 


### PR DESCRIPTION
﻿## Why

`main` was prettier-dirty after the Prettier 3.9.1 dependency bump,
so every PR inherited a failing whole-tree Prettier check. The deps-only
bump did not run the CI job that would have caught the formatting drift.

## What

- Reformatted 36 tracked `src/**` files with Prettier 3.9.1.
- Added the deps output to the `lint-and-types` job-level guard.
- Added the deps output to the `setup-node-deps` step guard.
- Added the deps output to the `Prettier check` step guard.
- Left ESLint and tests-config steps `src`-only.

## Guideline compliance

| Guideline | Verified |
| --- | --- |
| Atomic Conventional commits | ✅ Two commits: `style:` for formatting, `ci(pr):` for the workflow guard. |
| Selective staging | ✅ Used `git add -u -- src` and `git add .github/workflows/pr.yml`; never `git add .`. |
| Hooks | ✅ Committed normally; never used `--no-verify`. |
| ESLint guardrails | ✅ No ESLint rule, canary, or threshold weakened. |
| Formatting | ✅ `npm run format:check` passed with Prettier 3.9.1. |
| CI guard scope | ✅ Exactly three intended `lint-and-types` guard lines changed. |
| PR size | ✅ 37 files changed, below the 150-file cap. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded pull request checks so dependency-only changes now run the lint/type validation bundle.
  * Adjusted formatting across code and tests for consistency, with no behavior changes.

* **Tests**
  * Updated several test helpers and fixtures to use the same cleaner expression style, without changing test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->