### PR TITLE
chore(lint): guard against tests duplicating production logic

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -195,6 +195,7 @@ bg_gate "canaries"          "yes" npm run lint:canaries
 bg_gate "dead-code"         "yes" npm run lint:dead-code
 bg_gate "cycles"            "yes" npm run lint:cycles
 bg_gate "guideline-coverage" "yes" npm run lint:guideline-coverage
+bg_gate "test-duplication"  "yes" npm run lint:test-duplication
 bg_gate "bank-coverage"     "yes" npm run lint:bank-coverage
 bg_gate "fixtures-pii"      "yes" npm run lint:fixtures-pii
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This snippet shows the redacted shape produced by the [redaction layer](#logging
 | Bank Hapoalim      | Browser    | `userCode`, `password`, OTP          |
 | Bank Leumi         | Browser    | `username`, `password`               |
 | Bank Otsar Hahayal | Browser    | `username`, `password`, OTP          |
-| Bank Yahav         | Browser    | `username`, `nationalID`, `password` |
+| Bank Yahav         | Browser    | `num`, `nationalID`, `password`      |
 | Behatsdaa          | Browser    | `id`, `password`                     |
 | Beinleumi          | Browser    | `username`, `password`, OTP          |
 | Beyahad Bishvilha  | Browser    | `id`, `password`                     |
@@ -243,7 +243,7 @@ This snippet shows the redacted shape produced by the [redaction layer](#logging
 
 </details>
 
-> **Migration notice (wide-net policy):** 5 banks are still on the **legacy** scraper path — _Behatsdaa_, _Beyahad Bishvilha_, _Bank Leumi_, _Mizrahi Bank_, _Bank Yahav_. They keep working through the same `createScraper(...)` entry point, but new features and bug fixes target the Pipeline architecture. They are scheduled for migration; the broader `src/Scrapers/Base/`, `src/Common/`, and legacy bank folders are also on the migration path and will be folded into `src/Scrapers/Pipeline/` over time. Public API behavior is preserved.
+> **Migration notice (wide-net policy):** 3 banks are still on the **legacy** scraper path — _Behatsdaa_, _Beyahad Bishvilha_, _Mizrahi Bank_. They keep working through the same `createScraper(...)` entry point, but new features and bug fixes target the Pipeline architecture. They are scheduled for migration; the broader `src/Scrapers/Base/`, `src/Common/`, and legacy bank folders are also on the migration path and will be folded into `src/Scrapers/Pipeline/` over time. Public API behavior is preserved.
 
 ## OTP (Two-Factor Authentication)
 

--- a/docs/architecture/layers.md
+++ b/docs/architecture/layers.md
@@ -34,7 +34,7 @@ flowchart TB
 | 3   | Pipeline mediator            | `src/Scrapers/Pipeline/Mediator/` (BalanceResolve, Browser, Dashboard, Elements, Form, Login, Network, OtpFill, OtpTrigger, Scrape, …)                                                                                                                             | Canonical                                             |
 | 4   | Pipeline strategy + registry | `src/Scrapers/Pipeline/Strategy/`, `src/Scrapers/Pipeline/Banks/`, `src/Scrapers/Pipeline/Registry/`, `src/Scrapers/Registry/Factory.ts`                                                                                                                           | Canonical                                             |
 | 5   | Pipeline types               | `src/Scrapers/Pipeline/Types/`, `src/Scrapers/Base/{Interface, ErrorTypes, ScraperError, Config/, Interfaces/}`                                                                                                                                                    | Shared infra                                          |
-| 6   | Legacy scrapers              | `src/Scrapers/Base/{BaseScraper, BaseScraperWithBrowser, BaseScraperHelpers, ConcreteGenericScraper, GenericBankScraper}.ts`, `src/Scrapers/{Behatsdaa, BeyahadBishvilha, Leumi, Mizrahi}/`, `src/Scrapers/Registry/ScraperRegistryLeumiToYahav.ts` (Mizrahi only) | **Deprecated**                                        |
+| 6   | Legacy scrapers              | `src/Scrapers/Base/{BaseScraper, BaseScraperWithBrowser, BaseScraperHelpers, ConcreteGenericScraper, GenericBankScraper}.ts`, `src/Scrapers/{Behatsdaa, BeyahadBishvilha, Mizrahi}/`, `src/Scrapers/Registry/ScraperRegistryLeumiToYahav.ts` (Mizrahi only) | **Deprecated**                                        |
 | 7   | Common utilities             | `src/Common/` (Browser, CamoufoxLauncher, Fetch, Navigation, OtpDetector, OtpHandler, ResultFormatter, SafeScreenshot, SelectorResolver, Storage, Waiting, …)                                                                                                      | **Mostly deprecated** — pipeline uses only `Debug.ts` |
 | 8   | Tests                        | `src/Tests/Unit/`, `src/Tests/E2eMocked/`, `src/Tests/E2eReal/`, `src/Tests/Helpers/`, `src/Tests/Tools/`                                                                                                                                                          | Always-on gate                                        |
 | 9   | Build & CI                   | `.github/workflows/`, `.husky/`, `tsup.config.ts`, `biome.json`, `eslint.config.mjs`, `tsconfig.json`                                                                                                                                                              | Always-on gate                                        |
@@ -51,7 +51,7 @@ flowchart TB
 
 **Layer 6 (legacy)** still works through `createScraper` but is on the migration path:
 
-- The 4 legacy bank dirs (Behatsdaa, BeyahadBishvilha, Leumi, Mizrahi) — Yahav migrated to Pipeline
+- The 3 legacy bank dirs (Behatsdaa, BeyahadBishvilha, Mizrahi) — Leumi + Yahav migrated to Pipeline
 - The 5 legacy base classes (`BaseScraper`, `BaseScraperWithBrowser`, `BaseScraperHelpers`, `ConcreteGenericScraper`, `GenericBankScraper`)
 - The legacy registry (`ScraperRegistryLeumiToYahav.ts`)
 

--- a/docs/architecture/legacy.md
+++ b/docs/architecture/legacy.md
@@ -12,11 +12,11 @@ Everything **outside `src/Scrapers/Pipeline/`** except the **layer-5 shared infr
 | ----------------- | -------------------------------------------------- | -------------------------------------------- |
 | Behatsdaa         | `src/Scrapers/Behatsdaa/BehatsdaaScraper.ts`       | `SCRAPER_REGISTRY_AMEX_TO_ISRACARD` (subset) |
 | Beyahad Bishvilha | (registered in `ScraperRegistryAmexToIsracard.ts`) | `SCRAPER_REGISTRY_AMEX_TO_ISRACARD`          |
-| Bank Leumi        | `src/Scrapers/Leumi/LeumiScraper.ts`               | `SCRAPER_REGISTRY_LEUMI_TO_YAHAV`            |
 | Mizrahi Bank      | `src/Scrapers/Mizrahi/MizrahiScraper.ts`           | `SCRAPER_REGISTRY_LEUMI_TO_YAHAV`            |
 
-> **Bank Yahav** was migrated to the Pipeline and its legacy scraper deleted —
-> it is now pipeline-only (see [Bank Yahav](../banks/yahav.md)).
+> **Bank Leumi** and **Bank Yahav** were migrated to the Pipeline and their
+> legacy scrapers deleted — they are now pipeline-only (see
+> [Bank Leumi](../banks/leumi.md), [Bank Yahav](../banks/yahav.md)).
 
 ### Legacy base classes
 
@@ -43,8 +43,8 @@ Everything **outside `src/Scrapers/Pipeline/`** except the **layer-5 shared infr
 
 ## Why ship deprecated code?
 
-1. **Public API compatibility** — `createScraper(CompanyTypes.Leumi, ...)` already works; removing it would be a breaking change.
-2. **Migration is incremental** — porting Leumi to Pipeline requires writing a `LoginConfig`, a `PipelineDescriptor`, and registering in `PIPELINE_REGISTRY`. That's a per-bank PR, not a single sweep.
+1. **Public API compatibility** — `createScraper(CompanyTypes.Mizrahi, ...)` already works; removing it would be a breaking change.
+2. **Migration is incremental** — porting Mizrahi to Pipeline requires writing a `LoginConfig`, a `PipelineDescriptor`, and registering in `PIPELINE_REGISTRY`. That's a per-bank PR, not a single sweep.
 3. **Two-registry dispatch is safe** — `Factory.tryPipeline` is consulted first; legacy is a fallback. When a bank moves to Pipeline, `createScraper` automatically routes there with no caller change.
 
 ## What new code should NOT touch

--- a/docs/architecture/migration.md
+++ b/docs/architecture/migration.md
@@ -29,7 +29,7 @@ For each legacy bank, the porting PR does:
 | 6 | Once green, delete `src/Scrapers/<Bank>/` and remove from `SCRAPER_REGISTRY_LEUMI_TO_YAHAV.ts` or its sibling |
 | 7 | Re-run `lint:dead-code` to confirm no unused exports remain |
 
-The 14 banks already on Pipeline followed exactly this sequence over v8.3 → v8.4.
+The 16 banks already on Pipeline followed exactly this sequence.
 
 ## Per-utility migration sequence
 
@@ -44,6 +44,9 @@ For each `src/Common/` helper that the Pipeline does NOT already use:
 | 5 | When the last legacy caller is migrated, delete the original |
 
 ## Order of operations (proposed)
+
+> **Status:** Bank Leumi (wave 1) and Bank Yahav (wave 2) have since migrated to
+> the Pipeline; Mizrahi, Behatsdaa, and Beyahad Bishvilha remain.
 
 | Wave | Banks to migrate | Why this wave |
 |---|---|---|
@@ -62,7 +65,7 @@ Each wave is a separate PR, gated by:
 
 ## Why this order?
 
-- **Mizrahi + Leumi first** — they're the highest-traffic legacy banks, so any regression surfaces fastest in downstream consumers (Caspion, Moneyman, Actual Budget importer).
+- **Mizrahi + Leumi first** — the highest-traffic legacy banks (Leumi has since migrated), so any regression surfaces fastest in downstream consumers (Caspion, Moneyman, Actual Budget importer).
 - **Banks before utilities** — utilities can't safely be deleted while a single legacy bank still imports them. Migrate all bank surfaces, then fold the helpers.
 - **Base classes last** — they are an implementation detail; once no caller imports them, they go.
 

--- a/docs/banks/mizrahi.md
+++ b/docs/banks/mizrahi.md
@@ -22,4 +22,4 @@ const result = await scraper.scrape({
 
 ## Migration status
 
-**Wave 1** target in the [migration plan](../architecture/migration.md) — Mizrahi is a high-traffic legacy bank, so it lands in the first migration wave alongside Leumi.
+**Wave 1** target in the [migration plan](../architecture/migration.md) — Mizrahi is a high-traffic legacy bank, so it lands in the first migration wave — alongside Bank Leumi, which has since migrated to the Pipeline.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lint:dead-code": "npx tsx src/Tests/Tools/detect-dead-code.ts",
     "lint:cycles": "npx tsx src/Tests/Tools/lint-import-cycles.ts",
     "lint:guideline-coverage": "npx tsx src/Tests/Tools/lint-guideline-coverage.ts",
+    "lint:test-duplication": "npx tsx src/Tests/Tools/lint-test-duplication.ts",
     "lint:bank-coverage": "npx tsx src/Tests/Integration/Tools/CheckBankIntegrationCoverage.ts",
     "lint:fixtures-pii": "node scripts/audit-fixtures-pii.cjs",
     "lint:docs-strict": "python -m mkdocs build --strict --site-dir .mkdocs-strict-out",

--- a/src/Tests/Integration/README.md
+++ b/src/Tests/Integration/README.md
@@ -150,9 +150,9 @@ directory under `src/Scrapers/Pipeline/Banks/` and verifies:
   `bankId`.
 - `fixtures/banks/<bankId>/` exists.
 
-Legacy non-pipeline banks (Leumi, Mizrahi, Yahav, Behatsdaa,
-BeyahadBishvilha) and API-direct providers (OneZero, Pepper, PayBox)
-are explicitly allow-listed and exempted from the gate.
+Legacy non-pipeline banks (Mizrahi, Behatsdaa, BeyahadBishvilha) and
+API-direct providers (OneZero, Pepper, PayBox) are explicitly
+allow-listed and exempted from the gate.
 
 Wiring:
 

--- a/src/Tests/Tools/lint-test-duplication.ts
+++ b/src/Tests/Tools/lint-test-duplication.ts
@@ -1,0 +1,338 @@
+/**
+ * TEST-DUPLICATION CANARY — fails when a `*.test.ts` function body is
+ * byte-identical (comment/whitespace-normalized) to a production
+ * (shipped `src/**`) function body.
+ *
+ * Enforces the guideline "Tests must NOT duplicate production logic —
+ * import and reuse shared helpers from production code." A verbatim copy
+ * silently drifts when the production helper changes, masking the very
+ * regression the test should catch (CodeRabbit flagged exactly this on
+ * PR #405: a test-local `todayParts` re-implemented `todayDatePart`).
+ *
+ * Scope:
+ *   • test side       = files ending `.test.ts`.
+ *   • production side  = every other `src/**` `.ts` that {@link isProdFile}
+ *     accepts (not under `src/Tests/`, not a `.d.ts`) — shipped library
+ *     logic.
+ *   • test infra under `src/Tests/` that is not a `.test.ts` (helpers,
+ *     factories, fixtures, Tools) is ignored on both sides: sharing a
+ *     helper body across tests is allowed and is not "production logic".
+ *
+ * Only bodies with >= MIN_BODY_CHARS normalized characters are compared,
+ * so trivial one-liners (`return x;`) never trip the gate. Legitimate
+ * matches go in ALLOWLIST with a justifying comment.
+ *
+ * Invoked via `npm run lint:test-duplication`; wired into the pre-commit
+ * gate ladder so a duplicated test body cannot reach `origin`.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import ts from 'typescript';
+
+import { isProdFile } from './ImportGraphScan.js';
+
+const REPO_ROOT = process.cwd();
+const SRC_ROOT = path.join(REPO_ROOT, 'src');
+
+/**
+ * Minimum normalized body length compared. Trivial pass-through stubs
+ * (e.g. `succeed(input); return Promise.resolve(result)`) normalize to
+ * ~55 chars and are not "logic"; the real multi-statement duplication
+ * this gate targets is >= ~100 chars. 70 is the floor between the two.
+ */
+const MIN_BODY_CHARS = 70;
+
+/**
+ * Test bodies (`relativePath:functionName`, forward-slash) allowed to
+ * coincide with a production body. Each entry needs a comment justifying
+ * why importing the production helper is not the right fix.
+ */
+const ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  // M2 (CI quality hardening) inverted the Network<-AccountResolve dependency:
+  // Network owns `waitForFirstId`; ACCOUNT-RESOLVE owns the shape predicate.
+  // This Network-primitive test mirrors the production-shape predicate to
+  // exercise `waitForFirstId` WITHOUT importing AccountResolve internals —
+  // exporting the internal `findFirstIdInPool` to share it would re-introduce
+  // the coupling M2 removed. Deliberate, documented copy.
+  'src/Tests/Unit/Pipeline/Mediator/Network/WaitForFirstId.test.ts:findFirstIdInPool',
+]);
+
+/** One function body, located + normalized for comparison. */
+interface IBody {
+  readonly file: string;
+  readonly line: number;
+  readonly name: string;
+  readonly norm: string;
+}
+
+/** A test body that matches a production body. */
+interface IViolation {
+  readonly test: IBody;
+  readonly prod: IBody;
+}
+
+/** Sentinel returned by side-effecting helpers (no-void rule). */
+type Done = true;
+
+/**
+ * Recursively collect every `.ts` file under `dir` (skips `.d.ts`). Walks
+ * from `src/`, which contains no `node_modules`, so no prune is needed.
+ * @param dir - Directory to walk.
+ * @param out - Accumulator (mutated).
+ * @returns Sentinel true once recursion completes.
+ */
+function walkAllTs(dir: string, out: string[]): Done {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkAllTs(full, out);
+    } else if (full.endsWith('.ts') && !full.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return true;
+}
+
+/**
+ * Whether a node is a function-like declaration that can carry a block body.
+ * @param node - Any AST node.
+ * @returns True for function/arrow/method declarations.
+ */
+function isFnLike(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node)
+  );
+}
+
+/**
+ * The `{ ... }` block body of a function-like node, or false.
+ * @param node - Any AST node.
+ * @returns The block body, or false when absent / expression-bodied.
+ */
+function fnBlock(node: ts.Node): ts.Block | false {
+  if (!isFnLike(node)) return false;
+  const body = (node as ts.FunctionLikeDeclaration).body;
+  if (body !== undefined && ts.isBlock(body)) return body;
+  return false;
+}
+
+/**
+ * Strip comments + all whitespace so formatting/comment differences do
+ * not hide a copy.
+ * @param text - Raw body source text.
+ * @returns The canonical (comparable) form.
+ */
+export function normalizeBody(text: string): string {
+  const noBlock = text.replace(/\/\*[\s\S]*?\*\//g, '');
+  const noLine = noBlock.replace(/\/\/[^\n]*/g, '');
+  return noLine.replace(/\s+/g, '');
+}
+
+/**
+ * Best-effort function name for reporting — own name, else the enclosing
+ * `const x = () => {}` / property name, else `(anonymous)`.
+ * @param node - The function-like node.
+ * @param sf - Its source file (for `getText`).
+ * @returns A human-readable name.
+ */
+function fnName(node: ts.Node, sf: ts.SourceFile): string {
+  const named = node as { name?: ts.Node };
+  if (named.name) return named.name.getText(sf);
+  const parent = node.parent as { name?: ts.Node } | undefined;
+  if (parent?.name) return parent.name.getText(sf);
+  return '(anonymous)';
+}
+
+/**
+ * Append one function body to `out` when it clears the size floor.
+ * @param sf - Source file being walked.
+ * @param node - Candidate AST node.
+ * @param out - Accumulator (mutated).
+ * @returns Sentinel true (side-effecting helper).
+ */
+function pushBody(sf: ts.SourceFile, node: ts.Node, out: IBody[]): Done {
+  const body = fnBlock(node);
+  if (body === false) return true;
+  const bodyText = body.getText(sf);
+  const norm = normalizeBody(bodyText);
+  if (norm.length < MIN_BODY_CHARS) return true;
+  const entry = makeBody(sf, node, norm);
+  out.push(entry);
+  return true;
+}
+
+/**
+ * Build the located, normalized body record for one function node.
+ * @param sf - Source file being walked.
+ * @param node - The function-like node.
+ * @param norm - Its normalized body.
+ * @returns The body record (repo-relative, forward-slash path).
+ */
+function makeBody(sf: ts.SourceFile, node: ts.Node, norm: string): IBody {
+  const start = node.getStart(sf);
+  const pos = sf.getLineAndCharacterOfPosition(start);
+  const abs = path.relative(REPO_ROOT, sf.fileName);
+  const file = abs.split(path.sep).join('/');
+  const name = fnName(node, sf);
+  return { file, line: pos.line + 1, name, norm };
+}
+
+/**
+ * Recursively walk a node collecting every qualifying body. The
+ * `forEachChild` callback returns `false` so the walk visits every child
+ * (a truthy return would stop `forEachChild` after the first).
+ * @param sf - Source file being walked.
+ * @param node - Current node.
+ * @param out - Accumulator (mutated).
+ * @returns Sentinel true once the subtree is walked.
+ */
+function collectFromNode(sf: ts.SourceFile, node: ts.Node, out: IBody[]): Done {
+  pushBody(sf, node, out);
+  ts.forEachChild(node, (child): false => {
+    collectFromNode(sf, child, out);
+    return false;
+  });
+  return true;
+}
+
+/**
+ * Parse one file and collect its qualifying function bodies.
+ * @param file - Absolute file path.
+ * @returns All bodies clearing the size floor.
+ */
+function collectBodies(file: string): IBody[] {
+  const text = fs.readFileSync(file, 'utf8');
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  const out: IBody[] = [];
+  collectFromNode(sf, sf, out);
+  return out;
+}
+
+/**
+ * Route one file's bodies into the test or production bucket.
+ * @param file - Absolute file path.
+ * @param prod - Production accumulator (mutated).
+ * @param test - Test accumulator (mutated).
+ * @returns Sentinel true (side-effecting helper).
+ */
+function classifyBodies(file: string, prod: IBody[], test: IBody[]): Done {
+  const bodies = collectBodies(file);
+  if (file.endsWith('.test.ts')) {
+    test.push(...bodies);
+    return true;
+  }
+  if (isProdFile(file)) prod.push(...bodies);
+  return true;
+}
+
+/**
+ * Walk `src/` and split every function body into test vs production.
+ * @returns The two body buckets.
+ */
+function gatherBodies(): { prod: IBody[]; test: IBody[] } {
+  const all: string[] = [];
+  walkAllTs(SRC_ROOT, all);
+  const prod: IBody[] = [];
+  const test: IBody[] = [];
+  for (const file of all) classifyBodies(file, prod, test);
+  return { prod, test };
+}
+
+/**
+ * Index production bodies by normalized text (first occurrence wins).
+ * @param bodies - All production bodies.
+ * @returns Map from normalized body to its source.
+ */
+function indexByNorm(bodies: readonly IBody[]): Map<string, IBody> {
+  const map = new Map<string, IBody>();
+  for (const body of bodies) if (!map.has(body.norm)) map.set(body.norm, body);
+  return map;
+}
+
+/**
+ * Find every test body that is byte-identical to a production body.
+ * Pure — exported so a unit test drives it on synthetic bodies.
+ * @param prod - Production bodies.
+ * @param test - Test bodies.
+ * @returns The violations (test body <-> production body).
+ */
+export function detectDuplicates(prod: readonly IBody[], test: readonly IBody[]): IViolation[] {
+  const prodIndex = indexByNorm(prod);
+  const out: IViolation[] = [];
+  for (const body of test) {
+    const key = `${body.file}:${body.name}`;
+    if (ALLOWLIST.has(key)) continue;
+    const match = prodIndex.get(body.norm);
+    if (match) out.push({ test: body, prod: match });
+  }
+  return out;
+}
+
+/**
+ * Print one violation as `test:line name <-> prod:line name`.
+ * @param violation - The matched pair.
+ * @returns Sentinel true (side-effecting helper).
+ */
+function printViolation(violation: IViolation): Done {
+  const t = `${violation.test.file}:${String(violation.test.line)} ${violation.test.name}`;
+  const p = `${violation.prod.file}:${String(violation.prod.line)} ${violation.prod.name}`;
+  console.error(`   ${t}  <->  ${p}`);
+  return true;
+}
+
+/**
+ * Report violations and exit non-zero.
+ * @param violations - The matched pairs.
+ * @returns Never — the process exits first.
+ */
+function reportAndExit(violations: readonly IViolation[]): Done {
+  console.error('❌ TEST DUPLICATION — test bodies identical to production logic:');
+  for (const violation of violations) printViolation(violation);
+  console.error('');
+  console.error('   Import and reuse the production helper instead of copying its');
+  console.error('   body. If the match is genuinely intentional, add the test-side');
+  console.error('   `relativePath:functionName` to ALLOWLIST in');
+  console.error('   src/Tests/Tools/lint-test-duplication.ts with a justifying comment.');
+  process.exit(1);
+}
+
+/**
+ * Drive the canary end-to-end. Importable (guarded by {@link isMainModule})
+ * so unit tests can load this module without triggering a walk or exit.
+ * @returns Sentinel true once the canary completes successfully.
+ */
+function runCanary(): Done {
+  const { prod, test } = gatherBodies();
+  const violations = detectDuplicates(prod, test);
+  if (violations.length > 0) return reportAndExit(violations);
+  console.log(
+    `✅ Test-duplication canary clean — ${String(test.length)} test bodies, no production copies`,
+  );
+  return true;
+}
+
+/**
+ * Whether this module is the process entry point (direct `tsx` run).
+ * @returns True when invoked as the main module.
+ */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return path.resolve(entry).endsWith('lint-test-duplication.ts');
+}
+
+/**
+ * Entry-point wrapper — discards the sentinel via a typed binding.
+ * @returns The sentinel emitted by the runner.
+ */
+function bootCanary(): Done {
+  const didComplete = runCanary();
+  return didComplete;
+}
+
+if (isMainModule()) bootCanary();

--- a/src/Tests/Tools/lint-test-duplication.ts
+++ b/src/Tests/Tools/lint-test-duplication.ts
@@ -60,7 +60,7 @@ const ALLOWLIST: ReadonlySet<string> = new Set<string>([
 ]);
 
 /** One function body, located + normalized for comparison. */
-interface IBody {
+export interface IBody {
   readonly file: string;
   readonly line: number;
   readonly name: string;

--- a/src/Tests/Unit/Tools/LintTestDuplication.test.ts
+++ b/src/Tests/Unit/Tools/LintTestDuplication.test.ts
@@ -11,20 +11,35 @@
  * re-commented copy still collides).
  */
 
-import { detectDuplicates, normalizeBody } from '../../../Tests/Tools/lint-test-duplication.js';
+import {
+  detectDuplicates,
+  type IBody,
+  normalizeBody,
+} from '../../../Tests/Tools/lint-test-duplication.js';
+
+/**
+ * Minimal `IBody`-shaped fixture; override only the fields a case needs.
+ * @param overrides - Fields to override on the default fixture.
+ * @returns One `IBody` fixture.
+ */
+function makeBody(overrides: Partial<IBody> = {}): IBody {
+  return { file: 'src/Foo.ts', line: 10, name: 'helper', norm: 'BODYX', ...overrides };
+}
 
 describe('lint-test-duplication — detectDuplicates', () => {
   it('flags a test body byte-identical to a production body', () => {
-    const prod = [{ file: 'src/Foo.ts', line: 10, name: 'helper', norm: 'BODYX' }];
-    const test = [{ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'copy', norm: 'BODYX' }];
+    const prod = [makeBody()];
+    const test = [makeBody({ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'copy' })];
     const violations = detectDuplicates(prod, test);
     const pairs = violations.map((v): string => `${v.test.name}<->${v.prod.name}`);
     expect(pairs).toEqual(['copy<->helper']);
   });
 
   it('ignores a test body that matches nothing in production', () => {
-    const prod = [{ file: 'src/Foo.ts', line: 10, name: 'helper', norm: 'AAA' }];
-    const test = [{ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'other', norm: 'BBB' }];
+    const prod = [makeBody({ norm: 'AAA' })];
+    const test = [
+      makeBody({ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'other', norm: 'BBB' }),
+    ];
     const violations = detectDuplicates(prod, test);
     expect(violations).toEqual([]);
   });
@@ -32,8 +47,8 @@ describe('lint-test-duplication — detectDuplicates', () => {
   it('honours the allowlist for the documented intentional copy', () => {
     const prodFile = 'src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts';
     const testFile = 'src/Tests/Unit/Pipeline/Mediator/Network/WaitForFirstId.test.ts';
-    const prod = [{ file: prodFile, line: 54, name: 'findFirstIdInPool', norm: 'DUP' }];
-    const test = [{ file: testFile, line: 30, name: 'findFirstIdInPool', norm: 'DUP' }];
+    const prod = [makeBody({ file: prodFile, line: 54, name: 'findFirstIdInPool', norm: 'DUP' })];
+    const test = [makeBody({ file: testFile, line: 30, name: 'findFirstIdInPool', norm: 'DUP' })];
     const violations = detectDuplicates(prod, test);
     expect(violations).toEqual([]);
   });

--- a/src/Tests/Unit/Tools/LintTestDuplication.test.ts
+++ b/src/Tests/Unit/Tools/LintTestDuplication.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the test-duplication canary's pure core — the
+ * normalized-body matcher ({@link detectDuplicates}) and the
+ * comment/whitespace normaliser ({@link normalizeBody}).
+ *
+ * The canary enforces the guideline "Tests must NOT duplicate production
+ * logic — import and reuse shared helpers from production code." These
+ * tests pin the matcher (a byte-identical normalized test body flags),
+ * the allowlist escape hatch (the documented Network<->AccountResolve
+ * `findFirstIdInPool` copy is exempt), and the normaliser (a reformatted,
+ * re-commented copy still collides).
+ */
+
+import { detectDuplicates, normalizeBody } from '../../../Tests/Tools/lint-test-duplication.js';
+
+describe('lint-test-duplication — detectDuplicates', () => {
+  it('flags a test body byte-identical to a production body', () => {
+    const prod = [{ file: 'src/Foo.ts', line: 10, name: 'helper', norm: 'BODYX' }];
+    const test = [{ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'copy', norm: 'BODYX' }];
+    const violations = detectDuplicates(prod, test);
+    const pairs = violations.map((v): string => `${v.test.name}<->${v.prod.name}`);
+    expect(pairs).toEqual(['copy<->helper']);
+  });
+
+  it('ignores a test body that matches nothing in production', () => {
+    const prod = [{ file: 'src/Foo.ts', line: 10, name: 'helper', norm: 'AAA' }];
+    const test = [{ file: 'src/Tests/Unit/Foo.test.ts', line: 20, name: 'other', norm: 'BBB' }];
+    const violations = detectDuplicates(prod, test);
+    expect(violations).toEqual([]);
+  });
+
+  it('honours the allowlist for the documented intentional copy', () => {
+    const prodFile = 'src/Scrapers/Pipeline/Mediator/AccountResolve/AccountResolveActions.Wait.ts';
+    const testFile = 'src/Tests/Unit/Pipeline/Mediator/Network/WaitForFirstId.test.ts';
+    const prod = [{ file: prodFile, line: 54, name: 'findFirstIdInPool', norm: 'DUP' }];
+    const test = [{ file: testFile, line: 30, name: 'findFirstIdInPool', norm: 'DUP' }];
+    const violations = detectDuplicates(prod, test);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('lint-test-duplication — normalizeBody', () => {
+  it('ignores whitespace + line comments so a reformatted copy still collides', () => {
+    const spaced = normalizeBody('{\n  const x = 1; // note\n  return x;\n}');
+    const compact = normalizeBody('{ const x = 1; return x; }');
+    expect(spaced).toBe(compact);
+  });
+
+  it('strips block comments', () => {
+    const stripped = normalizeBody('{ /* doc */ return 1; }');
+    expect(stripped).toBe('{return1;}');
+  });
+});


### PR DESCRIPTION
## Why

CodeRabbit flagged on PR #405 that a test re-implemented a production
helper (`todayParts` re-created `todayDatePart`), violating the guideline
"Tests must NOT duplicate production logic — import and reuse shared
helpers from production code." That class of issue should be caught
locally, before review — not by a human or bot reviewer.

## What

A pre-commit canary (`lint:test-duplication`) that fails when a `*.test.ts`
function body is byte-identical (comment/whitespace-normalized) to a
shipped production function body.

- `src/Tests/Tools/lint-test-duplication.ts` walks `src/` via the
  TypeScript compiler API, normalizes function bodies, and flags a test
  body that matches a production one. Trivial bodies (< 70 normalized
  chars) are ignored so pass-through stubs never trip it; deliberate
  copies go in `ALLOWLIST` with a justifying comment.
- One pre-existing intentional copy is baselined: the Network-primitive
  test's `findFirstIdInPool` mirrors the AccountResolve predicate on
  purpose (M2 dependency inversion; sharing it would re-couple them).
- Wired as `npm run lint:test-duplication` + a pre-commit `bg_gate`
  (husky gate #22).
- A unit test covers the matcher (`detectDuplicates`) and the normalizer
  (`normalizeBody`).

## Guideline compliance

- **Clean-code caps** — every function <= 10 lines; the tool itself passes
  eslint under the repo's architecture ruleset (no `void`, no
  `return;`/`return null`, no call-as-argument-of-call, no `any`).
- **Default-deny scope** — compares only `.test.ts` bodies against shipped
  `src/**`; test infra under `src/Tests/` (helpers, factories, Tools) is
  ignored on both sides, so sharing a test helper is not flagged.
- **No gate / cap weakening** — this adds a gate.
- **Verified:** eslint + tsc clean; canary run clean (8009 test bodies, no
  production copies); unit test 5/5; committed through all 22 husky gates.

---

## Also in this PR — docs: reflect Leumi + Yahav pipeline migration

A second commit syncs stale docs to the code: Leumi and Yahav were migrated to
the Pipeline (their legacy scrapers deleted), but the README migration notice,
`architecture/legacy.md` / `layers.md` / `migration.md`, `banks/mizrahi.md`, and
the Integration README still listed them as legacy. Now corrected to the true
3 legacy banks (Behatsdaa, Beyahad Bishvilha, Mizrahi). `docs/banks/index.md`
was already correct. Validated with `mkdocs build --strict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new lint command to detect duplicate logic between production and test code, helping keep the codebase cleaner.

- **Documentation**
  - Updated migration and architecture docs to reflect the latest bank migration status.
  - Refreshed bank integration and institution docs with current supported fields and legacy-bank listings.

- **Tests**
  - Added coverage for the new duplication-checking logic, including normalization and allowed exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->