### PR TITLE
build(deps): upgrade playwright-core to 1.61.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 .husky/* text eol=lf
 *.sh text eol=lf
 
+# patch-package patches must stay LF or they fail to apply on Linux CI
+*.patch text eol=lf
+
 # Source files: normalize to LF in repo, respect OS on checkout
 *.ts text eol=lf
 *.js text eol=lf

--- a/.github/actions/install-camoufox/action.yml
+++ b/.github/actions/install-camoufox/action.yml
@@ -11,13 +11,16 @@ runs:
   steps:
     # Camoufox is pinned to the v135 stable line (v135.0.1-beta.24),
     # matching @hieutran094/camoufox-js 0.6.8 and playwright-core
-    # ~1.59.1 in package.json (Firefox 135 juggler protocol). Both the
-    # primary camoufox-js fetch AND the gh-release fallback below
-    # resolve to v135, so CI stays deterministic on a cache miss or a
-    # rate-limited primary fetch. Do NOT let the fallback track LATEST:
-    # v150.0.2's locale handling regressed `navigator.language`
-    # (returned `en-US` even when the context declared `he-IL`),
-    # breaking `AntiDetection.e2e-mocked.test.ts`.
+    # ~1.61.1 in package.json (Firefox 135 juggler protocol). playwright
+    # 1.61 needs two compat shims for this Firefox: viewport:null (avoids
+    # the unsupported Browser.setDefaultViewport) and the patch-package
+    # guard on pageError.location (Camoufox omits it) — see
+    # patches/playwright-core+1.61.1.patch. Both the primary camoufox-js
+    # fetch AND the gh-release fallback below resolve to v135, so CI stays
+    # deterministic on a cache miss or a rate-limited primary fetch. Do
+    # NOT let the fallback track LATEST: v150.0.2's locale handling
+    # regressed `navigator.language` (returned `en-US` even when the
+    # context declared `he-IL`), breaking `AntiDetection.e2e-mocked.test.ts`.
     - name: Resolve pinned Camoufox tag
       id: camoufox-tag
       shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@sergienko4/israeli-bank-scrapers",
       "version": "8.5.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@hieutran094/camoufox-js": "^0.6.8",
@@ -14,7 +15,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
         "pino": "^10.3.1",
-        "playwright-core": "~1.59.1",
+        "playwright-core": "~1.61.1",
         "utility-types": "^3.11.0"
       },
       "devDependencies": {
@@ -48,6 +49,7 @@
         "lint-staged": "^17.0.7",
         "minimist": "^1.2.8",
         "ncp": "^2.0.0",
+        "patch-package": "^8.0.1",
         "pino-pretty": "^13.1.3",
         "prettier": "^3.8.1",
         "publint": "^0.3.21",
@@ -671,9 +673,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -691,9 +690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -711,9 +707,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -731,9 +724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3429,6 +3419,13 @@
         "win32"
       ]
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3927,6 +3924,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -4439,6 +4486,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-indent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
@@ -4497,6 +4562,21 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4575,6 +4655,39 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -5293,6 +5406,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/fingerprint-generator": {
       "version": "2.1.82",
       "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.82.tgz",
@@ -5393,6 +5516,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -5443,6 +5576,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5451,6 +5609,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -5566,6 +5738,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5603,6 +5788,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/header-generator": {
@@ -5999,6 +6223,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6086,6 +6326,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6935,6 +7195,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6968,6 +7248,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsx-ast-utils-x": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
@@ -6986,6 +7276,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -7423,6 +7723,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/maxmind": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.6.tgz",
@@ -7745,6 +8055,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -7774,6 +8094,23 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7919,6 +8256,77 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -8158,9 +8566,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8847,6 +9255,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     }
   },
   "scripts": {
+    "postinstall": "patch-package",
     "clean": "rimraf lib",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathIgnorePatterns=E2eReal --testPathIgnorePatterns=E2eMocked --testPathIgnorePatterns=E2eSmoke --testPathIgnorePatterns=E2eFull",
@@ -135,6 +136,7 @@
     "lint-staged": "^17.0.7",
     "minimist": "^1.2.8",
     "ncp": "^2.0.0",
+    "patch-package": "^8.0.1",
     "pino-pretty": "^13.1.3",
     "prettier": "^3.8.1",
     "publint": "^0.3.21",
@@ -154,7 +156,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "pino": "^10.3.1",
-    "playwright-core": "~1.59.1",
+    "playwright-core": "~1.61.1",
     "utility-types": "^3.11.0"
   },
   "files": [

--- a/patches/playwright-core+1.61.1.patch
+++ b/patches/playwright-core+1.61.1.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/playwright-core/lib/coreBundle.js b/node_modules/playwright-core/lib/coreBundle.js
+index 7d8468f..8795de8 100644
+--- a/node_modules/playwright-core/lib/coreBundle.js
++++ b/node_modules/playwright-core/lib/coreBundle.js
+@@ -25126,9 +25126,9 @@ var init_tracing = __esm({
+           params: {
+             error: serializeError(pageError.error),
+             location: {
+-              url: pageError.location.url,
+-              line: pageError.location.lineNumber,
+-              column: pageError.location.columnNumber
++              url: (pageError.location?.url ?? ""),
++              line: (pageError.location?.lineNumber ?? 0),
++              column: (pageError.location?.columnNumber ?? 0)
+             }
+           },
+           pageId: page.guid
+@@ -52905,9 +52905,9 @@ var init_browserContextDispatcher = __esm({
+             error: serializeError(pageError.error),
+             page: PageDispatcher.from(this, page),
+             location: {
+-              url: pageError.location.url,
+-              line: pageError.location.lineNumber,
+-              column: pageError.location.columnNumber
++              url: (pageError.location?.url ?? ""),
++              line: (pageError.location?.lineNumber ?? 0),
++              column: (pageError.location?.columnNumber ?? 0)
+             }
+           });
+         });

--- a/src/Common/Browser.ts
+++ b/src/Common/Browser.ts
@@ -1,25 +1,24 @@
 import { type BrowserContextOptions } from 'playwright-core';
 
-import {
-  DESKTOP_VIEWPORT_HEIGHT,
-  DESKTOP_VIEWPORT_WIDTH,
-  ISRAEL_LOCALE,
-  ISRAEL_TIMEZONE,
-} from './Config/BrowserConfig.js';
+import { ISRAEL_LOCALE, ISRAEL_TIMEZONE } from './Config/BrowserConfig.js';
 
 export { ISRAEL_LOCALE, ISRAEL_TIMEZONE } from './Config/BrowserConfig.js';
 
 /**
  * Build Playwright browser context options with Israeli bank-friendly defaults.
- * Viewport is fixed at 1920×1080 to ensure desktop layout — Israeli banking sites
- * hide login buttons and show different HTML on smaller/mobile viewports.
- * @returns BrowserContextOptions configured for Israeli locale, timezone, and desktop viewport.
+ * Viewport is left `null` so the render surface follows the Camoufox-pinned
+ * 1920×1080 launch window (see `CamoufoxLauncher.buildLaunchOptions`) — Israeli
+ * banking sites hide login buttons and serve mobile HTML on smaller viewports,
+ * and a fixed Playwright `viewport` makes `newContext` emit a
+ * `Browser.setDefaultViewport` command Camoufox's Firefox does not implement
+ * (breaks on playwright-core ≥ 1.61).
+ * @returns BrowserContextOptions configured for Israeli locale, timezone, and the Camoufox window size.
  */
 export function buildContextOptions(): BrowserContextOptions {
   return {
     locale: ISRAEL_LOCALE,
     timezoneId: ISRAEL_TIMEZONE,
     javaScriptEnabled: true,
-    viewport: { width: DESKTOP_VIEWPORT_WIDTH, height: DESKTOP_VIEWPORT_HEIGHT },
+    viewport: null,
   };
 }

--- a/src/Scrapers/Pipeline/Mediator/Browser/BrowserConfig.ts
+++ b/src/Scrapers/Pipeline/Mediator/Browser/BrowserConfig.ts
@@ -3,9 +3,3 @@ export const ISRAEL_TIMEZONE = 'Asia/Jerusalem';
 
 /** Default locale for Israeli bank portals and date formatting. */
 export const ISRAEL_LOCALE = 'he-IL';
-
-/** Desktop viewport width — Israeli banks hide login forms at smaller sizes. */
-export const DESKTOP_VIEWPORT_WIDTH = 1920;
-
-/** Desktop viewport height — standard 1080p layout for bank portals. */
-export const DESKTOP_VIEWPORT_HEIGHT = 1080;

--- a/src/Scrapers/Pipeline/Mediator/Browser/BrowserContextBuilder.ts
+++ b/src/Scrapers/Pipeline/Mediator/Browser/BrowserContextBuilder.ts
@@ -1,25 +1,24 @@
 import { type BrowserContextOptions } from 'playwright-core';
 
-import {
-  DESKTOP_VIEWPORT_HEIGHT,
-  DESKTOP_VIEWPORT_WIDTH,
-  ISRAEL_LOCALE,
-  ISRAEL_TIMEZONE,
-} from './BrowserConfig.js';
+import { ISRAEL_LOCALE, ISRAEL_TIMEZONE } from './BrowserConfig.js';
 
 export { ISRAEL_LOCALE, ISRAEL_TIMEZONE } from './BrowserConfig.js';
 
 /**
  * Build Playwright browser context options with Israeli bank-friendly defaults.
- * Viewport is fixed at 1920×1080 to ensure desktop layout — Israeli banking sites
- * hide login buttons and show different HTML on smaller/mobile viewports.
- * @returns BrowserContextOptions configured for Israeli locale, timezone, and desktop viewport.
+ * Viewport is left `null` so the render surface follows the Camoufox-pinned
+ * 1920×1080 launch window (see `CamoufoxLauncher.buildLaunchOptions`) — Israeli
+ * banking sites hide login buttons and serve mobile HTML on smaller viewports,
+ * and a fixed Playwright `viewport` makes `newContext` emit a
+ * `Browser.setDefaultViewport` command Camoufox's Firefox does not implement
+ * (breaks on playwright-core ≥ 1.61).
+ * @returns BrowserContextOptions configured for Israeli locale, timezone, and the Camoufox window size.
  */
 export function buildContextOptions(): BrowserContextOptions {
   return {
     locale: ISRAEL_LOCALE,
     timezoneId: ISRAEL_TIMEZONE,
     javaScriptEnabled: true,
-    viewport: { width: DESKTOP_VIEWPORT_WIDTH, height: DESKTOP_VIEWPORT_HEIGHT },
+    viewport: null,
   };
 }

--- a/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
+++ b/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
@@ -13,6 +13,7 @@ import type { Browser, Page } from 'playwright-core';
 
 import { ScraperErrorTypes } from '../../../Base/ErrorTypes.js';
 import type { LifecyclePromise, Nullable } from '../../../Base/Interfaces/CallbackTypes.js';
+import { buildContextOptions } from '../../Mediator/Browser/BrowserContextBuilder.js';
 import { launchCamoufox } from '../../Mediator/Browser/CamoufoxLauncher.js';
 import type { Brand, SafeUrlForLog } from '../../Types/Brand.js';
 import { mintSafeUrlForLog } from '../../Types/Brand.js';
@@ -406,7 +407,8 @@ class CamoufoxIdentityFetchStrategy implements IFetchStrategy {
    * @returns Active Page on success; throws on failure (caller wraps).
    */
   private async navigateToOrigin(browser: Browser): Promise<Page> {
-    const context = await browser.newContext({ viewport: null });
+    const contextOptions = buildContextOptions();
+    const context = await browser.newContext(contextOptions);
     const hasBypass = this._bypassOriginChallenge;
     if (hasBypass) await this.installOriginChallengeBypass(context);
     const page = await context.newPage();

--- a/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
+++ b/src/Scrapers/Pipeline/Strategy/Fetch/CamoufoxIdentityFetchStrategy.ts
@@ -406,7 +406,7 @@ class CamoufoxIdentityFetchStrategy implements IFetchStrategy {
    * @returns Active Page on success; throws on failure (caller wraps).
    */
   private async navigateToOrigin(browser: Browser): Promise<Page> {
-    const context = await browser.newContext();
+    const context = await browser.newContext({ viewport: null });
     const hasBypass = this._bypassOriginChallenge;
     if (hasBypass) await this.installOriginChallengeBypass(context);
     const page = await context.newPage();

--- a/src/Tests/E2eMocked/Discount/Discount.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/Discount/Discount.e2e-mocked.test.ts
@@ -62,7 +62,7 @@ describe.skip('offline Discount invalid-creds', () => {
       );
     }
     browser = await launchCamoufox(true);
-    context = await browser.newContext();
+    context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     const interceptor = await installOfflineInterceptor({ page, fixtures });
     const scraper = createScraper({

--- a/src/Tests/E2eMocked/ExternalBrowser.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/ExternalBrowser.e2e-mocked.test.ts
@@ -53,7 +53,7 @@ describe.skip('External Browser: Mocked E2E', () => {
   }, 60000);
 
   it('uses provided browser context', async () => {
-    const context = await browser.newContext();
+    const context = await browser.newContext({ viewport: null });
 
     const scraper = createScraper({
       companyId: CompanyTypes.Amex,

--- a/src/Tests/E2eMocked/HomeEntrySelection.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/HomeEntrySelection.e2e-mocked.test.ts
@@ -116,7 +116,7 @@ function silentLogger(): pino.Logger {
 async function preparePage(
   testCase: IHomeEntryCase,
 ): Promise<{ context: BrowserContext; page: Page }> {
-  const context = await browser.newContext();
+  const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   await setupRequestInterception(page, [
     {

--- a/src/Tests/E2eMocked/HomeTargetBlankPopup.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/HomeTargetBlankPopup.e2e-mocked.test.ts
@@ -67,7 +67,7 @@ function silentLogger(): pino.Logger {
  * @returns Fresh context + page (caller must close the context).
  */
 async function preparePage(): Promise<{ context: BrowserContext; page: Page }> {
-  const context = await browser.newContext();
+  const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   await setupRequestInterception(page, [
     {

--- a/src/Tests/E2eMocked/Max/Max.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/Max/Max.e2e-mocked.test.ts
@@ -60,7 +60,7 @@ describe.skip('offline MAX invalid-creds', () => {
       );
     }
     browser = await launchCamoufox(true);
-    context = await browser.newContext();
+    context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     const interceptor = await installOfflineInterceptor({ page, fixtures });
     const scraper = createScraper({

--- a/src/Tests/E2eMocked/VisaCal/VisaCal.e2e-mocked.test.ts
+++ b/src/Tests/E2eMocked/VisaCal/VisaCal.e2e-mocked.test.ts
@@ -60,7 +60,7 @@ describe.skip('offline VisaCal invalid-creds', () => {
       );
     }
     browser = await launchCamoufox(true);
-    context = await browser.newContext();
+    context = await browser.newContext({ viewport: null });
     const page = await context.newPage();
     const interceptor = await installOfflineInterceptor({ page, fixtures });
     const scraper = createScraper({

--- a/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
+++ b/src/Tests/E2eReal/Tools/CaptureInvalidLogin.ts
@@ -652,7 +652,7 @@ async function buildSessionFromBrowser(
   browser: Browser,
   opts: ICliOptions,
 ): Promise<IBrowserSession> {
-  const context = await browser.newContext();
+  const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   page.setDefaultTimeout(opts.timeoutMs);
   return { browser, context, page };

--- a/src/Tests/Tools/probe-beinleumi-nth.ts
+++ b/src/Tests/Tools/probe-beinleumi-nth.ts
@@ -26,7 +26,7 @@ const EXPECTED_NTH1_ID = 'pm.q077';
 async function setupProbePage(): Promise<{ browser: Browser; page: Page }> {
   const html = fs.readFileSync(FIXTURE, 'utf8');
   const browser = await launchCamoufox(true);
-  const context = await browser.newContext();
+  const context = await browser.newContext({ viewport: null });
   const page = await context.newPage();
   await page.setContent(html);
   return { browser, page };

--- a/src/Tests/Unit/Browser.test.ts
+++ b/src/Tests/Unit/Browser.test.ts
@@ -1,10 +1,5 @@
 import { buildContextOptions } from '../../Common/Browser.js';
-import {
-  DESKTOP_VIEWPORT_HEIGHT,
-  DESKTOP_VIEWPORT_WIDTH,
-  ISRAEL_LOCALE,
-  ISRAEL_TIMEZONE,
-} from '../../Common/Config/BrowserConfig.js';
+import { ISRAEL_LOCALE, ISRAEL_TIMEZONE } from '../../Common/Config/BrowserConfig.js';
 
 describe('buildContextOptions', () => {
   it('returns Hebrew locale and Israel timezone', () => {
@@ -23,11 +18,8 @@ describe('buildContextOptions', () => {
     expect(options.userAgent).toBeUndefined();
   });
 
-  it('sets 1920x1080 viewport (Israeli banks hide login at smaller sizes)', () => {
+  it('leaves viewport null so the Camoufox-pinned 1920x1080 window is used', () => {
     const options = buildContextOptions();
-    expect(options.viewport).toEqual({
-      width: DESKTOP_VIEWPORT_WIDTH,
-      height: DESKTOP_VIEWPORT_HEIGHT,
-    });
+    expect(options.viewport).toBeNull();
   });
 });

--- a/src/Tests/Unit/Pipeline/Mediator/Browser/BrowserContextBuilder.test.ts
+++ b/src/Tests/Unit/Pipeline/Mediator/Browser/BrowserContextBuilder.test.ts
@@ -25,9 +25,9 @@ describe('buildContextOptions', () => {
     expect(opts.javaScriptEnabled).toBe(true);
   });
 
-  it('sets desktop viewport 1920x1080', () => {
+  it('leaves viewport null so the Camoufox-pinned window size is used', () => {
     const opts = buildContextOptions();
-    expect(opts.viewport).toEqual({ width: 1920, height: 1080 });
+    expect(opts.viewport).toBeNull();
   });
 
   it('returns a new object each call (immutable callers)', () => {


### PR DESCRIPTION
## Why

Dependabot #397 bumps `playwright-core` 1.59.1 → 1.61.1, but CI failed
(E2E mocked + Validate). Local investigation found **two independent
incompatibilities** between playwright-core ≥ 1.61 and Camoufox 0.6.8
(`@hieutran094/camoufox-js`, already `latest`):

1. **`Browser.setDefaultViewport`** (1.61.0+) — a fixed Playwright
   `viewport` makes `newContext` emit a Juggler command Camoufox's Firefox
   does not implement. Every browser launch fails at `newContext`.
2. **`pageError.location.url` crash** (1.60.0+) — surfaced only under live
   E2E. playwright-core added an unguarded
   `location: { url: pageError.location.url }` dispatch, but Camoufox emits
   uncaught page errors **without** a `location`. Real bank pages reliably
   throw uncaught JS errors → `TypeError: Cannot read properties of
   undefined (reading 'url')` crashes the run.

Bundle diff confirms #2 landed in 1.60.0 (1.59.1 dispatches `pageError`
with no `location`).

## What

Both fixes, so the app runs on 1.61.1 with Camoufox:

1. **`viewport: null`** — Camoufox already pins the launch window to
   1920×1080, so the Playwright viewport is redundant; leaving it `null`
   renders at the real window size (1920×1019, desktop). Applied in both
   context-option builders, the api-direct identity-fetch, and the 8
   test/tool callsites that build their own context. Dropped the now-orphaned
   Pipeline `DESKTOP_VIEWPORT_*` constants; updated the 2 viewport assertions.
2. **`patch-package` guard** — `patches/playwright-core+1.61.1.patch`
   defaults the unguarded read to `?? ""` / `?? 0` (2 sites in
   `coreBundle.js`). Re-applied by a `postinstall` hook (`npm ci` runs it in
   every CI job via `setup-node-deps`).
3. **Bump** `playwright-core` → `~1.61.1`.
4. **`.gitattributes`** — `*.patch text eol=lf` so the patch never gets
   CRLF-corrupted and fails to apply on Linux CI.

Supersedes #397.

## Guideline compliance

- **New dev-dependency (`patch-package`) + `postinstall`** — flagged;
  approved approach. `npm ci` (husky build gate + CI `setup-node-deps`)
  runs the postinstall patch; verified locally with a clean `npm ci`.
- **Vendored-bundle patch is version-brittle** — `~1.61.1` lets
  patch-package fuzzy-match across 1.61.x patch bumps (warns on drift); the
  next dependabot bump re-runs this whole gate. The real long-term fix is
  upstream (playwright: guard `pageError.location`; Camoufox: send
  `location`) — file issues and drop the patch when either lands.
- **No CSS-selector / clean-code / gate changes.** No public-surface
  (`src/index.ts`) change.
- **Verified @ 1.61.1:** mock E2E green (33 passed); **live Leumi + Yahav
  both scrape 3 txns** with no `setDefaultViewport` and no `pageError`
  crash; `npm ci` applies the patch from scratch; all 22 husky gates green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser sessions now use the expected window size behavior more reliably, improving page rendering and navigation consistency.
  * Fixed an issue that could prevent patch files from applying correctly in Linux-based installs and CI runs.
  * Improved compatibility with the latest browser automation dependency and made error handling more resilient when location details are missing.
* **Chores**
  * Added automatic patch application during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->