### PR TITLE
docs: direct-API-after-login pipeline for 8.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,15 @@ npm install @sergienko4/israeli-bank-scrapers
 
 ```mermaid
 flowchart LR
-    subgraph BB["Browser banks (16)"]
+    subgraph BB["Browser banks (13 pipeline)"]
       direction LR
       INIT --> HOME --> PRELOGIN["PRE-LOGIN (opt-in)"]
       PRELOGIN --> LOGIN
       LOGIN --> OTP["OTP-TRIGGER / OTP-FILL (opt-in)"]
       OTP --> AUTH["AUTH-DISCOVERY"]
-      AUTH --> ACCT["ACCOUNT-RESOLVE"]
-      ACCT --> DASH["DASHBOARD"]
-      DASH --> SCRAPE
-      SCRAPE --> BAL["BALANCE-RESOLVE"]
-      BAL --> TERM["TERMINATE"]
+      AUTH --> BIND["BIND-API-MEDIATOR"]
+      BIND --> SCRAPE["API-DIRECT-SCRAPE<br/>(direct API calls — no nav / DOM walk)"]
+      SCRAPE --> TERM["TERMINATE"]
     end
 
     subgraph API["API-direct banks (3) — OneZero · Pepper · PayBox"]
@@ -52,7 +50,13 @@ flowchart LR
     API -.->|"unified result shape"| RESULT
 ```
 
-12 phases for browser banks, 2 phases for api-direct banks, **one result shape**. Each phase owns its mediator zone and its own state — phases never reach into each other's data. See [Architecture](#architecture) for the contract that keeps the wiring honest.
+Every pipeline bank talks **direct API after login**: once `AUTH-DISCOVERY`
+proves the session, `BIND-API-MEDIATOR` binds an authenticated `ApiMediator`
+to the live page and `API-DIRECT-SCRAPE` walks a typed hard-model shape of
+REST/GraphQL calls — no post-auth page navigation, no DOM scraping. The
+retired generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE`
+chain is dormant (no bank triggers it). See [Architecture](#architecture)
+for the contract that keeps the wiring honest.
 
 > **📚 Full documentation:** [User Guide & Architecture (mkdocs)](https://sergienko4.github.io/israeli-bank-scrapers/) · [API Reference (TypeDoc)](https://sergienko4.github.io/israeli-bank-scrapers/api/) · [Changelog](./CHANGELOG.md) · [Contributing](./CONTRIBUTING.md)
 
@@ -119,8 +123,9 @@ Replace `userCode` and `password` with real credentials. See [Supported Institut
 - **Zero CSS selectors in interaction code** — visible Hebrew text + a 7-strategy `SelectorResolver`. Site UI redesigns rarely break logins.
 - **Auto-detect + auto-fill OTP** — either via a callback you provide or a stable long-term token (returned for API banks).
 - **End-to-end PII redaction** — every log line, captured network body, and DOM snapshot goes through one redactor _before_ it touches disk. Share traces publicly without leaking customer data.
-- **Phase-based pipeline** — 12 isolated phases for browser banks, 2 for api-direct banks. One result shape across both paths.
-- **Single-phase balance ownership (v6)** — `BALANCE-RESOLVE` owns every live balance fetch + per-card extraction; legitimate empty-month results pass through without a false "scrape failed" signal.
+- **Direct-API scraping after login** — once the browser proves the session, data is fetched through a typed hard-model shape of REST/GraphQL calls (`BIND-API-MEDIATOR → API-DIRECT-SCRAPE`), not DOM navigation. Every pipeline bank (browser and api-direct alike) reads its accounts, balances, and transactions straight from the bank's own API.
+- **Phase-based pipeline** — isolated, single-responsibility phases; browser banks add a WAF-bypassing login front-end, api-direct banks run login as a JSON-API flow. One result shape across both paths.
+- **Single-phase balance ownership** — the hard-model `API-DIRECT-SCRAPE` shape emits `balanceResolution` directly from each bank's balance endpoint; legitimate empty-month results pass through without a false "scrape failed" signal.
 - **Dual ESM + CJS** — works with both `import` and `require()`.
 - **3 test surfaces** — unit (Jest), pipeline coverage (with thresholds), mock + real E2E orchestrators.
 
@@ -481,25 +486,27 @@ If you spot a pattern that leaks past both layers, please open an issue — that
 Pipeline of typed phases. Each phase owns its mediator zone, its own well-known-selectors dictionary, and its own retry policy. Phases never reach into one another's state — communication happens via slim `Option<T>` fields on the pipeline context.
 
 ```
-Browser banks (12 phases):
+Browser banks — direct-API after login (hard model):
   INIT → HOME → [PRE-LOGIN] → LOGIN → [OTP-TRIGGER → OTP-FILL]
-       → AUTH-DISCOVERY → ACCOUNT-RESOLVE → DASHBOARD → SCRAPE
-       → BALANCE-RESOLVE → TERMINATE
+       → AUTH-DISCOVERY → BIND-API-MEDIATOR → API-DIRECT-SCRAPE → TERMINATE
 
-API-direct banks (2 phases):
+API-direct banks (fully headless, 2 phases):
   API-DIRECT-CALL → API-DIRECT-SCRAPE
 ```
 
 - `[PRE-LOGIN]` is opt-in — card banks with a separate "show login" toggle: Amex, Isracard, Max, VisaCal.
 - `[OTP-TRIGGER → OTP-FILL]` is opt-in. Beinleumi-group banks (Beinleumi, Massad, Otsar Hahayal, Pagi) and Hapoalim use them. Hapoalim uses OTP-FILL only, conditionally.
-- `AUTH-DISCOVERY` separates the credential exchange from the dashboard handoff so post-auth signal capture (cookies, ids, tokens) is observable, redactable, and testable in isolation.
-- `API-DIRECT-CALL` replaces `LOGIN [+ OTP-TRIGGER + OTP-FILL]` for banks with a programmatic auth endpoint. OTP, when required, is fetched via the same `otpCodeRetriever` callback during this phase.
-- `API-DIRECT-SCRAPE` replaces `SCRAPE [+ BALANCE-RESOLVE]` for those banks — same `PRE → ACTION → POST → FINAL` lifecycle, but the action is a shape-driven GraphQL/REST walk instead of a DOM walk. `.final` emits `ctx.balanceResolution` directly.
+- `AUTH-DISCOVERY` separates the credential exchange from the data handoff so post-auth signal capture (cookies, ids, tokens) is observable, redactable, and testable in isolation.
+- `BIND-API-MEDIATOR` binds an authenticated `ApiMediator` to the **live login page** so the hard-model scrape dispatches REST/GraphQL calls over the same WAF-passing browser session (cookies / discovered tokens ride along). It reads the login-inclusive capture pool once to prime any bearer / session token, then hands off.
+- `API-DIRECT-SCRAPE` replaces the retired generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE` chain for **every** pipeline bank — same `PRE → ACTION → POST → FINAL` lifecycle, but the action is a bank-supplied hard-model **shape** (a typed list of REST/GraphQL calls) instead of a DOM walk. `.final` emits `ctx.balanceResolution` directly. No post-auth page navigation.
+- `API-DIRECT-CALL` replaces `LOGIN [+ OTP-TRIGGER + OTP-FILL]` for banks with a programmatic auth endpoint (OneZero, Pepper, PayBox). OTP, when required, is fetched via the same `otpCodeRetriever` callback during this phase.
 
 <details open>
-<summary><strong>BALANCE-RESOLVE — single-phase balance ownership (v6)</strong></summary>
+<summary><strong>Balance ownership — emitted by the hard-model shape</strong></summary>
 
-`BALANCE-RESOLVE` is the only phase that performs balance work. SCRAPE no longer attributes per-account responses — it just emits the typed inputs `BALANCE-RESOLVE` consumes.
+Balance is resolved as part of `API-DIRECT-SCRAPE`: each bank's hard-model shape declares a balance call whose `.final` emits `ctx.balanceResolution` — a `Map<accountNumber, number>` that `PipelineResult` reads as the single source of truth. A universal miss (every account failed) is a real scrape failure; partial / legitimately-empty months pass through.
+
+> The standalone `BALANCE-RESOLVE` phase (v6) is retired for pipeline banks: it only ran on the generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE` chain, which no bank uses now. Its ESLint isolation canaries still guard the boundary so the phase cannot silently reach back into a scrape path.
 
 | Sub-step      | Responsibility                                                                                                                                                                                                                                                                                  |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -532,8 +539,8 @@ Every api-direct bank reuses the same building blocks below the two phases, so n
 
 Interceptors don't own data, they observe and dismiss:
 
-- **PopupInterceptor** — before HOME, ACCOUNT-RESOLVE, and DASHBOARD, the interceptor scans for modal overlays (privacy banners, new-feature promos, "you have a message" dialogs) and dismisses them by visible-text.
-- **NetworkDiscovery + trace lifecycle** — every HTTP request and response the page issues is observed and indexed. The discovery layer learns each bank's per-account / per-card / per-statement endpoints at runtime (no hand-maintained URL list) and feeds them into SCRAPE and BALANCE-RESOLVE. Bodies are captured to disk only inside the configured boundary (post-auth onward) so pre-auth secrets never hit the trace; bodies + URLs flow through the central `PiiRedactor` before any write.
+- **PopupInterceptor** — before HOME (and before the api-direct scrape), the interceptor scans for modal overlays (privacy banners, new-feature promos, "you have a message" dialogs) and dismisses them by visible-text.
+- **NetworkDiscovery + trace lifecycle** — every HTTP request and response the page issues is observed and indexed. The discovery layer learns each bank's per-account / per-card / per-statement endpoints at runtime (no hand-maintained URL list) and feeds them into `BIND-API-MEDIATOR` (token / session priming) and the `API-DIRECT-SCRAPE` shape. Bodies are captured to disk only inside the configured boundary (post-auth onward) so pre-auth secrets never hit the trace; bodies + URLs flow through the central `PiiRedactor` before any write.
 
 </details>
 
@@ -626,6 +633,7 @@ The pre-commit hook runs the same gates plus mock-E2E and bank tests. PRs are sq
 | v8.3.0  | Pipeline architecture v2 — Strategy / Builder / Mediator / Result patterns, AUTH-DISCOVERY phase + 100% phase isolation, cross-bank test factory (Phase H), TIMING ceilings, Telegram OTP delivery, PII redaction across log/network/snapshots                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | v8.4.0  | **Unified api-direct primitives** across OneZero / Pepper / PayBox — AES-CBC-PKCS7 body-pointer signer alongside the existing asymmetric header-attached one, declarative `JsonValueTemplate` bodies served by one hydration engine, `seedCarryFromCreds` + `derivedCarry` carry derivations (incl. deterministic `sha256-prefix-16` bootstrap for warm-start-stable device identifiers), session-context bus method-pair, in-body `cryptoField` pre-hook for symmetric OTP encryption, per-bank `phoneNumberFormat` normaliser, forensic-audit observability hook on the api-direct scrape POST; PayBox onboarding lands as a pure consumer of these primitives.<br><br>**Single-phase balance ownership (BALANCE-RESOLVE v6)** — SCRAPE.post emits `accountIdentities` + `balanceFetchTemplate`; BALANCE-RESOLVE owns live `api.fetchPost` / `fetchGet`, per-card extraction (Visa Cal nested cards + Amex `cardChargeNext`), quarantine on per-fetch failure, universal-miss hard-fail only when _every_ card missed; `ctx.balanceResolution` becomes the single source of truth read by `PipelineResult` for both browser and api-direct paths; v5 attribution path (~370 LOC) removed; 3 new ESLint canaries lock the separation at commit time. |
 | v8.5.0  | **Bank Leumi + Bank Yahav migrated to the Pipeline** (Yahav via BaNCS Digital) — 16 of 19 institutions are now pipeline-native, 3 legacy remain, and Yahav fetches the full requested date range through monthly BaNCS `OrigDt` chunking (current-month bound capped at today). **Config-driven BALANCE-RESOLVE** with a required per-bank `balanceKind` (`ACCOUNT` vs `CARD_CYCLE`). **Generic background WAF challenge interceptor** — hCaptcha / Turnstile checkbox auto-solve. **Phase 11 integration hard gate** — Mode A static-HTML drive + Mode B mirror across all pipeline banks. New commit-time guards: an acyclic-dependencies cycle gate (baseline-ratcheted) and a test-duplication canary that blocks tests from copying production logic. |
+| v8.6.0  | **Direct-API scraping after login for every pipeline bank.** The 13 browser banks retire the generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE` navigation + DOM-scrape chain. After `AUTH-DISCOVERY`, the new **`BIND-API-MEDIATOR`** phase binds an authenticated `ApiMediator` to the live login page (bearer / session token primed from the capture pool), then **`API-DIRECT-SCRAPE`** walks each bank's typed hard-model shape — explicit accounts + balances + transactions REST/GraphQL calls with `buildVars` / `extract*` / pagination cursor / `resultGuard` — with **no post-auth page navigation and no generic DOM extraction**. `balanceKind` (`ACCOUNT` vs `CARD_CYCLE`) is emitted by the shape's `.final`, so all 16 pipeline institutions (13 browser + 3 api-direct) now share one direct-API scrape driver. The generic phases remain in the codebase (ESLint-canary-guarded) but no pipeline bank triggers them. |
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ flowchart LR
     API -.->|"unified result shape"| RESULT
 ```
 
-Every pipeline bank talks **direct API after login**: once `AUTH-DISCOVERY`
-proves the session, `BIND-API-MEDIATOR` binds an authenticated `ApiMediator`
-to the live page and `API-DIRECT-SCRAPE` walks a typed hard-model shape of
-REST/GraphQL calls — no post-auth page navigation, no DOM scraping. The
-retired generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE`
-chain is dormant (no bank triggers it). See [Architecture](#architecture)
-for the contract that keeps the wiring honest.
+Every pipeline bank scrapes **direct API after login**. On the **browser
+banks (13)**, once `AUTH-DISCOVERY` proves the session, `BIND-API-MEDIATOR`
+binds an authenticated `ApiMediator` to the live page and `API-DIRECT-SCRAPE`
+walks a typed hard-model shape of REST/GraphQL calls — no post-auth page
+navigation, no DOM scraping. The **api-direct banks (3)** reach the same
+`API-DIRECT-SCRAPE` through `API-DIRECT-CALL` (headless JSON login) instead of
+the browser `LOGIN → AUTH-DISCOVERY → BIND-API-MEDIATOR` prefix. The retired
+generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE` chain is
+dormant (no bank triggers it). See [Architecture](#architecture) for the
+contract that keeps the wiring honest.
 
 > **📚 Full documentation:** [User Guide & Architecture (mkdocs)](https://sergienko4.github.io/israeli-bank-scrapers/) · [API Reference (TypeDoc)](https://sergienko4.github.io/israeli-bank-scrapers/api/) · [Changelog](./CHANGELOG.md) · [Contributing](./CONTRIBUTING.md)
 

--- a/docs/architecture/balance-resolve.md
+++ b/docs/architecture/balance-resolve.md
@@ -1,5 +1,7 @@
 # BALANCE-RESOLVE (v6) — single-phase balance ownership
 
+> **Retired for pipeline banks in v8.6.0.** Every pipeline bank now scrapes via the direct-API hard model ([`API-DIRECT-SCRAPE`](../phases/api-direct-scrape.md)), whose shape emits `ctx.balanceResolution` directly — so the standalone `BALANCE-RESOLVE` phase below no longer runs for any bank. The phase and its ESLint isolation canaries stay in the tree to guard the boundary. This page is retained as the design record of the v6 ownership model.
+
 > **Lands in v8.4.0** (commit `c267d48b`). The architectural shift that **closes the v4 "universal-empty" gate** and removes ~370 LOC of v5 attribution code from SCRAPE.
 
 ## What changed

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -6,7 +6,7 @@ The package is a **typed phase-based pipeline**. Banks register a declarative `P
 
 ## Read in this order
 
-1. **[Pipeline architecture](pipeline.md)** — the 12 browser phases + 2 api-direct phases, the `IPipelineContext`, the `Procedure<T>` result pattern.
+1. **[Pipeline architecture](pipeline.md)** — the browser phase chain (direct-API after login) + the 2 api-direct phases, the `IPipelineContext`, the `Procedure<T>` result pattern.
 2. **[Layer separation](layers.md)** — the 9 logical layers (public-api, orchestration, mediator, strategy-registry, types, legacy-scrapers, common-utilities, tests, build-ci) and how imports flow between them.
 3. **[Config Contracts (api-direct-call)](config-contracts.md)** — the 6-bucket type split that replaces the legacy `IApiDirectCallConfig.ts` god-file in v8.5; the example that defines how every type-tree should be carved into ≤150-LoC concern slices.
 4. **[BALANCE-RESOLVE (v6)](balance-resolve.md)** — the single-phase ownership rewrite that lands in v8.4; the example that defines how new phases should be structured.

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -2,22 +2,22 @@
 
 The pipeline is a **declarative chain of typed phases** orchestrated by `PipelineExecutor`. Each phase implements `BasePhase` and owns four sub-step hooks: `pre`, `action`, `post`, `final`. The executor drives them in order, threading an immutable `IPipelineContext` snapshot between phases.
 
-## The 12 + 2 phases
+## The phase chain (direct-API after login)
 
 ```mermaid
 flowchart TD
-    subgraph "Browser banks — 12 phases"
+    subgraph "Browser banks — direct-API after login"
       direction TB
       I[INIT] --> H[HOME] --> PL["PRE-LOGIN<br/>(opt-in)"]
       PL --> L[LOGIN] --> OT["OTP-TRIGGER<br/>(opt-in)"]
       OT --> OF["OTP-FILL<br/>(opt-in)"]
-      OF --> AD[AUTH-DISCOVERY] --> AR[ACCOUNT-RESOLVE] --> D[DASHBOARD]
-      D --> S[SCRAPE] --> BR["BALANCE-RESOLVE<br/>(v6)"] --> T[TERMINATE]
+      OF --> AD[AUTH-DISCOVERY] --> BIND[BIND-API-MEDIATOR]
+      BIND --> ADS["API-DIRECT-SCRAPE<br/>(hard-model shape — no nav)"] --> T[TERMINATE]
     end
 
     subgraph "API-direct banks — 2 phases"
       direction TB
-      ADC[API-DIRECT-CALL] --> ADS[API-DIRECT-SCRAPE]
+      ADC[API-DIRECT-CALL] --> ADS2[API-DIRECT-SCRAPE]
     end
 ```
 
@@ -30,13 +30,11 @@ flowchart TD
 | 5 | [OTP-TRIGGER](../phases/otp-trigger.md) | ⚙️ opt-in | Ask bank to dispatch SMS (Beinleumi-group, Hapoalim conditional) |
 | 6 | [OTP-FILL](../phases/otp-fill.md) | ⚙️ opt-in | Fill the code returned by `otpCodeRetriever` |
 | 7 | [AUTH-DISCOVERY](../phases/auth-discovery.md) | ✅ browser | Capture post-login auth token + API origin from network |
-| 8 | [ACCOUNT-RESOLVE](../phases/account-resolve.md) | ✅ browser | Discover account/card list + billing-cycle catalog |
-| 9 | [DASHBOARD](../phases/dashboard.md) | ✅ browser | Pivot to dashboard, prime network capture pool |
-| 10 | [SCRAPE](../phases/scrape.md) | ✅ all | Per-account transaction walk; emits `accountIdentities` + `balanceFetchTemplate` |
-| 11 | [BALANCE-RESOLVE](../phases/balance-resolve.md) | ✅ browser | **New in v6** — owns every live balance fetch + per-card extraction |
-| 12 | [TERMINATE](../phases/terminate.md) | ✅ browser | Close page/context/browser, finalise `IScraperScrapingResult` |
+| 8 | `BIND-API-MEDIATOR` | ✅ browser | Bind an authenticated `ApiMediator` to the live login page; prime bearer / session token from the capture pool |
+| 9 | [API-DIRECT-SCRAPE](../phases/api-direct-scrape.md) | ✅ all | Walk the bank's typed hard-model shape (accounts + balances + transactions) over direct REST/GraphQL — no nav; `.final` emits `ctx.balanceResolution` |
+| 10 | [TERMINATE](../phases/terminate.md) | ✅ browser | Close page/context/browser, finalise `IScraperScrapingResult` |
 | — | [API-DIRECT-CALL](../phases/api-direct-call.md) | api-direct only | Replaces INIT…OTP-FILL for OneZero/Pepper/PayBox |
-| — | [API-DIRECT-SCRAPE](../phases/api-direct-scrape.md) | api-direct only | Replaces SCRAPE+BALANCE-RESOLVE; `.final` emits `ctx.balanceResolution` |
+| — | _dormant_: [ACCOUNT-RESOLVE](../phases/account-resolve.md) · [DASHBOARD](../phases/dashboard.md) · [SCRAPE](../phases/scrape.md) · [BALANCE-RESOLVE](../phases/balance-resolve.md) | — | The retired generic navigation + DOM-scrape chain. Still in the codebase (ESLint canaries guard the boundary) but **no pipeline bank triggers them** — superseded by `BIND-API-MEDIATOR` + `API-DIRECT-SCRAPE`. |
 
 ## The Procedure result pattern
 
@@ -62,21 +60,18 @@ See [`Procedure.ts`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{
 
 `IPipelineContext` is a discriminated record of `Option<T>` slots. Each phase reads the slots its `pre`/`action`/`post`/`final` declare, and writes only the slots it owns. The compiler enforces that no phase writes outside its declared scope.
 
-Key slots (v8.4+):
+Key slots (v8.6+):
 
 | Slot | Owner | Purpose |
 |---|---|---|
 | `browser` | INIT | Playwright browser + context + page |
 | `login` | LOGIN | `persistentOtpToken`, `urlBeforeSubmit` |
-| `accountDiscovery` | ACCOUNT-RESOLVE | `ids`, `records`, `billingCycleCatalog` |
-| `txnEndpoint` | DASHBOARD.final | Slim `ITxnEndpoint` consumed by SCRAPE |
-| `dashboardTxnHarvest` | DASHBOARD.final | Captured per-card txn pool |
-| `scrape` | SCRAPE.post | `accounts`, `accountIdentities`, `balanceFetchTemplate` |
-| `balanceFetchPlan` | BALANCE-RESOLVE.pre | Per-bank-account fetch plan |
-| `balanceResponsesByBankAccount` | BALANCE-RESOLVE.action | Live responses keyed by `bankAccountUniqueId` |
-| `balanceExtracted` | BALANCE-RESOLVE.action | `Map<cardDisplayId, number | 'MISS'>` |
-| `balanceValidation` | BALANCE-RESOLVE.post | `{ resolvedIds, missedIds, totalAccounts }` |
-| `balanceResolution` | BALANCE-RESOLVE.final | Final `Map<accountNumber, number>` → `PipelineResult` |
+| `apiMediator` | BIND-API-MEDIATOR | Authenticated `ApiMediator` bound to the live login page, with any primed bearer / session token |
+| `scrape` | API-DIRECT-SCRAPE.post | `accounts`, `accountIdentities` produced by the hard-model shape |
+| `balanceResolution` | API-DIRECT-SCRAPE.final | Final `Map<accountNumber, number>` → `PipelineResult` |
+| _dormant_ | ACCOUNT-RESOLVE / DASHBOARD / BALANCE-RESOLVE | `accountDiscovery`, `txnEndpoint`, `dashboardTxnHarvest`, `balanceFetchPlan`, `balanceResponsesByBankAccount`, `balanceExtracted`, `balanceValidation` — slots of the retired generic chain; still declared on `IPipelineContext` but written by no pipeline bank |
+
+> **api-direct banks** reuse the exact same `apiMediator` → `scrape` → `balanceResolution` slots — the only difference is that `API-DIRECT-CALL` (not a browser LOGIN) mints the mediator.
 
 The two paths converge on `balanceResolution` — that's the single source of truth read by [`PipelineResult.combineWithBalance`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts).
 
@@ -84,15 +79,15 @@ The two paths converge on `balanceResolution` — that's the single source of tr
 
 | Interceptor | Runs between | Job |
 |---|---|---|
-| **PopupInterceptor** | HOME / ACCOUNT-RESOLVE / DASHBOARD | Dismiss modal overlays by visible text |
-| **NetworkDiscovery** | (whole run) | Index every HTTP request/response post-auth, redact body+URL before write, feed endpoints to SCRAPE + BALANCE-RESOLVE |
+| **PopupInterceptor** | HOME / before the api-direct scrape | Dismiss modal overlays by visible text |
+| **NetworkDiscovery** | (whole run) | Index every HTTP request/response post-auth, redact body+URL before write, feed endpoints to BIND-API-MEDIATOR + API-DIRECT-SCRAPE |
 
 Source: [`src/Scrapers/Pipeline/Interceptors/`](https://github.com/sergienko4/israeli-bank-scrapers/tree/{{BRANCH}}/src/Scrapers/Pipeline/Interceptors).
 
 ### Network-discovery contract types
 
 The `NetworkDiscovery` interceptor exposes two type-only contracts that
-downstream phases (DASHBOARD, SCRAPE, BALANCE-RESOLVE) import to
+downstream phases (BIND-API-MEDIATOR, API-DIRECT-SCRAPE) import to
 consume the capture pool without coupling to the live implementation:
 
 - `INetworkDiscovery` — the mediator-side contract: capture-lifecycle

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -66,12 +66,12 @@ Key slots (v8.6+):
 |---|---|---|
 | `browser` | INIT | Playwright browser + context + page |
 | `login` | LOGIN | `persistentOtpToken`, `urlBeforeSubmit` |
-| `apiMediator` | BIND-API-MEDIATOR | Authenticated `ApiMediator` bound to the live login page, with any primed bearer / session token |
+| `apiMediator` | BIND-API-MEDIATOR (browser) · headless context wiring (api-direct) | Authenticated `ApiMediator`. **Browser banks:** `BIND-API-MEDIATOR` commits a page-bound mediator to the live login page (+ any primed bearer / session token). **api-direct banks:** wired at context build via `createBrowserBackedHeadlessApiMediator`, then consumed by `API-DIRECT-CALL` |
 | `scrape` | API-DIRECT-SCRAPE.post | `accounts`, `accountIdentities` produced by the hard-model shape |
 | `balanceResolution` | API-DIRECT-SCRAPE.final | Final `Map<accountNumber, number>` → `PipelineResult` |
 | _dormant_ | ACCOUNT-RESOLVE / DASHBOARD / BALANCE-RESOLVE | `accountDiscovery`, `txnEndpoint`, `dashboardTxnHarvest`, `balanceFetchPlan`, `balanceResponsesByBankAccount`, `balanceExtracted`, `balanceValidation` — slots of the retired generic chain; still declared on `IPipelineContext` but written by no pipeline bank |
 
-> **api-direct banks** reuse the exact same `apiMediator` → `scrape` → `balanceResolution` slots — the only difference is that `API-DIRECT-CALL` (not a browser LOGIN) mints the mediator.
+> Both paths converge on the same `apiMediator` → `scrape` → `balanceResolution` slots. They differ only in **who mints the mediator**: `BIND-API-MEDIATOR` for browser banks (page-bound, post-auth); the headless context wiring — consumed by `API-DIRECT-CALL` — for api-direct banks.
 
 The two paths converge on `balanceResolution` — that's the single source of truth read by [`PipelineResult.combineWithBalance`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Core/PipelineResult.ts).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,12 +36,12 @@ npm install @sergienko4/israeli-bank-scrapers
 
 ```mermaid
 flowchart LR
-    subgraph BB["Browser banks (16)"]
+    subgraph BB["Browser banks (13 pipeline)"]
       direction LR
       INIT --> HOME --> PRELOGIN["PRE-LOGIN (opt-in)"]
       PRELOGIN --> LOGIN --> OTP["OTP (opt-in)"]
-      OTP --> AUTH["AUTH-DISCOVERY"] --> ACCT["ACCOUNT-RESOLVE"] --> DASH["DASHBOARD"]
-      DASH --> SCRAPE --> BAL["BALANCE-RESOLVE"] --> TERM["TERMINATE"]
+      OTP --> AUTH["AUTH-DISCOVERY"] --> BIND["BIND-API-MEDIATOR"]
+      BIND --> SCRAPE["API-DIRECT-SCRAPE<br/>(direct API — no nav)"] --> TERM["TERMINATE"]
     end
 
     subgraph API["API-direct banks (3)"]
@@ -55,15 +55,16 @@ flowchart LR
 
 | Surface | Counts | Source of truth |
 |---|---|---|
-| Banks supported | **19** total — 14 on Pipeline, 5 on legacy migration path | [Banks](banks/index.md) |
-| Phases | **12** (browser) + **2** (api-direct) | [Phases](phases/index.md) |
+| Banks supported | **19** total — 16 on Pipeline (13 browser + 3 api-direct), 3 on legacy migration path | [Banks](banks/index.md) |
+| Phases | Browser: `INIT → HOME → [PRE-LOGIN] → LOGIN → [OTP] → AUTH-DISCOVERY → BIND-API-MEDIATOR → API-DIRECT-SCRAPE → TERMINATE` · api-direct: **2** | [Phases](phases/index.md) |
 | Test suites | 412, ~4,800 tests, 97.20% statements coverage | [Workflow → CI gates](workflow/ci.md) |
 | Pre-commit gates | 12 gates in parallel | [Workflow → Pre-commit](workflow/pre-commit.md) |
 
 ## What's new
 
+- **v8.6.0** — **Direct-API scraping after login for every pipeline bank.** The 13 browser banks retire the generic `ACCOUNT-RESOLVE → DASHBOARD → SCRAPE → BALANCE-RESOLVE` navigation chain: after `AUTH-DISCOVERY`, `BIND-API-MEDIATOR` binds an authenticated `ApiMediator` to the live page and `API-DIRECT-SCRAPE` walks a typed hard-model shape of REST/GraphQL calls (accounts, balances, transactions) — no post-auth page navigation or DOM scraping. Balance is emitted by the shape's `.final`.
 - **v8.4.0** — Two milestones land together:
-    - [`BALANCE-RESOLVE` single-phase ownership (v6)](architecture/balance-resolve.md). SCRAPE emits identities + template, BALANCE-RESOLVE owns every live `api.fetchPost`/`fetchGet` and per-card extraction. Universal-miss fail only when **every** card missed.
+    - [`BALANCE-RESOLVE` single-phase ownership (v6)](architecture/balance-resolve.md). SCRAPE emits identities + template, BALANCE-RESOLVE owns every live `api.fetchPost`/`fetchGet` and per-card extraction. Universal-miss fail only when **every** card missed. _(Retired in v8.6.0 — balance now rides the hard-model shape.)_
     - Unified api-direct primitives across OneZero, Pepper, PayBox (signer config DU, `JsonValueTemplate`, carry derivations).
 - **v8.3.0** — Pipeline architecture v2 (Strategy / Builder / Mediator / Result patterns, phase isolation, PII redaction).
 

--- a/docs/phases/index.md
+++ b/docs/phases/index.md
@@ -4,7 +4,7 @@
 
 Every phase implements [`BasePhase`](https://github.com/sergienko4/israeli-bank-scrapers/blob/{{BRANCH}}/src/Scrapers/Pipeline/Types/BasePhase.ts) and owns four sub-step hooks: `pre`, `action`, `post`, `final`. The `PipelineExecutor` drives them in order and threads an immutable `IPipelineContext` snapshot between phases.
 
-## Browser banks — 12 phases
+## Browser banks — direct-API after login
 
 | Slot | Phase | Always-on? | One-line role |
 |---|---|---|---|
@@ -15,18 +15,17 @@ Every phase implements [`BasePhase`](https://github.com/sergienko4/israeli-bank-
 | 5 | [OTP-TRIGGER](otp-trigger.md) | ⚙️ | Ask bank to dispatch SMS |
 | 6 | [OTP-FILL](otp-fill.md) | ⚙️ | Fill the code from `otpCodeRetriever` |
 | 7 | [AUTH-DISCOVERY](auth-discovery.md) | ✅ | Capture post-login auth token + API origin |
-| 8 | [ACCOUNT-RESOLVE](account-resolve.md) | ✅ | Discover account/card list + billing-cycle catalog |
-| 9 | [DASHBOARD](dashboard.md) | ✅ | Pivot to dashboard, prime network capture |
-| 10 | [SCRAPE](scrape.md) | ✅ | Per-account transaction walk; emit identities + balance template |
-| 11 | [BALANCE-RESOLVE](balance-resolve.md) | ✅ | **v6** — owns every live balance fetch + per-card extraction |
-| 12 | [TERMINATE](terminate.md) | ✅ | Close browser, finalise result |
+| 8 | `BIND-API-MEDIATOR` | ✅ | Bind an authenticated `ApiMediator` to the live page; prime bearer / session token |
+| 9 | [API-DIRECT-SCRAPE](api-direct-scrape.md) | ✅ | Walk the bank's hard-model shape (accounts + balances + transactions) — no nav; `.final` emits `ctx.balanceResolution` |
+| 10 | [TERMINATE](terminate.md) | ✅ | Close browser, finalise result |
+| — | _dormant_: [ACCOUNT-RESOLVE](account-resolve.md) · [DASHBOARD](dashboard.md) · [SCRAPE](scrape.md) · [BALANCE-RESOLVE](balance-resolve.md) | — | Retired generic navigation + DOM-scrape chain; still in the tree (ESLint-canary-guarded) but unused by any pipeline bank |
 
 ## API-direct banks — 2 phases
 
 | Phase | Replaces (browser side) | One-line role |
 |---|---|---|
 | [API-DIRECT-CALL](api-direct-call.md) | INIT → HOME → … → OTP-FILL | Login + OTP via JSON API |
-| [API-DIRECT-SCRAPE](api-direct-scrape.md) | SCRAPE + BALANCE-RESOLVE | Shape-driven walk; `.final` emits `ctx.balanceResolution` |
+| [API-DIRECT-SCRAPE](api-direct-scrape.md) | shared — the same scrape phase browser banks run | Shape-driven walk; `.final` emits `ctx.balanceResolution` |
 
 ## Sub-step contract template
 


### PR DESCRIPTION
## Why

The docs still described the **generic navigation + DOM-scrape** post-auth chain
(`AUTH-DISCOVERY -> ACCOUNT-RESOLVE -> DASHBOARD -> SCRAPE -> BALANCE-RESOLVE`)
for browser banks. Since PR #404 that chain is **dormant**: every pipeline bank
now scrapes via the direct-API **hard model** after login (`BIND-API-MEDIATOR ->
API-DIRECT-SCRAPE`) — no post-auth page navigation, no generic DOM extraction.
New readers of the README and the architecture docs were being pointed at a
flow no bank runs. This PR realigns the user-facing docs with the shipped
architecture for the **8.6.0** release.

## What

Documentation-only. No source, no behavior change.

- **README.md**
  - Architecture-at-a-glance + detailed **Architecture** diagrams and bullets:
    browser flow is now `... AUTH-DISCOVERY -> BIND-API-MEDIATOR ->
    API-DIRECT-SCRAPE -> TERMINATE`; "Browser banks (13 pipeline)".
  - Features: "Direct-API scraping after login" replaces the "12 phases" bullet.
  - Balance section retitled — balance is emitted by the hard-model shape's
    `.final`; the standalone `BALANCE-RESOLVE` phase is noted as retired/dormant.
  - Interceptor bullets repointed to `BIND-API-MEDIATOR` / `API-DIRECT-SCRAPE`.
  - **Version history**: new **v8.6.0** row describing the direct-API-after-login
    migration for every pipeline bank.
- **docs/index.md** — landing mermaid, phase-count row, bank-count row
  (16 pipeline / 3 legacy), and a **v8.6.0** "What's new" entry.
- **docs/architecture/pipeline.md** — heading, mermaid, phase table
  (added `BIND-API-MEDIATOR`, marked the generic phases *dormant*), the
  `IPipelineContext` slot table (`apiMediator` slot), and the interceptor table.
- **docs/phases/index.md** — browser phase table realigned to the hard-model chain.
- **docs/architecture/index.md** — "read in this order" line.
- **docs/architecture/balance-resolve.md** — top banner noting the phase is
  retired for pipeline banks (page kept as the v6 design record).

Validated with `npm run lint:docs-strict` (strict mkdocs build passes, no broken
links). `BIND-API-MEDIATOR` is referenced as inline code (no phase page exists
yet) to avoid a dangling link.

## Guideline compliance

| # | Guideline (source) | Verified |
|---|--------------------|----------|
| 1 | `git-hub-readme-guidlines.md` — README stays accurate, no stale flows | done — generic chain replaced with the shipped direct-API flow across all sections |
| 2 | Docs-only change — no lint/build/test of source required | done — no `src/**` touched (`git status` = 6 `.md` files) |
| 3 | `lint:docs-strict` (strict mkdocs build) | done — exit 0, "Documentation built", no broken links/warnings introduced |
| 4 | `commit-guidlines.md` — Conventional Commit, imperative, 50/72 | done — `docs:` subject, wrapped body, Co-authored-by trailer |
| 5 | `pr-guidlines.md` sections 7 + 10 — PR body has Why / What / Guideline compliance | done — this body; validated by `lint:pr-body` |
| 6 | `pr-guidlines.md` sections 1/12 — small, focused, <=150 files | done — 6 files, single purpose (docs realignment) |
| 7 | Accuracy — phase names + context slot verified against source | done — `apiMediator` slot + `bind-api-mediator` phase confirmed in `PipelineContext.ts` / `Phase.ts` |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and phase docs to reflect the new direct-API-after-login pipeline flow.
  * Revised diagrams, phase tables, and release notes to show the post-login API binding and direct scraping steps.
  * Clarified that the older balance-resolve navigation path is retired and that balance details now come from the direct scrape response.
  * Refreshed the overview counts and supported-bank breakdown to match the latest pipeline coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->