### PR TITLE
docs(banks): document Leumi as a Pipeline bank

### DIFF
--- a/docs/banks/index.md
+++ b/docs/banks/index.md
@@ -2,66 +2,66 @@
 
 > **Who this is for:** users picking the right `CompanyTypes` for their bank and looking up credentials, OTP behavior, or known quirks.
 
-19 institutions are supported. **14 are on the Pipeline architecture** (recommended), **5 are on the legacy path** (still ship, on the migration roadmap).
+19 institutions are supported. **15 are on the Pipeline architecture** (recommended), **4 are on the legacy path** (still ship, on the migration roadmap).
 
 ## Quick directory
 
 <div class="grid cards" markdown>
 
--   :material-bank: **Banks (browser engine)**
+- :material-bank: **Banks (browser engine)**
 
-    [Bank Hapoalim](hapoalim.md) · [Beinleumi](beinleumi.md) · [Discount](discount.md) · [Massad](massad.md) · [Mercantile](mercantile.md) · [Otsar Hahayal](otsar-hahayal.md) · [Pagi](pagi.md)
+  [Bank Hapoalim](hapoalim.md) · [Bank Leumi](leumi.md) · [Beinleumi](beinleumi.md) · [Discount](discount.md) · [Massad](massad.md) · [Mercantile](mercantile.md) · [Otsar Hahayal](otsar-hahayal.md) · [Pagi](pagi.md)
 
--   :material-credit-card: **Credit cards (browser engine)**
+- :material-credit-card: **Credit cards (browser engine)**
 
-    [Amex](amex.md) · [Isracard](isracard.md) · [Max](max.md) · [Visa Cal](visacal.md)
+  [Amex](amex.md) · [Isracard](isracard.md) · [Max](max.md) · [Visa Cal](visacal.md)
 
--   :material-api: **API-direct (no browser)**
+- :material-api: **API-direct (no browser)**
 
-    [OneZero](onezero.md) · [Pepper](pepper.md) · [PayBox](paybox.md)
+  [OneZero](onezero.md) · [Pepper](pepper.md) · [PayBox](paybox.md)
 
--   :material-archive: **Legacy (deprecated)**
+- :material-archive: **Legacy (deprecated)**
 
-    [Behatsdaa](behatsdaa.md) · [Beyahad Bishvilha](beyahad-bishvilha.md) · [Bank Leumi](leumi.md) · [Mizrahi Bank](mizrahi.md) · [Bank Yahav](yahav.md)
+  [Behatsdaa](behatsdaa.md) · [Beyahad Bishvilha](beyahad-bishvilha.md) · [Mizrahi Bank](mizrahi.md) · [Bank Yahav](yahav.md)
 
 </div>
 
-## Pipeline-backed banks (14) — credentials at a glance
+## Pipeline-backed banks (15) — credentials at a glance
 
-| Bank | `CompanyTypes` | Credential fields | OTP |
-|---|---|---|---|
-| Amex | `Amex` | `id`, `card6Digits`, `password` | — |
-| Bank Hapoalim | `Hapoalim` | `userCode`, `password` | conditional |
-| Beinleumi | `Beinleumi` | `username`, `password` | required |
-| Discount Bank | `Discount` | `id`, `password`, `num` | — |
-| Isracard | `Isracard` | `id`, `card6Digits`, `password` | — |
-| Massad | `Massad` | `username`, `password` | required |
-| Max | `Max` | `username`, `password` | — |
-| Mercantile Bank | `Mercantile` | `id`, `password`, `num` | — |
-| One Zero | `OneZero` | `email`, `password` | required (API) |
-| Otsar Hahayal | `OtsarHahayal` | `username`, `password` | required |
-| Pagi | `Pagi` | `username`, `password` | required |
-| PayBox | `PayBox` | `phoneNumber` | required (API) |
-| Pepper | `Pepper` | `phoneNumber`, `password` | required (API) |
-| Visa Cal | `VisaCal` | `username`, `password` | — |
+| Bank            | `CompanyTypes` | Credential fields               | OTP            |
+| --------------- | -------------- | ------------------------------- | -------------- |
+| Amex            | `Amex`         | `id`, `card6Digits`, `password` | —              |
+| Bank Hapoalim   | `Hapoalim`     | `userCode`, `password`          | conditional    |
+| Bank Leumi      | `Leumi`        | `username`, `password`          | —              |
+| Beinleumi       | `Beinleumi`    | `username`, `password`          | required       |
+| Discount Bank   | `Discount`     | `id`, `password`, `num`         | —              |
+| Isracard        | `Isracard`     | `id`, `card6Digits`, `password` | —              |
+| Massad          | `Massad`       | `username`, `password`          | required       |
+| Max             | `Max`          | `username`, `password`          | —              |
+| Mercantile Bank | `Mercantile`   | `id`, `password`, `num`         | —              |
+| One Zero        | `OneZero`      | `email`, `password`             | required (API) |
+| Otsar Hahayal   | `OtsarHahayal` | `username`, `password`          | required       |
+| Pagi            | `Pagi`         | `username`, `password`          | required       |
+| PayBox          | `PayBox`       | `phoneNumber`                   | required (API) |
+| Pepper          | `Pepper`       | `phoneNumber`, `password`       | required (API) |
+| Visa Cal        | `VisaCal`      | `username`, `password`          | —              |
 
-## Legacy banks (5) — credentials at a glance
+## Legacy banks (4) — credentials at a glance
 
-| Bank | `CompanyTypes` | Credential fields | OTP |
-|---|---|---|---|
-| Behatsdaa | `Behatsdaa` | `id`, `password` | — |
-| Beyahad Bishvilha | `BeyahadBishvilha` | `id`, `password` | — |
-| Bank Leumi | `Leumi` | `username`, `password` | — |
-| Mizrahi Bank | `Mizrahi` | `username`, `password` | — |
-| Bank Yahav | `Yahav` | `username`, `nationalID`, `password` | — |
+| Bank              | `CompanyTypes`     | Credential fields                    | OTP |
+| ----------------- | ------------------ | ------------------------------------ | --- |
+| Behatsdaa         | `Behatsdaa`        | `id`, `password`                     | —   |
+| Beyahad Bishvilha | `BeyahadBishvilha` | `id`, `password`                     | —   |
+| Mizrahi Bank      | `Mizrahi`          | `username`, `password`               | —   |
+| Bank Yahav        | `Yahav`            | `username`, `nationalID`, `password` | —   |
 
 Source: [`src/Definitions.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Definitions.ts).
 
 ## How to pick the right page
 
-| If you... | Read |
-|---|---|
-| ... just want to scrape with code that works today | The per-bank page for credential fields, then [Quick Start](../quick-start.md) |
-| ... want to know which engine your bank uses (browser vs API) | The per-bank page's "Engine" line |
-| ... hit `INVALID_OTP` or `INVALID_PASSWORD` | The per-bank "Known quirks" section + [Phases → LOGIN](../phases/login.md) / [OTP-FILL](../phases/otp-fill.md) |
-| ... see `WAF_BLOCKED` | The per-bank page (in case of bank-specific quirks) + [Error Types → WAF](https://github.com/sergienko4/israeli-bank-scrapers#error-types) |
+| If you...                                                     | Read                                                                                                                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| ... just want to scrape with code that works today            | The per-bank page for credential fields, then [Quick Start](../quick-start.md)                                                             |
+| ... want to know which engine your bank uses (browser vs API) | The per-bank page's "Engine" line                                                                                                          |
+| ... hit `INVALID_OTP` or `INVALID_PASSWORD`                   | The per-bank "Known quirks" section + [Phases → LOGIN](../phases/login.md) / [OTP-FILL](../phases/otp-fill.md)                             |
+| ... see `WAF_BLOCKED`                                         | The per-bank page (in case of bank-specific quirks) + [Error Types → WAF](https://github.com/sergienko4/israeli-bank-scrapers#error-types) |

--- a/docs/banks/leumi.md
+++ b/docs/banks/leumi.md
@@ -1,25 +1,57 @@
 # Bank Leumi
 
---8<-- "_deprecated.md"
-
-| | |
-|---|---|
-| `CompanyTypes` | `Leumi` |
-| Engine | **Legacy** (`BaseScraperWithBrowser`) — **not on Pipeline** |
-| Credentials | `username`, `password` |
-| OTP | — |
-| Registry | `SCRAPER_REGISTRY_LEUMI_TO_YAHAV` |
-| Source | [`src/Scrapers/Leumi/LeumiScraper.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Leumi/LeumiScraper.ts) |
+|                |                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CompanyTypes` | `Leumi`                                                                                                                                                  |
+| Engine         | Browser (Pipeline)                                                                                                                                       |
+| Credentials    | `username`, `password`                                                                                                                                   |
+| OTP            | —                                                                                                                                                        |
+| Phase chain    | INIT → HOME → LOGIN → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE → TERMINATE                                                |
+| Source         | [`Banks/Leumi/LeumiPipeline.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Banks/Leumi/LeumiPipeline.ts) |
 
 ## Quick example
 
 ```typescript
+import { CompanyTypes, createScraper } from '@sergienko4/israeli-bank-scrapers';
+
+const scraper = createScraper({
+  companyId: CompanyTypes.Leumi,
+  startDate: new Date('2024-01-01'),
+});
+
 const result = await scraper.scrape({
   username: 'myuser',
   password: 'mypassword',
 });
 ```
 
-## Migration status
+## Pipeline specifics
 
-**Wave 1** target in the [migration plan](../architecture/migration.md) — Leumi is one of the highest-traffic legacy banks, so it lands first to surface regressions early. Until then, `createScraper(CompanyTypes.Leumi, ...)` uses the legacy scraper. Public API and result shape preserved.
+Leumi is a **real-browser** Pipeline bank: Camoufox drives `https://www.leumi.co.il`, and post-login network-traffic discovery does the rest — no imperative scraping code. Its config entry ([`Registry/Config/PipelineBankConfig.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Registry/Config/PipelineBankConfig.ts)) is minimal:
+
+| Key                | Value                                                                             |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `urls.base`        | `https://www.leumi.co.il` — INIT navigates here; LOGIN reuses it as the login URL |
+| `balanceKind`      | `ACCOUNT` — live balance resolved per bank-account in BALANCE-RESOLVE             |
+| `authStrategyKind` | `SESSION_COOKIE` — the session is carried by cookies, not a bearer token          |
+
+**Login is zero-config.** `LEUMI_LOGIN` ships **empty selector arrays** and the migration added **no `LoginWK` entries** — `SelectorResolver` matches the `username`/`password` inputs and submit button from the generic Well-Known login candidates (visible text), per the repo's ZERO-CSS-selectors rule. The builder wires only `.withBrowser()` + `.withDeclarativeLogin(LEUMI_LOGIN)`, so there is no PRE-LOGIN and no OTP.
+
+**Everything past login extends generic Well-Known dictionaries.** The migration added bank-specific values to five otherwise-generic WK dictionaries — the normal shape of a browser-bank change, not an exception:
+
+| Generic dictionary       | Leumi's addition                                                         | Why it's needed                                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ScrapeWK.ts`            | `/GetBusinessAccountTrx/i` list-endpoint pattern                         | Leumi's WCF txn module abbreviates `Trx` (not `Transactions`), so the generic `get\w*Transactions` pattern misses it                                                                                   |
+| `DashboardWK.ts`         | `/\bBusinessAccountTrx\b/i` route pattern                                | Leumi's SPA hash-route (`SPA.aspx#/ts/BusinessAccountTrx`) for the transactions view                                                                                                                   |
+| `ScrapeFieldMappings.ts` | `accountsItems` container · `DateUTC` date alias · `ReferenceNumberLong` | maps Leumi's WCF `UC_SO_27_GetBusinessAccountTrx` rows (and the accounts container) onto the canonical shape — without the `DateUTC` alias, `autoMapTransaction` rejects every Leumi txn as empty-date |
+| `ScrapeIdFields.ts`      | `MaskedNumber` · `AccountIndex`                                          | Leumi's account display-id / query-id field names                                                                                                                                                      |
+| `SharedWK.ts`            | `'סגירה'` close-popup text (ariaLabel + exactText)                       | dismiss Leumi's cookie-consent overlay so HOME can reach the login link                                                                                                                                |
+
+To add a bank like this, see [Adding a new bank](../contributing/new-bank.md) — it walks through the same builder-and-Well-Known steps Leumi uses.
+
+## Known quirks
+
+- HOME dismisses Leumi's cookie-consent overlay (the `'סגירה'` close control added to `SharedWK`) before it can reach the login link.
+- No OTP — plain `username`/`password` login; the pipeline is 100% generic via network-traffic discovery.
+- Transactions arrive from Leumi's WCF endpoint `UC_SO_27_GetBusinessAccountTrx`; its rows carry the date as `DateUTC` and the per-txn reference as `ReferenceNumberLong` (see the Well-Known extensions above).
+- BALANCE-RESOLVE is per-bank-account (`balanceKind: ACCOUNT`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
       - Browser:
           - Amex: banks/amex.md
           - Bank Hapoalim: banks/hapoalim.md
+          - Bank Leumi: banks/leumi.md
           - Beinleumi: banks/beinleumi.md
           - Discount: banks/discount.md
           - Isracard: banks/isracard.md
@@ -169,7 +170,6 @@ nav:
       - Legacy (deprecated):
           - Behatsdaa: banks/behatsdaa.md
           - Beyahad Bishvilha: banks/beyahad-bishvilha.md
-          - Bank Leumi: banks/leumi.md
           - Mizrahi Bank: banks/mizrahi.md
           - Bank Yahav: banks/yahav.md
   - Observability:


### PR DESCRIPTION
## Why

Bank Leumi was migrated to the declarative **Pipeline** architecture in PR #381 (`b1301722`), but the documentation never caught up:

- `docs/banks/leumi.md` still described Leumi as a **legacy, not-on-Pipeline** bank (stale `_deprecated.md` include, a legacy `LeumiScraper.ts` source link, a "Wave 1 migration target" section).
- `docs/banks/index.md` listed Leumi under **Legacy (deprecated)** in both the quick-directory card and the credentials table, with wrong counts (14 Pipeline / 5 legacy).

This misleads users into thinking Leumi runs on the old imperative scraper. This PR brings the reference docs in line with the shipped code.

## What

- **`docs/banks/leumi.md`** — full rewrite to the Pipeline bank-doc shape:
  - Engine **Browser (Pipeline)**; phase chain `INIT -> HOME -> LOGIN -> AUTH-DISCOVERY -> ACCOUNT-RESOLVE -> DASHBOARD -> SCRAPE -> BALANCE-RESOLVE -> TERMINATE`.
  - Login is **zero-config** (`LEUMI_LOGIN` ships empty selector arrays; the migration added **no `LoginWK` entry** per `git show b1301722 --stat`).
  - `PipelineBankConfig` facts: base `https://www.leumi.co.il`, `balanceKind: ACCOUNT`, `authStrategyKind: SESSION_COOKIE`.
  - The five Well-Known dictionaries Leumi extends, with real identifiers (`ScrapeWK` GetBusinessAccountTrx; `DashboardWK` BusinessAccountTrx; `ScrapeFieldMappings` accountsItems / DateUTC / ReferenceNumberLong; `ScrapeIdFields` MaskedNumber / AccountIndex; `SharedWK` close-button text).
- **`docs/banks/index.md`** — move Leumi from **Legacy -> Pipeline** in the directory card and the credentials table; fix counts to **15 Pipeline / 4 legacy**. (The file was pre-existing prettier-dirty, so prettier 3.8 also re-aligned its markdown tables in place — incidental, no content change beyond the Leumi move.)
- **`mkdocs.yml`** — nav: move Leumi from Legacy to Browser.

No source code touched. No `.env`/secrets read or modified. No E2E run.

## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | Conventional Commits + 50/72 (`commit-guidlines.md`) | OK — subject 46 chars; body wrapped <=72; `Co-authored-by: Copilot` trailer present |
| 2 | Single-responsibility PR (`pr-guidlines.md` S2) | OK — one logical change: document Leumi as a Pipeline bank |
| 3 | Docs are code-grounded (`git-hub-readme-guidlines`, BLUF) | OK — every claim cites source: `LeumiPipeline.ts`, `PipelineBankConfig.ts`, the 5 WK files, and PR #381 `b1301722` |
| 4 | Docs-only — husky docs gates | OK — prettier `--check` clean; `docs:strict` ran (mkdocs soft-skip); no `src/**` change so code gates do not apply |
| 5 | `{{BRANCH}}` source-link placeholder preserved | OK — all source links use `{{BRANCH}}` |
| 6 | No secrets / `.env` untouched (`logging-pii-guidlines`) | OK — no secrets; `.env` not read or modified |
| 7 | Self-review before review (`pr-guidlines.md` S3) | OK — diff reviewed line-by-line; only the intended Leumi moves + prettier alignment |

Code-specific gates (canaries, coverage 97/95/97/98, `lib/index.cjs` byte-identity, `madge --circular`) are **N/A**: this PR changes only Markdown + mkdocs nav.